### PR TITLE
Fix to handling of auth errors on reconnect

### DIFF
--- a/src/natsp.h
+++ b/src/natsp.h
@@ -117,6 +117,10 @@ static const char *inboxPrefix = "_INBOX.";
         if ((s) == NATS_OK) \
             DUP_STRING((s), (s1), (s2))
 
+
+#define ERR_CODE_AUTH_EXPIRED   (1)
+#define ERR_CODE_AUTH_VIOLATION (2)
+
 // This is temporary until we remove original connection status enum
 // values without NATS_CONN_STATUS_ prefix
 #if defined(NATS_CONN_STATUS_NO_PREFIX)
@@ -474,7 +478,8 @@ struct __natsConnection
 
     natsConnStatus      status;
     bool                initc; // true if the connection is performing the initial connect
-    bool                abortConn;
+    bool                ar;    // abort reconnect attempts
+    bool                rle;   // reconnect loop ended
     natsStatus          err;
     char                errStr[256];
 

--- a/src/srvpool.c
+++ b/src/srvpool.c
@@ -24,7 +24,6 @@ _freeSrv(natsSrv *srv)
 
     natsUrl_Destroy(srv->url);
     NATS_FREE(srv->tlsName);
-    NATS_FREE(srv->lastErr);
     NATS_FREE(srv);
 }
 

--- a/src/srvpool.h
+++ b/src/srvpool.h
@@ -26,7 +26,7 @@ typedef struct __natsSrv
     int         reconnects;
     int64_t     lastAttempt;
     char        *tlsName;
-    char        *lastErr;
+    int         lastAuthErrCode;
 
 } natsSrv;
 

--- a/src/util.c
+++ b/src/util.c
@@ -243,8 +243,12 @@ nats_NormalizeErr(char *error)
     }
 
     for (end=len-1; end>0; end--)
-        if ((error[end] != ' ') && (error[end] != '\''))
-            break;
+    {
+        char c = error[end];
+        if ((c == '\r') || (c == '\n') || (c == '\'') || (c == ' '))
+            continue;
+        break;
+    }
 
     if (end <= start)
     {

--- a/test/list.txt
+++ b/test/list.txt
@@ -156,7 +156,7 @@ BasicClusterReconnect
 HotSpotReconnect
 ProperReconnectDelay
 ProperFalloutAfterMaxAttempts
-ProperFalloutMaxAttemptsAuth
+StopReconnectAfterTwoAuthErr
 TimeoutOnNoServer
 PingReconnect
 GetServers


### PR DESCRIPTION
Similar to what has been done in Go client (https://github.com/nats-io/nats.go/pull/506)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>