### PR TITLE
[FIXED] Windows: exclude DllMain when building static library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,7 @@ if(NATS_BUILD_LIB_STATIC)
   set_target_properties(nats_static PROPERTIES
     VERSION ${NATS_VERSION_MAJOR}.${NATS_VERSION_MINOR}.${NATS_VERSION_PATCH}
     SOVERSION ${NATS_VERSION_MAJOR}.${NATS_VERSION_MINOR})
+  target_compile_definitions(nats_static PRIVATE -DNATS_STATIC)
 endif(NATS_BUILD_LIB_STATIC)
 
 # --------------------------------------

--- a/src/nats.c
+++ b/src/nats.c
@@ -206,6 +206,7 @@ nats_ReleaseThreadMemory(void)
 }
 
 #if _WIN32
+#ifndef NATS_STATIC
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, // DLL module handle
      DWORD fdwReason,                   // reason called
      LPVOID lpvReserved)                // reserved
@@ -232,6 +233,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, // DLL module handle
     UNREFERENCED_PARAMETER(hinstDLL);
     UNREFERENCED_PARAMETER(lpvReserved);
 }
+#endif
 #endif
 
 static void


### PR DESCRIPTION
Resolves #284

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>