### PR TITLE
[ADDED] natsSubscription_SetOnComplete API

### DIFF
--- a/src/natsp.h
+++ b/src/natsp.h
@@ -137,8 +137,6 @@ extern int64_t gLockSpinCount;
 
 typedef void (*natsInitOnceCb)(void);
 
-typedef void (*natsOnCompleteCB)(void *closure);
-
 typedef struct __natsControl
 {
     char    *op;

--- a/src/stan/conn.c
+++ b/src/stan/conn.c
@@ -358,7 +358,7 @@ stanConnection_Connect(stanConnection **newConn, const char* clusterID, const ch
         {
             natsSubscription_SetPendingLimits(sc->hbSubscription, -1, -1);
             sc->refs++;
-            s = natsSub_setOnCompleteCB(sc->hbSubscription, _releaseStanConnCB, (void*) sc);
+            s = natsSubscription_SetOnCompleteCB(sc->hbSubscription, _releaseStanConnCB, (void*) sc);
             if (s != NATS_OK)
                 sc->refs--;
         }
@@ -376,7 +376,7 @@ stanConnection_Connect(stanConnection **newConn, const char* clusterID, const ch
 
             natsSubscription_SetPendingLimits(pingSub, -1, -1);
             sc->refs++;
-            s = natsSub_setOnCompleteCB(pingSub, _releaseStanConnCB, (void*) sc);
+            s = natsSubscription_SetOnCompleteCB(pingSub, _releaseStanConnCB, (void*) sc);
             if (s != NATS_OK)
                 sc->refs--;
         }
@@ -522,7 +522,7 @@ stanConnection_Connect(stanConnection **newConn, const char* clusterID, const ch
         {
             natsSubscription_SetPendingLimits(sc->ackSubscription, -1, -1);
             sc->refs++;
-            s = natsSub_setOnCompleteCB(sc->ackSubscription, _releaseStanConnCB, (void*) sc);
+            s = natsSubscription_SetOnCompleteCB(sc->ackSubscription, _releaseStanConnCB, (void*) sc);
             if (s != NATS_OK)
                 sc->refs--;
         }

--- a/src/stan/sub.c
+++ b/src/stan/sub.c
@@ -346,7 +346,7 @@ stanConn_subscribe(stanSubscription **newSub, stanConnection *sc,
             // Retain both sub and sc
             sub->refs++;
             stanConn_retain(sc);
-            s = natsSub_setOnCompleteCB(sub->inboxSub, _releaseStanSubCB, (void*) sub);
+            s = natsSubscription_SetOnCompleteCB(sub->inboxSub, _releaseStanSubCB, (void*) sub);
             if (s != NATS_OK)
             {
                 sub->refs--;

--- a/src/sub.c
+++ b/src/sub.c
@@ -226,12 +226,15 @@ natsSub_setMax(natsSubscription *sub, uint64_t max)
 }
 
 natsStatus
-natsSub_setOnCompleteCB(natsSubscription *sub, natsOnCompleteCB cb, void *closure)
+natsSubscription_SetOnCompleteCB(natsSubscription *sub, natsOnCompleteCB cb, void *closure)
 {
     natsStatus s = NATS_OK;
 
+    if (sub == NULL)
+        return nats_setDefaultError(NATS_INVALID_ARG);
+
     natsSub_Lock(sub);
-    if (sub->closed)
+    if ((sub->closed) || (sub->msgCb == NULL))
         s = nats_setDefaultError(NATS_INVALID_SUBSCRIPTION);
     else
     {
@@ -434,7 +437,7 @@ natsConnection_SubscribeTimeout(natsSubscription **sub, natsConnection *nc, cons
     natsStatus s;
 
     if ((cb == NULL) || (timeout <= 0))
-            return nats_setDefaultError(NATS_INVALID_ARG);
+        return nats_setDefaultError(NATS_INVALID_ARG);
 
     s = natsConn_subscribeWithTimeout(sub, nc, subject, timeout, cb, cbClosure);
 

--- a/src/sub.h
+++ b/src/sub.h
@@ -46,9 +46,6 @@ natsSub_setMax(natsSubscription *sub, uint64_t max);
 void
 natsSub_drain(natsSubscription *sub);
 
-natsStatus
-natsSub_setOnCompleteCB(natsSubscription *sub, natsOnCompleteCB cb, void *closure);
-
 void
 natsSub_close(natsSubscription *sub, bool connectionClosed);
 

--- a/test/list.txt
+++ b/test/list.txt
@@ -132,6 +132,7 @@ AsyncErrHandler
 AsyncSubscriberStarvation
 AsyncSubscriberOnClose
 NextMsgCallOnAsyncSub
+SubOnComplete
 GetLastError
 StaleConnection
 ServerErrorClosesConnection


### PR DESCRIPTION
This allows users to set a callback that will be invoked when the
subscription is closed and message handler returns.

Resolves #302

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>