### PR TITLE
[FIXED] Do not send partial protocols during a reconnect

### DIFF
--- a/test/list.txt
+++ b/test/list.txt
@@ -73,6 +73,7 @@ IsClosed
 IsReconnectingAndStatus
 ReconnectBufSize
 RetryOnFailedConnect
+NoPartialOnReconnect
 ErrOnConnectAndDeadlock
 ErrOnMaxPayloadLimit
 Auth


### PR DESCRIPTION
Make sure we don't transfer possible write buffer to pending when
reconnecting.
Empty the pending buffer when flushing it on reconnect, regardless
if we get an error or not since we would otherwise take the risk
of sending duplicates.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>