### PR TITLE
[ADDED] natsOptions_SetWriteDeadline()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,17 @@ matrix:
           - gcc-9
       env:
         - MATRIX_EVAL="CC=gcc-9"
+        - NATS_DEFAULT_LIB_WRITE_DEADLINE=2000 BUILD_OPT="-DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=address" NATS_TEST_VALGRIND=yes DO_COVERAGE="no"
+    - compiler: gcc
+      os: linux
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-9
+      env:
+        - MATRIX_EVAL="CC=gcc-9"
         - BUILD_OPT="-DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=thread" DO_COVERAGE="no"
     - compiler: clang
       os: linux

--- a/README.md
+++ b/README.md
@@ -754,6 +754,15 @@ passing a connection handler:
 ```
 Check the example `examples/connect.c` for more use cases.
 
+You can also specify a write deadline which means that when the library is trying to
+send bytes to the NATS Server, if the connection if unhealthy but as not been reported
+as closed, calls will fail with a `NATS_TIMEOUT` error. The socket will be closed and
+the library will attempt to reconnect (unless disabled). Note that this could also
+happen in the event the server is not consuming fast enough.
+```c
+    // Sets a write deadline of 2 seconds (value is in milliseconds).
+    s = natsOptions_SetWriteDeadline(opts, 2000);
+```
 
 ## Clustered Usage
 

--- a/examples/examples.h
+++ b/examples/examples.h
@@ -146,6 +146,7 @@ printUsageAndExit(const char *progName, const char *usage)
 "-creds         user credentials chained file\n" \
 "-subj          subject (default is 'foo')\n" \
 "-print         for consumers, print received messages (default is false)\n" \
+"-wd            write deadline in milliseconds\n" \
                 "%s\n",
                 progName, usage);
 
@@ -372,6 +373,13 @@ parseArgs(int argc, char **argv, const char *usage)
                 printUsageAndExit(argv[0], usage);
 
             s = natsOptions_SetUserCredentialsFromFiles(opts, argv[++i], NULL);
+        }
+        else if (strcasecmp(argv[i], "-wd") == 0)
+        {
+            if (i + 1 == argc)
+                printUsageAndExit(argv[0], usage);
+
+            s = natsOptions_SetWriteDeadline(opts, atol(argv[++i]));
         }
         else
         {

--- a/src/comsock.h
+++ b/src/comsock.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 The NATS Authors
+// Copyright 2015-2019 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -64,7 +64,8 @@ natsStatus
 natsSock_Write(natsSockCtx *ctx, const char *data, int len, int *n);
 
 // Writes 'len' bytes to the socket. Does not return until all bytes
-// have been written, unless the socket is closed or an error occurs.
+// have been written, unless the socket is closed or an error occurs
+// (including write timeout).
 natsStatus
 natsSock_WriteFully(natsSockCtx *ctx, const char *data, int len);
 
@@ -80,5 +81,10 @@ natsSock_SetCommonTcpOptions(natsSock fd);
 void
 natsSock_Shutdown(natsSock fd);
 
+void
+natsSock_ClearDeadline(natsSockCtx *ctx);
+
+void
+natsSock_InitDeadline(natsSockCtx *ctx, int64_t timeout);
 
 #endif /* SOCK_H_ */

--- a/src/conn.h
+++ b/src/conn.h
@@ -32,6 +32,8 @@ void natsConn_Unlock(natsConnection *nc);
 
 #endif // DEV_MODE
 
+#define SET_WRITE_DEADLINE(nc) if ((nc)->opts->writeDeadline > 0) natsDeadline_Init(&(nc)->sockCtx.writeDeadline, (nc)->opts->writeDeadline)
+
 natsStatus
 natsConn_create(natsConnection **newConn, natsOptions *options);
 
@@ -137,6 +139,6 @@ void
 natsConn_close(natsConnection *nc);
 
 void
-natsConn_destroy(natsConnection *nc);
+natsConn_destroy(natsConnection *nc, bool fromPublicDestroy);
 
 #endif /* CONN_H_ */

--- a/src/include/n-win.h
+++ b/src/include/n-win.h
@@ -46,7 +46,7 @@ typedef int                 natsRecvLen;
 
 #define NATS_SOCK_INVALID               (INVALID_SOCKET)
 #define NATS_SOCK_CLOSE(s)              closesocket((s))
-#define NATS_SOCK_SHUTDOWN(s)           shutdown((s), SD_BOTH)
+#define NATS_SOCK_SHUTDOWN(s)           {shutdown((s), SD_BOTH); closesocket((s));}
 #define NATS_SOCK_CONNECT_IN_PROGRESS   (WSAEWOULDBLOCK)
 #define NATS_SOCK_WOULD_BLOCK           (WSAEWOULDBLOCK)
 #define NATS_SOCK_ERROR                 (SOCKET_ERROR)

--- a/src/nats.c
+++ b/src/nats.c
@@ -112,6 +112,7 @@ typedef struct __natsLib
     bool            initializing;
     bool            initAborted;
     bool            libHandlingMsgDeliveryByDefault;
+    int64_t         libDefaultWriteDeadline;
 
     natsLibTimers       timers;
     natsLibAsyncCbs     asyncCbs;
@@ -1013,6 +1014,11 @@ nats_Open(int64_t lockSpinCount)
         s = natsMutex_Create(&(gLib.dlvWorkers.lock));
     if (s == NATS_OK)
     {
+        char *defaultWriteDeadlineStr = getenv("NATS_DEFAULT_LIB_WRITE_DEADLINE");
+
+        if (defaultWriteDeadlineStr != NULL)
+            gLib.libDefaultWriteDeadline = (int64_t) atol(defaultWriteDeadlineStr);
+
         gLib.libHandlingMsgDeliveryByDefault = (getenv("NATS_DEFAULT_TO_LIB_MSG_DELIVERY") != NULL ? true : false);
         gLib.dlvWorkers.maxSize = 2;
         gLib.dlvWorkers.workers = NATS_CALLOC(gLib.dlvWorkers.maxSize, sizeof(natsMsgDlvWorker*));
@@ -1930,6 +1936,12 @@ bool
 natsLib_isLibHandlingMsgDeliveryByDefault()
 {
     return gLib.libHandlingMsgDeliveryByDefault;
+}
+
+int64_t
+natsLib_defaultWriteDeadline()
+{
+    return gLib.libDefaultWriteDeadline;
 }
 
 void

--- a/src/nats.h
+++ b/src/nats.h
@@ -1529,6 +1529,22 @@ natsOptions_SetNKey(natsOptions             *opts,
                     natsSignatureHandler    sigCB,
                     void                    *sigClosure);
 
+/** \brief Sets the write deadline.
+ *
+ * If this is set, the socket is set to non-blocking mode and
+ * write will have a deadline set. If the deadline is reached,
+ * the write call will return an error which will translate
+ * to publish calls, or any library call trying to send data
+ * to the server, to possibly fail.
+ *
+ * @param opts the pointer to the #natsOptions object.
+ * @param deadline the write deadline expressed in milliseconds.
+ * If set to 0, it means that there is no deadline and socket
+ * is in blocking mode.
+ */
+NATS_EXTERN natsStatus
+natsOptions_SetWriteDeadline(natsOptions *opts, int64_t deadline);
+
 /** \brief Destroys a #natsOptions object.
  *
  * Destroys the natsOptions object, freeing used memory. See the note in

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -211,6 +211,7 @@ struct __natsOptions
     int                     maxReconnect;
     int64_t                 reconnectWait;
     int                     reconnectBufSize;
+    int64_t                 writeDeadline;
 
     char                    *user;
     char                    *password;
@@ -422,10 +423,8 @@ typedef struct __natsSockCtx
     natsSock        fd;
     bool            fdActive;
 
-    // We switch to blocking socket after receiving the PONG to the first PING
-    // during the connect process. Should we make all read/writes non blocking,
-    // then we will use two different deadlines.
-    natsDeadline    deadline;
+    natsDeadline    readDeadline;
+    natsDeadline    writeDeadline;
 
     SSL             *ssl;
 
@@ -575,6 +574,9 @@ natsLib_msgDeliveryAssignWorker(natsSubscription *sub);
 
 bool
 natsLib_isLibHandlingMsgDeliveryByDefault(void);
+
+int64_t
+natsLib_defaultWriteDeadline(void);
 
 void
 natsLib_getMsgDeliveryPoolInfo(int *maxSize, int *size, int *idx, natsMsgDlvWorker ***workersArray);

--- a/src/opts.c
+++ b/src/opts.c
@@ -1031,6 +1031,18 @@ natsOptions_SetNKey(natsOptions             *opts,
     return NATS_OK;
 }
 
+natsStatus
+natsOptions_SetWriteDeadline(natsOptions *opts, int64_t deadline)
+{
+    LOCK_AND_CHECK_OPTIONS(opts, (deadline < 0));
+
+    opts->writeDeadline = deadline;
+
+    UNLOCK_OPTS(opts);
+
+    return NATS_OK;
+}
+
 static void
 _freeOptions(natsOptions *opts)
 {
@@ -1081,6 +1093,7 @@ natsOptions_Create(natsOptions **newOpts)
     opts->maxPendingMsgs = NATS_OPTS_DEFAULT_MAX_PENDING_MSGS;
     opts->timeout        = NATS_OPTS_DEFAULT_TIMEOUT;
     opts->libMsgDelivery = natsLib_isLibHandlingMsgDeliveryByDefault();
+    opts->writeDeadline  = natsLib_defaultWriteDeadline();
 
     *newOpts = opts;
 

--- a/src/pub.c
+++ b/src/pub.c
@@ -89,7 +89,7 @@ natsConn_publish(natsConnection *nc, const char *subj,
         if (natsBuf_Len(nc->pending) >= nc->opts->reconnectBufSize)
         {
             natsConn_Unlock(nc);
-            return NATS_INSUFFICIENT_BUFFER;
+            return nats_setDefaultError(NATS_INSUFFICIENT_BUFFER);
         }
     }
 
@@ -140,6 +140,8 @@ natsConn_publish(natsConnection *nc, const char *subj,
         s = natsBuf_Append(nc->scratch, (b+i), sizeSize);
     if (s == NATS_OK)
         s = natsBuf_Append(nc->scratch, _CRLF_, _CRLF_LEN_);
+
+    SET_WRITE_DEADLINE(nc);
 
     if (s == NATS_OK)
         s = natsConn_bufferWrite(nc, natsBuf_Data(nc->scratch), msgHdSize);

--- a/src/stan/conn.c
+++ b/src/stan/conn.c
@@ -52,7 +52,7 @@ _freeConn(stanConnection *sc)
     natsSubscription_Destroy(sc->hbSubscription);
     natsSubscription_Destroy(sc->ackSubscription);
     natsSubscription_Destroy(sc->pingSub);
-    natsConn_destroy(sc->nc);
+    natsConn_destroy(sc->nc, false);
     natsInbox_Destroy(sc->hbInbox);
     natsStrHash_Destroy(sc->pubAckMap);
     natsCondition_Destroy(sc->pubAckCond);

--- a/src/unix/sock.c
+++ b/src/unix/sock.c
@@ -25,7 +25,7 @@ natsSys_Init(void)
 natsStatus
 natsSock_WaitReady(int waitMode, natsSockCtx *ctx)
 {
-    natsDeadline    *deadline = &(ctx->deadline);
+    natsDeadline    *deadline = &(ctx->writeDeadline);
     struct pollfd   pfd       = {0};
     int             timeout   = -1;
     int             res;
@@ -35,6 +35,7 @@ natsSock_WaitReady(int waitMode, natsSockCtx *ctx)
     switch (waitMode)
     {
         case WAIT_FOR_READ:
+            deadline = &(ctx->readDeadline);
             pfd.events = POLLIN;
             break;
         case WAIT_FOR_WRITE:

--- a/src/win/sock.c
+++ b/src/win/sock.c
@@ -38,7 +38,7 @@ natsSys_Init(void)
 natsStatus
 natsSock_WaitReady(int waitMode, natsSockCtx *ctx)
 {
-    natsDeadline    *deadline = &(ctx->deadline);
+    natsDeadline    *deadline = &ctx->writeDeadline;
     struct timeval  timeout_tv= {0};
     struct timeval  *timeout  = NULL;
     natsSock        sock      = ctx->fd;
@@ -51,6 +51,9 @@ natsSock_WaitReady(int waitMode, natsSockCtx *ctx)
 
     FD_ZERO(&errSet);
     FD_SET(sock, &errSet);
+
+    if (waitMode == WAIT_FOR_READ)
+        deadline = &ctx->readDeadline;
 
     if (deadline != NULL)
     {

--- a/test/list.txt
+++ b/test/list.txt
@@ -142,6 +142,7 @@ UserCredsCallbacks
 UserCredsFromFiles
 NKey
 ConnSign
+WriteDeadline
 SSLBasic
 SSLVerify
 SSLVerifyHostname


### PR DESCRIPTION
Adds a write deadline for all socket write operations. It means that
a publish call could fail (with NATS_TIMEOUT) if the server is not
able to consume data (either not fast enough or connection is in
a state where it is not reported as closed, but transmission is
not happening).

Resolves #217
Resolves #215

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>