### PR TITLE
Use new nats.c.deps repo for build dependencies on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
-language: c
+language: cpp
+dist: bionic
+os: linux
 
 cache:
   directories:
-  - $HOME/nats-server
-  - $HOME/nats-streaming-server
-  - $HOME/pbuf
-  - $HOME/sodium
+  - $HOME/deps
 
-sudo: true
+sudo: false
 
 compiler:
   - gcc
@@ -18,83 +17,96 @@ before_install:
   - eval "${MATRIX_EVAL}"
 
 before_script:
-  - export PATH=$HOME/nats-server:$HOME/nats-streaming-server:$HOME/pbuf:$PATH
+  - export PATH=$HOME/deps/nats-server:$HOME/deps/nats-streaming-server:$PATH
   - mkdir build && cd build
   - export COVERALLS_SERVICE_NAME=travis-ci
 
 env:
-  - DO_COVERAGE="coverage" BUILD_OPT="-DNATS_COVERAGE=ON -DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Debug -DNATS_COVERAGE_UPLOAD=ON -DCMAKE_BUILD_TYPE=Debug"
+  - DO_COVERAGE="coverage" BUILD_OPT="-DNATS_COVERAGE=ON -DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Debug -DNATS_COVERAGE_UPLOAD=ON -DNATS_BUILD_TLS_USE_OPENSSL_1_1_API=ON -DCMAKE_BUILD_TYPE=Debug"
 
 matrix:
   include:
-    - compiler: gcc
-      os: linux
+
+    - name: "gcc-9 - TLS OFF"
+      compiler: gcc
       addons:
         apt:
           sources:
-          - ubuntu-toolchain-r-test
+            - ubuntu-toolchain-r-test
+            - sourceline: ppa:ubuntu-toolchain-r/test
           packages:
-          - gcc-9
+            - g++-9
       env:
         - MATRIX_EVAL="CC=gcc-9"
         - BUILD_OPT="-DNATS_BUILD_WITH_TLS=OFF -DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Release" DO_COVERAGE="no"
-    - compiler: gcc
-      os: linux
+
+    - name: "gcc-9 - Streaming OFF"
+      compiler: gcc
       addons:
         apt:
           sources:
-          - ubuntu-toolchain-r-test
+            - ubuntu-toolchain-r-test
+            - sourceline: ppa:ubuntu-toolchain-r/test
           packages:
-          - gcc-9
+            - g++-9
       env:
         - MATRIX_EVAL="CC=gcc-9"
         - BUILD_OPT="-DNATS_BUILD_STREAMING=OFF -DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Release" DO_COVERAGE="no" CTEST_OPT="-I 1,1"
-    - compiler: gcc
-      os: linux
+
+    - name: "gcc-9 - Default - sanitize address"
+      compiler: gcc
       addons:
         apt:
           sources:
-          - ubuntu-toolchain-r-test
+            - ubuntu-toolchain-r-test
+            - sourceline: ppa:ubuntu-toolchain-r/test
           packages:
-          - gcc-9
+            - g++-9
       env:
         - MATRIX_EVAL="CC=gcc-9"
         - BUILD_OPT="-DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=address" NATS_TEST_VALGRIND=yes DO_COVERAGE="no"
-    - compiler: gcc
-      os: linux
+
+    - name: "gcc-9 - Lib msg delivery - sanitize address"
+      compiler: gcc
       addons:
         apt:
           sources:
-          - ubuntu-toolchain-r-test
+            - ubuntu-toolchain-r-test
+            - sourceline: ppa:ubuntu-toolchain-r/test
           packages:
-          - gcc-9
+            - g++-9
       env:
         - MATRIX_EVAL="CC=gcc-9"
         - NATS_DEFAULT_TO_LIB_MSG_DELIVERY=yes BUILD_OPT="-DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=address" NATS_TEST_VALGRIND=yes DO_COVERAGE="no"
-    - compiler: gcc
-      os: linux
+
+    - name: "gcc-9 - Write deadline - sanitize address"
+      compiler: gcc
       addons:
         apt:
           sources:
-          - ubuntu-toolchain-r-test
+            - ubuntu-toolchain-r-test
+            - sourceline: ppa:ubuntu-toolchain-r/test
           packages:
-          - gcc-9
+            - g++-9
       env:
         - MATRIX_EVAL="CC=gcc-9"
         - NATS_DEFAULT_LIB_WRITE_DEADLINE=2000 BUILD_OPT="-DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=address" NATS_TEST_VALGRIND=yes DO_COVERAGE="no"
-    - compiler: gcc
-      os: linux
+
+    - name: "gcc-9 - Default - sanitize thread"
+      compiler: gcc
       addons:
         apt:
           sources:
-          - ubuntu-toolchain-r-test
+            - ubuntu-toolchain-r-test
+            - sourceline: ppa:ubuntu-toolchain-r/test
           packages:
-          - gcc-9
+            - g++-9
       env:
         - MATRIX_EVAL="CC=gcc-9"
         - BUILD_OPT="-DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=thread" DO_COVERAGE="no"
