### PR TITLE
Reset buffers when connecting. Fixes #275

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -2661,11 +2661,7 @@ natsConn_processErr(natsConnection *nc, char *buf, int bufLen)
     }
     else
     {
-        close = true;
-        natsConn_Lock(nc);
-        nc->err = NATS_ERR;
-        snprintf(nc->errStr, sizeof(nc->errStr), "%s", error);
-        natsConn_Unlock(nc);
+        _processOpError(nc, NATS_ERR, false);
     }
     if (close)
         _close(nc, NATS_CONN_STATUS_CLOSED, false, true);

--- a/src/conn.c
+++ b/src/conn.c
@@ -398,13 +398,11 @@ _createConn(natsConnection *nc)
     {
         nc->sockCtx.fdActive = true;
 
-        if ((nc->pending != NULL) && (nc->bw != NULL)
-            && (natsBuf_Len(nc->bw) > 0))
-        {
-            // Move to pending buffer
-            s = natsConn_bufferWrite(nc, natsBuf_Data(nc->bw),
-                                     natsBuf_Len(nc->bw));
-        }
+        if (nc->pending != NULL)
+            natsBuf_Reset(nc->pending);
+
+        if (nc->bw != NULL)
+            natsBuf_Reset(nc->bw);
     }
 
     // Need to create the buffer even on failure in case we allow


### PR DESCRIPTION
Reset buffers when connecting. This prevents sending of partial message frames.