### PR TITLE
[FIXED] Possible core on process exit

### DIFF
--- a/src/win/thread.c
+++ b/src/win/thread.c
@@ -62,6 +62,7 @@ static unsigned __stdcall _threadStart(void* arg)
   NATS_FREE(c);
 
   nats_ReleaseThreadMemory();
+  natsLib_Release();
 
   return 0;
 }
@@ -73,6 +74,7 @@ natsThread_Create(natsThread **thread, natsThreadCb cb, void *arg)
     natsThread          *t   = NULL;
     natsStatus          s    = NATS_OK;
 
+    natsLib_Retain();
     ctx = (struct threadCtx*) NATS_CALLOC(1, sizeof(*ctx));
     t = (natsThread*) NATS_CALLOC(1, sizeof(natsThread));
 
@@ -100,6 +102,7 @@ natsThread_Create(natsThread **thread, natsThreadCb cb, void *arg)
     {
         NATS_FREE(ctx);
         NATS_FREE(t);
+        natsLib_Release();
     }
 
     return s;


### PR DESCRIPTION
We attach a destructor on process exit to do final cleanup of
the library. However, some NATS threads may have still be running
and accessing locks/etc.. that were freed. Make sure to retain/release
the library in NATS threads start/end.
Also natsThreadLocal_SetEx() in the unix implementation was not
checking the setErr that is set to false on library teardown which
was causing the library to be attempted to be opened in case of
error.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>