### PR TITLE
Make natsConnection_GetClientIP() return NATS_NO_SERVER_SUPPORT

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -4070,7 +4070,9 @@ natsConnection_GetClientIP(natsConnection *nc, char **ip)
     natsConn_Lock(nc);
     if (natsConn_isClosed(nc))
         s = nats_setDefaultError(NATS_CONNECTION_CLOSED);
-    else if ((nc->info.clientIP != NULL) && ((*ip = NATS_STRDUP(nc->info.clientIP)) == NULL))
+    else if (nc->info.clientIP == NULL)
+        s = nats_setDefaultError(NATS_NO_SERVER_SUPPORT);
+    else if ((*ip = NATS_STRDUP(nc->info.clientIP)) == NULL)
         s = nats_setDefaultError(NATS_NO_MEMORY);
     natsConn_Unlock(nc);
 

--- a/src/nats.h
+++ b/src/nats.h
@@ -2519,6 +2519,10 @@ natsConnection_Sign(natsConnection *nc,
  * \note The user is responsible to free memory allocated to store
  * the client IP address.
  *
+ * \note This is supported on servers >= version 2.1.6. Calling
+ * #natsConnection_GetClientIP() with server below this version will
+ * return the #NATS_NO_SERVER_SUPPORT error.
+ *
  * @param nc the pointer to the #natsConnection object.
  * @param ip the memory location where to store the client's IP string.
  * The user is responsible from freeing this memory.


### PR DESCRIPTION
if connected to an older server. In pair with the Go client.

Related to #312

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>