### PR TITLE
[ADDED] Ability to set IO read/write buffer size.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Compiled Object files, Static and Dynamic libs (Shared Objects)
 
 # Folders
 build*/
+cmake-build*/
 install/
 html/
 !doc/html/
@@ -21,6 +22,7 @@ html/
 .settings/
 
 .vscode/
+.idea/
 
 # Mac
 .DS_Store

--- a/src/conn.c
+++ b/src/conn.c
@@ -34,6 +34,7 @@
 #include "nkeys.h"
 
 #define DEFAULT_SCRATCH_SIZE    (512)
+#define MAX_INFO_MESSAGE_SIZE   (32768)
 
 #define NATS_EVENT_ACTION_ADD       (true)
 #define NATS_EVENT_ACTION_REMOVE    (false)
@@ -477,20 +478,13 @@ static natsStatus
 _readOp(natsConnection *nc, natsControl *control)
 {
     natsStatus  s = NATS_OK;
-    char        *buffer;
-
-    buffer = NATS_MALLOC(nc->opts->ioBufSize);
-    if (buffer == NULL) {
-        return NATS_UPDATE_ERR_STACK(NATS_NO_MEMORY);
-    }
+    char        buffer[MAX_INFO_MESSAGE_SIZE];
 
     buffer[0] = '\0';
 
-    s = natsSock_ReadLine(&(nc->sockCtx), buffer, nc->opts->ioBufSize);
+    s = natsSock_ReadLine(&(nc->sockCtx), buffer, sizeof(buffer));
     if (s == NATS_OK)
         s = nats_ParseControl(control, buffer);
-
-    NATS_FREE(buffer);
 
     return NATS_UPDATE_ERR_STACK(s);
 }

--- a/src/conn.c
+++ b/src/conn.c
@@ -2093,6 +2093,8 @@ _readLoop(void  *arg)
         natsConn_Lock(nc);
     }
 
+    NATS_FREE(buffer);
+
     natsSock_Close(fd);
     nc->sockCtx.fd       = NATS_SOCK_INVALID;
     nc->sockCtx.fdActive = false;

--- a/src/conn.c
+++ b/src/conn.c
@@ -2052,14 +2052,16 @@ _readLoop(void  *arg)
     char        *buffer;
     natsSock    fd;
     int         n;
+    int         bufSize;
 
     natsConnection *nc = (natsConnection*) arg;
 
     natsConn_Lock(nc);
 
     fd = nc->sockCtx.fd;
+    bufSize = nc->opts->ioBufSize;
 
