### PR TITLE
[FIXED] Missing header for offsetof() causing build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,17 @@ matrix:
           - gcc-9
       env:
         - MATRIX_EVAL="CC=gcc-9"
+        - BUILD_OPT="-DNATS_BUILD_STREAMING=OFF -DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Release" DO_COVERAGE="no" CTEST_OPT="-I 1,1"
+    - compiler: gcc
+      os: linux
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-9
+      env:
+        - MATRIX_EVAL="CC=gcc-9"
         - BUILD_OPT="-DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=address" NATS_TEST_VALGRIND=yes DO_COVERAGE="no"
     - compiler: gcc
       os: linux

--- a/src/nats.c
+++ b/src/nats.c
@@ -16,6 +16,7 @@
 #include "stan/stanp.h"
 #endif
 
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>


### PR DESCRIPTION
The missing header is included in one of the header we depend on
when building streaming. But when NATS_BUILD_STREAMING is set to OFF
the library would not build.
Added missing include and add a build with -DNATS_BUILD_STREAMING=OFF
to the build matrix.

Resolves #248

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>