### PR TITLE
add the cmake options NATS_BUILD_STATIC_LIBRARY & NATS_BUILD_SHARED_LIBRARY to control which type of library is built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ option(NATS_BUILD_STATIC_EXAMPLES "Statically link examples" OFF)
 option(NATS_BUILD_STREAMING "Build NATS Streaming" ON)
 option(NATS_BUILD_NO_PREFIX_CONNSTS "No prefix for connection status enum" OFF)
 option(NATS_COMPILER_HARDENING "Compiler hardening flags" OFF)
+option(NATS_BUILD_STATIC_LIBRARY "Build static library" ON)
+option(NATS_BUILD_SHARED_LIBRARY "Build shared library" ON)
+
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/coveralls-cmake/cmake)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,18 +29,30 @@ endif(NATS_BUILD_STREAMING)
 # --------------------------------------
 # Create the shared and static libraries
 # --------------------------------------
-add_library(nats SHARED ${SOURCES} ${PS_SOURCES} ${S_SOURCES})
-target_link_libraries(nats ${NATS_OPENSSL_LIBS} ${NATS_EXTRA_LIB} ${NATS_PROTOBUF_LIB})
-add_library(nats_static STATIC ${SOURCES} ${PS_SOURCES} ${S_SOURCES})
-target_link_libraries(nats_static ${NATS_OPENSSL_LIBS} ${NATS_PROTOBUF_LIB})
-set_target_properties(nats nats_static PROPERTIES
-  VERSION ${NATS_VERSION_MAJOR}.${NATS_VERSION_MINOR}.${NATS_VERSION_PATCH}
-  SOVERSION ${NATS_VERSION_MAJOR}.${NATS_VERSION_MINOR})
+
+if(NATS_BUILD_SHARED_LIBRARY)
+  add_library(nats SHARED ${SOURCES} ${PS_SOURCES} ${S_SOURCES})
+  target_link_libraries(nats ${NATS_OPENSSL_LIBS} ${NATS_EXTRA_LIB} ${NATS_PROTOBUF_LIB})
+  set_target_properties(nats PROPERTIES
+    VERSION ${NATS_VERSION_MAJOR}.${NATS_VERSION_MINOR}.${NATS_VERSION_PATCH}
+    SOVERSION ${NATS_VERSION_MAJOR}.${NATS_VERSION_MINOR})
+endif(NATS_BUILD_SHARED_LIBRARY)
+
+if(NATS_BUILD_STATIC_LIBRARY)
+  add_library(nats_static STATIC ${SOURCES} ${PS_SOURCES} ${S_SOURCES})
+  target_link_libraries(nats_static ${NATS_OPENSSL_LIBS} ${NATS_PROTOBUF_LIB})
+  set_target_properties(nats_static PROPERTIES
+    VERSION ${NATS_VERSION_MAJOR}.${NATS_VERSION_MINOR}.${NATS_VERSION_PATCH}
+    SOVERSION ${NATS_VERSION_MAJOR}.${NATS_VERSION_MINOR})
+endif(NATS_BUILD_STATIC_LIBRARY)
 
 # --------------------------------------
 # Install the libraries and header files
 # --------------------------------------
-install(TARGETS nats DESTINATION ${NATS_LIBDIR})
+if(NATS_BUILD_SHARED_LIBRARY)
+  install(TARGETS nats DESTINATION ${NATS_LIBDIR})
+endif(NATS_BUILD_SHARED_LIBRARY)
+
 install(TARGETS nats_static ARCHIVE DESTINATION ${NATS_LIBDIR})
 install(FILES deprnats.h DESTINATION ${NATS_INCLUDE_DIR} RENAME nats.h)
 install(FILES nats.h status.h version.h DESTINATION ${NATS_INCLUDE_DIR}/nats)


### PR DESCRIPTION
This helps in speeding up the build (by choosing only one of them) when cnats is being used either with cmake ExternalProject or FetchContent especially in Continuous Integration.