### PR TITLE
[FIXED] Possible memory corruption due to use of select()

### DIFF
--- a/src/comsock.h
+++ b/src/comsock.h
@@ -19,8 +19,6 @@
 natsStatus
 natsSock_Init(natsSockCtx *ctx);
 
-void
-natsSock_Clear(natsSockCtx *ctx);
 
 natsStatus
 natsSock_WaitReady(int waitMode, natsSockCtx *ctx);
@@ -30,12 +28,6 @@ natsSock_ConnectTcp(natsSockCtx *ctx, const char *host, int port);
 
 natsStatus
 natsSock_SetBlocking(natsSock fd, bool blocking);
-
-natsStatus
-natsSock_CreateFDSet(fd_set **newFDSet);
-
-void
-natsSock_DestroyFDSet(fd_set *fdSet);
 
 bool
 natsSock_IsConnected(natsSock fd);

--- a/src/conn.c
+++ b/src/conn.c
@@ -191,7 +191,6 @@ _freeConn(natsConnection *nc)
     natsThread_Destroy(nc->flusherThread);
     natsHash_Destroy(nc->subs);
     natsOptions_Destroy(nc->opts);
-    natsSock_Clear(&nc->sockCtx);
     if (nc->sockCtx.ssl != NULL)
         SSL_free(nc->sockCtx.ssl);
     NATS_FREE(nc->el.buffer);

--- a/src/include/n-unix.h
+++ b/src/include/n-unix.h
@@ -21,15 +21,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifdef DARWIN
-#define FD_SETSIZE  (32768)
-#else
-#include <sys/types.h>
-#undef __FD_SETSIZE
-#define __FD_SETSIZE (32768)
-#include <sys/select.h>
-#endif
-
 #include <sys/time.h>
 #include <fcntl.h>
 #include <netinet/tcp.h>
@@ -41,6 +32,7 @@
 #include <errno.h>
 #include <string.h>
 #include <netinet/in.h>
+#include <poll.h>
 
 typedef pthread_t       natsThread;
 typedef pthread_key_t   natsThreadLocal;

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -423,12 +423,7 @@ typedef struct __natsSockCtx
 
     // We switch to blocking socket after receiving the PONG to the first PING
     // during the connect process. Should we make all read/writes non blocking,
-    // then we will use two different fd sets, and also probably pass deadlines
-    // individually as opposed to use one at the connection level.
-    fd_set          *fdSet;
-#ifdef _WIN32
-    fd_set          *errSet;
-#endif
+    // then we will use two different deadlines.
     natsDeadline    deadline;
 
     SSL             *ssl;

--- a/src/natstime.c
+++ b/src/natstime.c
@@ -63,8 +63,6 @@ natsDeadline_Init(natsDeadline *deadline, int64_t timeout)
 {
     deadline->active          = true;
     deadline->absoluteTime    = nats_Now() + timeout;
-    deadline->timeout.tv_sec  = (long) timeout / 1000;
-    deadline->timeout.tv_usec = (timeout % 1000) * 1000;
 }
 
 void
@@ -73,18 +71,17 @@ natsDeadline_Clear(natsDeadline *deadline)
     deadline->active = false;
 }
 
-struct timeval*
+int
 natsDeadline_GetTimeout(natsDeadline *deadline)
 {
-    int64_t timeout;
+    int timeout;
 
     if (!(deadline->active))
-        return NULL;
+        return -1;
 
-    timeout = deadline->absoluteTime - nats_Now();
+    timeout = (int) (deadline->absoluteTime - nats_Now());
+    if (timeout < 0)
+        timeout = 0;
 
-    deadline->timeout.tv_sec  = (long) (timeout / 1000);
-    deadline->timeout.tv_usec = (timeout % 1000) * 1000;
-
-    return &(deadline->timeout);
+    return timeout;
 }

--- a/src/natstime.h
+++ b/src/natstime.h
@@ -20,7 +20,6 @@
 typedef struct __natsDeadline
 {
     int64_t             absoluteTime;
-    struct timeval      timeout;
     bool                active;
 
 } natsDeadline;
@@ -28,7 +27,7 @@ typedef struct __natsDeadline
 void
 natsDeadline_Init(natsDeadline *deadline, int64_t timeout);
 
-struct timeval*
+int
 natsDeadline_GetTimeout(natsDeadline *deadline);
 
 void

--- a/test/test.c
+++ b/test/test.c
@@ -3704,7 +3704,6 @@ _checkStart(const char *url, int orderIP, int maxAttempts)
             s = NATS_NO_SERVER;
     }
 
-    natsSock_Clear(&ctx);
     nats_clearLastError();
 
     return s;
@@ -12016,7 +12015,7 @@ test_BasicClusterReconnect(void)
 
     test("Check reconnect time did not take too long: ");
 #if _WIN32
-    testCond(reconnectTime <= 1100);
+    testCond(reconnectTime <= 1300);
 #else
     testCond(reconnectTime <= 100);
 #endif


### PR DESCRIPTION
Replaced use of select with poll() (for unix platforms).
Verified with user's provided reproducible repo that this solves
the issue.

Resolves #243

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>