### PR TITLE
[FIXED] natsOptions_SetDisconnectedCB() documentation

### DIFF
--- a/src/nats.h
+++ b/src/nats.h
@@ -1221,10 +1221,7 @@ natsOptions_SetClosedCB(natsOptions *opts, natsConnectionHandler closedCb,
  *         lost.
  *
  * Specifies the callback to invoke when a connection to the `NATS Server`
- * is lost. There could be two instances of the callback when reconnection
- * is allowed: one before attempting the reconnect attempts, and one when
- * all reconnect attempts have failed and the connection is going to be
- * permanently closed.
+ * is lost.
  *
  * \warning Invocation of this callback is asynchronous, which means that
  * the state of the connection may have changed when this callback is


### PR DESCRIPTION
The documentation stated that the callback could be invoked twice:
once during the initial disconnect and a second time when the
library failed to reconnect.
This behavior has been fixed since v1.2.10 such as the library does
not invoke the callback during the final close after failed
reconnect attempts.

Resolves #321

[ci skip]

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>