-    - compiler: clang
-      os: linux
+
+    - name: "clang-8 - TLS OFF"
+      compiler: clang
       addons:
         apt:
           sources:
@@ -105,8 +117,9 @@ matrix:
         - MATRIX_EVAL="CC=clang-8"
         # Run only one test, this matrix is just to make sure that we compile ok.
         - BUILD_OPT="-DNATS_BUILD_WITH_TLS=OFF -DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Release" DO_COVERAGE="no" CTEST_OPT="-I 1,1"
-    - compiler: clang
-      os: linux
+
+    - name: "clang-8 - Default - sanitize address"
+      compiler: clang
       addons:
         apt:
           sources:
@@ -116,8 +129,9 @@ matrix:
       env:
         - MATRIX_EVAL="CC=clang-8"
         - BUILD_OPT="-DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=address" NATS_TEST_VALGRIND=yes DO_COVERAGE="no"
-    - compiler: clang
-      os: linux
+
+    - name: "clang-8 - Default - sanitize thread"
+      compiler: clang
       addons:
         apt:
           sources:
@@ -129,7 +143,7 @@ matrix:
         - BUILD_OPT="-DNATS_BUILD_ARCH=64 -DNATS_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=thread" DO_COVERAGE="no"
 
 script:
-  - $TRAVIS_BUILD_DIR/buildOnTravis.sh "$CC" "$DO_COVERAGE" "$BUILD_OPT -DNATS_SANITIZE=ON -DNATS_PROTOBUF_DIR=$HOME/pbuf -DNATS_BUILD_USE_SODIUM=ON -DNATS_SODIUM_DIR=$HOME/sodium" "$CTEST_OPT"
+  - $TRAVIS_BUILD_DIR/buildOnTravis.sh "$CC" "$DO_COVERAGE" "$BUILD_OPT -DNATS_SANITIZE=ON -DNATS_BUILD_TLS_USE_OPENSSL_1_1_API=ON -DNATS_PROTOBUF_DIR=$HOME/deps/pbuf -DNATS_BUILD_USE_SODIUM=ON -DNATS_SODIUM_DIR=$HOME/deps/sodium" "$CTEST_OPT"
 
 notifications:
   email: false

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,50 +1,9 @@
 #!/bin/sh
 set -ex
-# check to see if nats-server folder is empty
-if [ ! "$(ls -A $HOME/nats-server)" ]; then
-  mkdir -p $HOME/nats-server
-  cd $HOME/nats-server
-  wget https://github.com/nats-io/nats-server/releases/download/v2.1.0/nats-server-v2.1.0-linux-amd64.zip -O nats-server.zip
-  unzip nats-server.zip
-  mv nats-server-v2.1.0-linux-amd64/nats-server .
-else
-  echo 'Using cached directory.';
-fi
-
-cd $HOME
-# check to see if nats-streaming-server folder is empty
-if [ ! "$(ls -A $HOME/nats-streaming-server)" ]; then
-  mkdir -p $HOME/nats-streaming-server
-  cd $HOME/nats-streaming-server
-  wget https://github.com/nats-io/nats-streaming-server/releases/download/v0.16.2/nats-streaming-server-v0.16.2-linux-amd64.zip -O nats-streaming-server.zip
-  unzip nats-streaming-server.zip
-  mv nats-streaming-server-v0.16.2-linux-amd64/nats-streaming-server .
-else
-  echo 'Using cached directory.';
-fi
-
-# check to see if pbuf folder is empty
-if [ ! "$(ls -A $HOME/pbuf)" ]; then
-  sudo echo "deb http://archive.ubuntu.com/ubuntu disco main restricted universe multiverse" >> /etc/apt/sources.list
-  sudo apt-get update
-  sudo apt-get install libprotobuf-c-dev
-  mkdir -p $HOME/pbuf
-  cp -pr /usr/include/protobuf-c $HOME/pbuf/
-  cp /usr/lib/x86_64-linux-gnu/libprotobuf-c.so* $HOME/pbuf
-  sudo rm /usr/lib/x86_64-linux-gnu/libprotobuf-c.*
-else
-  echo 'Using cached directory.';
-fi
-
-# check to see if sodium folder is empty
-if [ ! "$(ls -A $HOME/sodium)" ]; then
-  sudo apt-get update
-  sudo apt-get install libsodium-dev
-  mkdir -p $HOME/sodium
-  cp -pr /usr/include/sodium $HOME/sodium/
-  cp -pr /usr/include/sodium.h $HOME/sodium/
-  cp /usr/lib/x86_64-linux-gnu/libsodium.so* $HOME/sodium
-  sudo rm /usr/lib/x86_64-linux-gnu/libsodium.*
+# check to see if the deps folder is empty
+if [ ! "$(ls -A $HOME/deps)" ]; then
+  mkdir -p $HOME/deps
+  git clone https://github.com/nats-io/nats.c.deps.git $HOME/deps
 else
   echo 'Using cached directory.';
 fi


### PR DESCRIPTION
Download the dependencies:

- NATS Server
- NATS Streaming Server
- libprotobuf
- libsodium

from nats.c.deps repository. These deps are installed only when
the travis cache is found to be empty.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>