### PR TITLE
[FIXED] Remove calls to "ERR_remove_thread_state()" which was depreca…

### DIFF
--- a/src/natsp.h
+++ b/src/natsp.h
@@ -499,6 +499,11 @@ struct __natsConnection
 //
 // Library
 //
+// Returns true if version of the current installed OpenSSL is not older than
+// the given version as parameter to the function.
+bool
+natsOpenSSL_Version(int majorVersion, int minorVersion, int patchVersion, long int openSSLVersion);
+
 void
 natsSys_Init(void);
 

--- a/test/test.c
+++ b/test/test.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <openssl/opensslv.h>
 
 #include "buf.h"
 #include "timer.h"
@@ -12596,6 +12597,14 @@ test_Version(void)
 
     test("Version number: ");
     testCond(nats_GetVersionNumber() == LIB_NATS_VERSION_NUMBER);
+
+    long int openSSLVersion = 0x01010102f;
+
+    test("Check if OpenSSL version is extracted correctly: ");
+
+    testCond(natsOpenSSL_Version(1, 1, 1, openSSLVersion));
+    testCond(natsOpenSSL_Version(1, 1, 0, openSSLVersion));
+    testCond(!natsOpenSSL_Version(1, 1, 2, openSSLVersion));
 }
 
 static void


### PR DESCRIPTION
…ted in OpenSSL 1.1.0

The thread initialisation and deinitialisation is done automatically in
OpenSSL from version 1.1.0.