### PR TITLE
[FIXED] Randomize discovered server URLs if allowed

### DIFF
--- a/src/srvpool.c
+++ b/src/srvpool.c
@@ -183,19 +183,19 @@ _addURLToPool(natsSrvPool *pool, char *sURL, bool implicit, const char *tlsName)
 }
 
 static void
-_shufflePool(natsSrvPool *pool)
+_shufflePool(natsSrvPool *pool, int offset)
 {
     int     i, j;
     natsSrv *tmp;
 
-    if (pool->size <= 1)
+    if (pool->size <= offset+1)
         return;
 
     srand((unsigned int) nats_NowInNanoSeconds());
 
-    for (i = 0; i < pool->size; i++)
+    for (i = offset; i < pool->size; i++)
     {
-        j = rand() % (i + 1);
+        j = offset + rand() % (i + 1 - offset);
         tmp = pool->srvrs[i];
         pool->srvrs[i] = pool->srvrs[j];
         pool->srvrs[j] = tmp;
@@ -322,7 +322,7 @@ natsSrvPool_addNewURLs(natsSrvPool *pool, const natsUrl *curUrl, char **urls, in
             s = _addURLToPool(pool, url, true, tlsName);
         }
         if ((s == NATS_OK) && added && pool->randomize)
-            _shufflePool(pool);
+            _shufflePool(pool, 1);
     }
 
     natsStrHash_Destroy(tmp);
@@ -375,7 +375,7 @@ natsSrvPool_Create(natsSrvPool **newPool, natsOptions *opts)
     {
         // Randomize if allowed to
         if (pool->randomize)
-            _shufflePool(pool);
+            _shufflePool(pool, 0);
     }
 
     // Normally, if this one is set, Options.Servers should not be,

--- a/src/srvpool.c
+++ b/src/srvpool.c
@@ -321,6 +321,8 @@ natsSrvPool_addNewURLs(natsSrvPool *pool, const natsUrl *curUrl, char **urls, in
             }
             s = _addURLToPool(pool, url, true, tlsName);
         }
+        if ((s == NATS_OK) && added && pool->randomize)
+            _shufflePool(pool);
     }
 
     natsStrHash_Destroy(tmp);
@@ -360,6 +362,7 @@ natsSrvPool_Create(natsSrvPool **newPool, natsOptions *opts)
     // Set the current capacity. The array of urls may have to grow in
     // the future.
     pool->cap = poolSize;
+    pool->randomize = !opts->noRandomize;
 
     // Map that helps find out if an URL is already known.
     s = natsStrHash_Create(&(pool->urls), poolSize);
@@ -371,7 +374,7 @@ natsSrvPool_Create(natsSrvPool **newPool, natsOptions *opts)
     if (s == NATS_OK)
     {
         // Randomize if allowed to
-        if (!(opts->noRandomize))
+        if (pool->randomize)
             _shufflePool(pool);
     }
 

--- a/src/srvpool.h
+++ b/src/srvpool.h
@@ -36,6 +36,7 @@ typedef struct __natsSrvPool
     natsStrHash *urls;
     int         size;
     int         cap;
+    bool        randomize;
 
 } natsSrvPool;
 

--- a/test/test.c
+++ b/test/test.c
@@ -5839,6 +5839,9 @@ test_AsyncINFO(void)
             s = checkNewURLsAddedRandomly(nc, urlsAfterPoolSetup, initialPoolSize);
         testCond((s == NATS_OK) && (nc->ps->state == OP_START));
 
+        test("First URL should not have been changed: ")
+        testCond((s == NATS_OK) && !strcmp(nc->srvPool->srvrs[0]->url->fullUrl, urlsAfterPoolSetup[0]));
+
         if (urlsAfterPoolSetup != NULL)
         {
             for (i=0; i<initialPoolSize; i++)


### PR DESCRIPTION
If randomize is allowed, discovered URLs will be randomly added
to the pool of urls instead of always be appended.

See nats-io/nats.go#565

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>