### PR TITLE
Allow compiler to statically check format string

### DIFF
--- a/src/url.c
+++ b/src/url.c
@@ -125,16 +125,14 @@ natsUrl_Create(natsUrl **newUrl, const char *urlStr)
         {
             char        *str = NULL;
             int         res  = 0;
-            const char  *fmt = NULL;
 
             if (*start == '\0')
-                fmt = "%slocalhost:%s";
+                res = nats_asprintf(&str, "%slocalhost:%s", copy, DEFAULT_PORT_STRING);
             else if (ptr != NULL)
-                fmt = "%s%s";
+                res = nats_asprintf(&str, "%s%s", copy, DEFAULT_PORT_STRING);
             else
-                fmt = "%s:%s";
+                res = nats_asprintf(&str, "%s:%s", copy, DEFAULT_PORT_STRING);
 
-            res = nats_asprintf(&str, fmt, copy, DEFAULT_PORT_STRING);
             if (res == -1)
                 s = nats_setDefaultError(NATS_NO_MEMORY);
             else


### PR DESCRIPTION
If format string is a string literal compiler can check that arguments are of correct type

> [ 14%] Building C object src/CMakeFiles/nats.dir/url.c.o
/home/erigtorp/src/github.com/nats-io/nats.c/src/url.c: In function ‘natsUrl_Create’:
/home/erigtorp/src/github.com/nats-io/nats.c/src/url.c:137:13: warning: format not a string literal, argument types not checked [-Wformat-nonliteral]
  137 |             res = nats_asprintf(&str, fmt, copy, DEFAULT_PORT_STRING);
      |   
