### PR TITLE
[FIXED] Handle auth errors on reconnects

### DIFF
--- a/src/natsp.h
+++ b/src/natsp.h
@@ -75,9 +75,10 @@
 #define _UNSUB_PROTO_        "UNSUB %" PRId64 " %d\r\n"
 #define _UNSUB_NO_MAX_PROTO_ "UNSUB %" PRId64 " \r\n"
 
-#define STALE_CONNECTION     "Stale Connection"
-#define PERMISSIONS_ERR      "Permissions Violation"
-#define AUTHORIZATION_ERR    "Authorization Violation"
+#define STALE_CONNECTION            "Stale Connection"
+#define PERMISSIONS_ERR             "Permissions Violation"
+#define AUTHORIZATION_ERR           "Authorization Violation"
+#define AUTHENTICATION_EXPIRED_ERR  "User Authentication Expired"
 
 #define _CRLF_LEN_          (2)
 #define _SPC_LEN_           (1)

--- a/src/srvpool.c
+++ b/src/srvpool.c
@@ -24,6 +24,7 @@ _freeSrv(natsSrv *srv)
 
     natsUrl_Destroy(srv->url);
     NATS_FREE(srv->tlsName);
+    NATS_FREE(srv->lastErr);
     NATS_FREE(srv);
 }
 

--- a/src/srvpool.h
+++ b/src/srvpool.h
@@ -26,6 +26,7 @@ typedef struct __natsSrv
     int         reconnects;
     int64_t     lastAttempt;
     char        *tlsName;
+    char        *lastErr;
 
 } natsSrv;
 

--- a/test/list.txt
+++ b/test/list.txt
@@ -80,6 +80,7 @@ AuthToken
 AuthTokenHandler
 PermViolation
 AuthViolation
+AuthenticationExpired
 ConnectedServer
 MultipleClose
 SimplePublish


### PR DESCRIPTION
In general we want to retry a connection that got an auth error
whether its a violation or expiration. However we want to close
the connection if we get the same error twice on same server.

Resolves #244

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>