### PR TITLE
[FIXED] Make CMake fail for incompatible configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(NATS_BUILD_STREAMING)
       ${NATS_PROTOBUF_DIR}
   )
   FIND_LIBRARY(NATS_PROTOBUF_LIBRARY
-    NAMES libprotobuf-c.a libprotobuf-c.so libprotobuf-c.dylib protobuf-c.lib protobuf-c.dll
+    NAMES libprotobuf-c.so libprotobuf-c.dylib libprotobuf-c.a protobuf-c.lib protobuf-c.dll
     HINTS ${NATS_PROTOBUF_DIR}
   )
   FIND_PACKAGE_HANDLE_STANDARD_ARGS(libprotobuf-c DEFAULT_MSG
@@ -104,7 +104,7 @@ if(NATS_BUILD_USE_SODIUM)
       ${NATS_SODIUM_DIR}
   )
   FIND_LIBRARY(NATS_SODIUM_LIBRARY
-    NAMES libsodium.a libsodium.so libsodium.dylib libsodium.lib libsodium.dll
+    NAMES libsodium.so libsodium.dylib libsodium.a libsodium.lib libsodium.dll
     HINTS ${NATS_SODIUM_DIR}
   )
   FIND_PACKAGE_HANDLE_STANDARD_ARGS(libsodium DEFAULT_MSG

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,7 +2,8 @@ if(NOT NATS_BUILD_EXAMPLES)
   return()
 endif()
 if(NOT NATS_BUILD_STATIC_EXAMPLES AND NOT NATS_BUILD_LIB_SHARED)
-  message("Building examples require shared library")
+  MESSAGE(FATAL_ERROR
+    "Building examples require shared library, or run CMake with -DNATS_BUILD_STATIC_EXAMPLES=ON")
 endif()
 
 # We need this directory to build the examples

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,8 @@ if(NOT BUILD_TESTING)
   return()
 endif()
 if(NOT NATS_BUILD_LIB_STATIC)
-   message("Building tests require static library")
+   MESSAGE(FATAL_ERROR
+     "Building tests require static library, or run CMake with -DBUILD_TESTING=OFF")
   return()
 endif()  
 


### PR DESCRIPTION
For instance, building static library only requires the user to
set `-DNATS_BUILD_STATIC_EXAMPLES=ON` otherwise a message is printed.
Replace the simple error message with a fatal error.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>