### PR TITLE
[IMPROVED] Check for bad subject and queue name on subscribe

### DIFF
--- a/src/status.c
+++ b/src/status.c
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 The NATS Authors
+// Copyright 2015-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -64,6 +64,8 @@ static const char *statusText[] = {
     "Not Yet Connected",
 
     "Draining in progress",
+
+    "Invalid queue name",
 };
 
 const char*

--- a/src/status.h
+++ b/src/status.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 The NATS Authors
+// Copyright 2015-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -121,6 +121,8 @@ typedef enum
 
     NATS_DRAINING,                      ///< A connection and/or subscription entered the draining mode.
                                         ///  Some operations will fail when in that mode.
+
+    NATS_INVALID_QUEUE_NAME,            ///< An invalid queue name was passed when creating a queue subscription.
 
 } natsStatus;
 

--- a/test/list.txt
+++ b/test/list.txt
@@ -110,6 +110,7 @@ FlushErrOnDisconnect
 Inbox
 Stats
 BadSubject
+SubBadSubjectAndQueueNames
 ClientAsyncAutoUnsub
 ClientSyncAutoUnsub
 ClientAutoUnsubAndReconnect


### PR DESCRIPTION
Some new users have been incorrectly specifying a subject or
queue name with space that was not causing error but would prevent
messages from being received.

Added code that checks for invalid subject and queue name on
subscribe.

Resolves #245

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>