### PR TITLE
[FIXED] Enabled compile type checking of error format args

### DIFF
--- a/src/err.h
+++ b/src/err.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 The NATS Authors
+// Copyright 2015-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -26,7 +26,7 @@
 #define nats_setError(e, f, ...) nats_setErrorReal(__FILE__, __NATS_FUNCTION__, __LINE__, (e), (f), __VA_ARGS__)
 
 natsStatus
-nats_setErrorReal(const char *fileName, const char *funcName, int line, natsStatus errSts, const void *errTxtFmt, ...);
+nats_setErrorReal(const char *fileName, const char *funcName, int line, natsStatus errSts, const char *errTxtFmt, ...);
 
 #define NATS_UPDATE_ERR_STACK(s) (s == NATS_OK ? s : nats_updateErrStack(s, __NATS_FUNCTION__))
 
@@ -42,6 +42,6 @@ nats_doNotUpdateErrStack(bool skipStackUpdate);
 #define NATS_UPDATE_ERR_TXT(f, ...) nats_updateErrTxt(__FILE__, __NATS_FUNCTION__, __LINE__, (f), __VA_ARGS__)
 
 void
-nats_updateErrTxt(const char *fileName, const char *funcName, int line, const void *errTxtFmt, ...);
+nats_updateErrTxt(const char *fileName, const char *funcName, int line, const char *errTxtFmt, ...);
 
 #endif /* ERR_H_ */

--- a/src/nats.c
+++ b/src/nats.c
@@ -1315,8 +1315,11 @@ _updateStack(natsTLError *errTL, const char *funcName, natsStatus errSts,
     errTL->func[idx] = funcName;
 }
 
+#if !defined(_WIN32)
+__attribute__ ((format (printf, 5, 6)))
+#endif
 natsStatus
-nats_setErrorReal(const char *fileName, const char *funcName, int line, natsStatus errSts, const void *errTxtFmt, ...)
+nats_setErrorReal(const char *fileName, const char *funcName, int line, natsStatus errSts, const char *errTxtFmt, ...)
 {
     natsTLError *errTL  = _getTLError();
     char        tmp[256];
@@ -1354,8 +1357,11 @@ nats_setErrorReal(const char *fileName, const char *funcName, int line, natsStat
     return errSts;
 }
 
+#if !defined(_WIN32)
+__attribute__ ((format (printf, 4, 5)))
+#endif
 void
-nats_updateErrTxt(const char *fileName, const char *funcName, int line, const void *errTxtFmt, ...)
+nats_updateErrTxt(const char *fileName, const char *funcName, int line, const char *errTxtFmt, ...)
 {
     natsTLError *errTL  = _getTLError();
     char        tmp[256];
@@ -1791,7 +1797,7 @@ nats_SetMessageDeliveryPoolSize(int max)
     if (max <= 0)
     {
         natsMutex_Unlock(workers->lock);
-        return nats_setError(NATS_ERR, "Pool size cannot be negative or zero", "");
+        return nats_setError(NATS_ERR, "%s", "Pool size cannot be negative or zero");
     }
 
     // Do not error on max < workers->maxSize in case we allow shrinking
@@ -1863,7 +1869,7 @@ natsLib_msgDeliveryAssignWorker(natsSubscription *sub)
     if (workers->maxSize == 0)
     {
         natsMutex_Unlock(workers->lock);
-        return nats_setError(NATS_FAILED_TO_INITIALIZE, "Message delivery thread pool size is 0!", "");
+        return nats_setError(NATS_FAILED_TO_INITIALIZE, "%s", "Message delivery thread pool size is 0!");
     }
 
     worker = workers->workers[workers->idx];


### PR DESCRIPTION
Did it using __attribute((format(printf())) as suggested by @rigtorp.
Fixed 2 cases where invocation of nats_setError() was wrong.

Resolves #223

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>