-    buffer = NATS_MALLOC(nc->opts->ioBufSize);
+    buffer = NATS_MALLOC(bufSize);
     if (buffer == NULL) {
         natsSock_Close(fd);
         nc->sockCtx.fd       = NATS_SOCK_INVALID;
@@ -2083,7 +2085,7 @@ _readLoop(void  *arg)
 
         n = 0;
 
-        s = natsSock_Read(&(nc->sockCtx), buffer, nc->opts->ioBufSize, &n);
+        s = natsSock_Read(&(nc->sockCtx), buffer, bufSize, &n);
         if (s == NATS_OK)
             s = natsParser_Parse(nc, buffer, n);
 

--- a/src/nats.h
+++ b/src/nats.h
@@ -1045,15 +1045,15 @@ natsOptions_SetPingInterval(natsOptions *opts, int64_t interval);
 NATS_EXTERN natsStatus
 natsOptions_SetMaxPingsOut(natsOptions *opts, int maxPingsOut);
 
-/** \brief Sets the size of the internal read buffer.
+/** \brief Sets the size of the internal read/write buffers.
  *
- * Sets the size, in bytes, of the internal read buffer used for read data from
- * a socket.
+ * Sets the size, in bytes, of the internal read/write buffers used for
+ * reading/writing data from a socket.
  * If not specified, or the value is 0, the library will use a default value,
  * currently set to 32KB.
  *
  * @param opts the pointer to the #natsOptions object.
- * @param ioBufSize the size, in bytes, of the internal buffer for read
+ * @param ioBufSize the size, in bytes, of the internal buffer for read/write
  * operations.
  */
 NATS_EXTERN natsStatus

--- a/src/nats.h
+++ b/src/nats.h
@@ -1045,6 +1045,20 @@ natsOptions_SetPingInterval(natsOptions *opts, int64_t interval);
 NATS_EXTERN natsStatus
 natsOptions_SetMaxPingsOut(natsOptions *opts, int maxPingsOut);
 
+/** \brief Sets the size of the internal read buffer.
+ *
+ * Sets the size, in bytes, of the internal read buffer used for read data from
+ * a socket.
+ * If not specified, or the value is 0, the library will use a default value,
+ * currently set to 32KB.
+ *
+ * @param opts the pointer to the #natsOptions object.
+ * @param ioBufSize the size, in bytes, of the internal buffer for read
+ * operations.
+ */
+NATS_EXTERN natsStatus
+natsOptions_SetIOBufSize(natsOptions *opts, int ioBufSize);
+
 /** \brief Indicates if the connection will be allowed to reconnect.
  *
  * Specifies whether or not the client library should try to reconnect when

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -203,6 +203,7 @@ struct __natsOptions
     bool                    pedantic;
     bool                    allowReconnect;
     bool                    secure;
+    int                     ioBufSize;
     int                     maxReconnect;
     int64_t                 reconnectWait;
     int                     reconnectBufSize;

--- a/src/opts.c
+++ b/src/opts.c
@@ -597,6 +597,17 @@ natsOptions_SetMaxPingsOut(natsOptions *opts, int maxPignsOut)
     return NATS_OK;
 }
 
+natsStatus
+natsOptions_SetIOBufSize(natsOptions *opts, int ioBufSize)
+{
+  LOCK_AND_CHECK_OPTIONS(opts, (ioBufSize < 0));
+
+  opts->ioBufSize = ioBufSize;
+
+  UNLOCK_OPTS(opts);
+
+  return NATS_OK;
+}
 
 natsStatus
 natsOptions_SetAllowReconnect(natsOptions *opts, bool allow)
@@ -1066,6 +1077,7 @@ natsOptions_Create(natsOptions **newOpts)
     opts->reconnectWait  = NATS_OPTS_DEFAULT_RECONNECT_WAIT;
     opts->pingInterval   = NATS_OPTS_DEFAULT_PING_INTERVAL;
     opts->maxPingsOut    = NATS_OPTS_DEFAULT_MAX_PING_OUT;
+    opts->ioBufSize      = NATS_OPTS_DEFAULT_IO_BUF_SIZE;
     opts->maxPendingMsgs = NATS_OPTS_DEFAULT_MAX_PENDING_MSGS;
     opts->timeout        = NATS_OPTS_DEFAULT_TIMEOUT;
     opts->libMsgDelivery = natsLib_isLibHandlingMsgDeliveryByDefault();

--- a/src/opts.c
+++ b/src/opts.c
@@ -600,13 +600,13 @@ natsOptions_SetMaxPingsOut(natsOptions *opts, int maxPignsOut)
 natsStatus
 natsOptions_SetIOBufSize(natsOptions *opts, int ioBufSize)
 {
-  LOCK_AND_CHECK_OPTIONS(opts, (ioBufSize < 0));
+    LOCK_AND_CHECK_OPTIONS(opts, (ioBufSize < 0));
 
-  opts->ioBufSize = ioBufSize;
+    opts->ioBufSize = ioBufSize;
 
-  UNLOCK_OPTS(opts);
+    UNLOCK_OPTS(opts);
 
-  return NATS_OK;
+    return NATS_OK;
 }
 
 natsStatus

--- a/src/opts.h
+++ b/src/opts.h
@@ -29,6 +29,7 @@
 #define NATS_OPTS_DEFAULT_RECONNECT_WAIT      (2 * 1000)          // 2 seconds
 #define NATS_OPTS_DEFAULT_PING_INTERVAL       (2 * 60 * 1000)     // 2 minutes
 #define NATS_OPTS_DEFAULT_MAX_PING_OUT        (2)
+#define NATS_OPTS_DEFAULT_IO_BUF_SIZE         (32 * 1024)         // 32 KB
 #define NATS_OPTS_DEFAULT_MAX_PENDING_MSGS    (65536)
 #define NATS_OPTS_DEFAULT_RECONNECT_BUF_SIZE  (8 * 1024 * 1024)   // 8 MB
 

--- a/test/test.c
+++ b/test/test.c
@@ -2224,6 +2224,7 @@ test_natsOptions(void)
              && (opts->timeout == 2 * 1000)
              && (opts->pingInterval == 2 * 60 *1000)
              && (opts->maxPingsOut == 2)
+             && (opts->ioBufSize == 32 * 1024)
              && (opts->maxPendingMsgs == 65536)
              && (opts->user == NULL)
              && (opts->password == NULL)
@@ -2389,6 +2390,10 @@ test_natsOptions(void)
     if (s == NATS_OK)
         s = natsOptions_SetMaxPingsOut(opts, 10);
     testCond((s == NATS_OK) && (opts->maxPingsOut == 10));
+
+    test("Set IOBufSize: ");
+    s = natsOptions_SetIOBufSize(opts, 1024 * 1024);
+    testCond((s == NATS_OK) && (opts->ioBufSize == 1024 * 1024));
 
     test("Set AllowReconnect: ");
     s = natsOptions_SetAllowReconnect(opts, true);

--- a/test/test.c
+++ b/test/test.c
@@ -2392,7 +2392,11 @@ test_natsOptions(void)
     testCond((s == NATS_OK) && (opts->maxPingsOut == 10));
 
     test("Set IOBufSize: ");
-    s = natsOptions_SetIOBufSize(opts, 1024 * 1024);
+    s = natsOptions_SetIOBufSize(opts, -1);
+    if ((s != NATS_OK) && (opts->ioBufSize == NATS_OPTS_DEFAULT_IO_BUF_SIZE))
+        s = natsOptions_SetIOBufSize(opts, 0);
+    if ((s == NATS_OK) && (opts->ioBufSize == 0))
+        s = natsOptions_SetIOBufSize(opts, 1024 * 1024);
     testCond((s == NATS_OK) && (opts->ioBufSize == 1024 * 1024));
 
     test("Set AllowReconnect: ");


### PR DESCRIPTION
Using this option, we can change the internal temporary buffer size, which is used for read/write and was hard coded as `DEFAULT_BUF_SIZE` in conn.c.
Increase of the size can improve the performance of read/write operations in some heavy load situations.

I would like to change the value in my use case, so could you consider it?
