### PR TITLE
[FIXED] stanConnOptions_SetURL() had no effect

### DIFF
--- a/src/nats.h
+++ b/src/nats.h
@@ -1581,13 +1581,18 @@ stanConnOptions_Create(stanConnOptions **newOpts);
 /** \brief Sets the URL to connect to.
  *
  * Sets the URL of the `NATS Streaming Server` the client should try to connect to.
- * The URL can contain optional user name and password.
+ * The URL can contain optional user name and password. You can provide a comma
+ * separated list of URLs too.
  *
  * Some valid URLS:
  *
  * - nats://localhost:4222
  * - nats://user\@localhost:4222
  * - nats://user:password\@localhost:4222
+ * - nats://host1:4222,nats://host2:4222,nats://host3:4222
+ *
+ * \note This option takes precedence over #natsOptions_SetURL when NATS options
+ * are passed with #stanConnOptions_SetNATSOptions.
  *
  * @param opts the pointer to the #stanConnOptions object.
  * @param url the string representing the URL the connection should use
@@ -1605,6 +1610,9 @@ stanConnOptions_SetURL(stanConnOptions *opts, const char *url);
  *
  * This function clones the passed options, so after this call, any
  * changes to the given #natsOptions will not affect the #stanConnOptions.
+ *
+ * \note If both #natsOptions_SetURL and #stanConnOptions_SetURL are used
+ * the URL(s) set in the later take precedence.
  *
  * @param opts the pointer to the #stanConnOptions object.
  * @param nOpts the pointer to the #natsOptions object to use to create

--- a/src/stan/conn.c
+++ b/src/stan/conn.c
@@ -1,4 +1,4 @@
-// Copyright 2018 The NATS Authors
+// Copyright 2018-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -301,6 +301,10 @@ stanConnection_Connect(stanConnection **newConn, const char* clusterID, const ch
     // We don't support SetRetryOnFailedConnect for now
     if ((s == NATS_OK) && (opts != NULL))
         s = natsOptions_SetRetryOnFailedConnect(sc->opts->ncOpts, false, NULL, NULL);
+
+    // Set the URL if provided through STAN options
+    if ((s == NATS_OK) && (sc->opts->url != NULL))
+        s = natsOptions_SetURL(sc->opts->ncOpts, sc->opts->url);
 
     // Connect to NATS
     if (s == NATS_OK)

--- a/src/stan/copts.c
+++ b/src/stan/copts.c
@@ -1,4 +1,4 @@
-// Copyright 2018 The NATS Authors
+// Copyright 2018-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -48,8 +48,7 @@ stanConnOptions_Create(stanConnOptions **newOpts)
         return NATS_UPDATE_ERR_STACK(NATS_NO_MEMORY);
     }
 
-    DUP_STRING(s, opts->url, NATS_DEFAULT_URL);
-    IF_OK_DUP_STRING(s, opts->discoveryPrefix, STAN_CONN_OPTS_DEFAULT_DISCOVERY_PREFIX);
+    DUP_STRING(s, opts->discoveryPrefix, STAN_CONN_OPTS_DEFAULT_DISCOVERY_PREFIX);
     if (s == NATS_OK)
     {
         opts->pubAckTimeout = STAN_CONN_OPTS_DEFAULT_PUB_ACK_TIMEOUT;
@@ -73,14 +72,15 @@ stanConnOptions_SetURL(stanConnOptions *opts, const char *url)
 {
     natsStatus s = NATS_OK;
 
-    LOCK_AND_CHECK_OPTIONS(opts, ((url == NULL) || (url[0] == '\0')));
+    LOCK_AND_CHECK_OPTIONS(opts, 0);
 
     if (opts->url != NULL)
     {
         NATS_FREE(opts->url);
         opts->url = NULL;
     }
-    DUP_STRING(s, opts->url, url);
+    if ((url != NULL) && (url[0] != '\0'))
+        DUP_STRING(s, opts->url, url);
 
     UNLOCK_OPTS(opts);
 
@@ -215,10 +215,8 @@ stanConnOptions_clone(stanConnOptions **clonedOpts, stanConnOptions *opts)
     if (s != NATS_OK)
         return NATS_UPDATE_ERR_STACK(s);
 
-    // The Create call sets (strdup) the default URL and discovery prefix.
+    // The Create call sets (strdup) the default discovery prefix.
     // So free those now.
-    NATS_FREE(cloned->url);
-    cloned->url = NULL;
     NATS_FREE(cloned->discoveryPrefix);
     cloned->discoveryPrefix = NULL;
 

--- a/src/stan/stanp.h
+++ b/src/stan/stanp.h
@@ -1,4 +1,4 @@
-// Copyright 2018 The NATS Authors
+// Copyright 2018-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -25,7 +25,7 @@ struct __stanConnOptions
 {
     natsMutex                   *mu;
 
-    // URL to connect to, unless ncOpts is not NULL.
+    // URL to connect to. Takes precedence to any URL set in ncOpts.
     char                        *url;
 
     // Low level NATS connection options to use to create the NATS connection.


### PR DESCRIPTION
Had to changes few things:
- No longer strdup to default URL when creating stanConnOptions
- Set the stan URL option to override any possible natsOptions
  URL that could be set
- Update doc to specify that stanConnOptions_SetURL() takes
  precedence to natsOptions_SetURL() if NATS options are passed
  with stanConnOptions_SetNATSOptions().

Resolves #262

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>