### PR TITLE
[FIXED] ErrorHandler not properly invoked for SlowConsumer cases

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -2540,7 +2540,7 @@ natsConn_processMsg(natsConnection *nc, char *buf, int bufLen)
 
         sub->dropped++;
 
-        sc = sub->slowConsumer;
+        sc = !sub->slowConsumer;
         sub->slowConsumer = true;
 
         // Undo stats from above.

--- a/test/list.txt
+++ b/test/list.txt
@@ -122,6 +122,7 @@ CloseSubRelease
 IsValidSubscriber
 SlowSubscriber
 SlowAsyncSubscriber
+SlowConsumerCb
 PendingLimitsDeliveredAndDropped
 PendingLimitsWithSyncSub
 AsyncSubscriptionPending


### PR DESCRIPTION
The goal is to invoked the error handler only once for several
dropped messages, that is, until the slow consumer marker for
a subscription is cleared. There was a defect in getting to
know when to fire the callback.
Typical case would be if there is a condition that trips the
slow consumer, the callback would not be invoked until after
a new message is received (and be still over the limit).

Resolves #327

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>