### PR TITLE
Fixed natsSock_WaitReady() on Windows when given "no deadline"

### DIFF
--- a/src/win/sock.c
+++ b/src/win/sock.c
@@ -56,9 +56,12 @@ natsSock_WaitReady(int waitMode, natsSockCtx *ctx)
     if (deadline != NULL)
     {
         int timeoutMS = natsDeadline_GetTimeout(deadline);
-        timeout_tv.tv_sec = (long) timeoutMS / 1000;
-        timeout_tv.tv_usec = (timeoutMS % 1000) * 1000;
-        timeout = &timeout_tv;
+        if (timeoutMS != -1)
+        {
+            timeout_tv.tv_sec = (long) timeoutMS / 1000;
+            timeout_tv.tv_usec = (timeoutMS % 1000) * 1000;
+            timeout = &timeout_tv;
+        }
     }
 
     start = nats_Now();

--- a/test/list.txt
+++ b/test/list.txt
@@ -34,6 +34,7 @@ natsKeys
 natsReadFile
 natsGetJWTOrSeed
 natsHostIsIP
+natsWaitReady
 ReconnectServerStats
 ParseStateReconnectFunctionality
 ServersRandomize


### PR DESCRIPTION
Changes made in #256 broke the case of "infinite" deadline in
natsSock_WaitReady() on Windows. Added a test to make sure
that works now.

Also updated a test that would leak file descriptors.

Related to #256
Resolves #243

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>