### PR TITLE
[FIXED] Close connection callback possibly invoked twice

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -3408,6 +3408,11 @@ _drainPubsAndClose(natsConnection *nc)
 
     // Flip state
     natsConn_Lock(nc);
+    if (natsConn_isClosed(nc))
+    {
+        natsConn_Unlock(nc);
+        return;
+    }
     nc->status = NATS_CONN_STATUS_DRAINING_PUBS;
     natsConn_Unlock(nc);
 
@@ -3430,6 +3435,7 @@ _checkAllSubsAreDrained(natsTimer *t, void *closure)
     natsConn_Lock(nc);
     if (nc->status == NATS_CONN_STATUS_CLOSED)
     {
+        natsTimer_Stop(nc->drainTimer);
         natsConn_Unlock(nc);
         return;
     }

--- a/test/list.txt
+++ b/test/list.txt
@@ -141,6 +141,7 @@ NoEcho
 NoEchoOldServer
 DrainSub
 DrainConn
+NoDoubleCloseCbOnDrain
 GetClientID
 GetClientIP
 GetRTT


### PR DESCRIPTION
There was a race between draining a connection and connection
being closed that could lead to the connection's close callback
to be invoked twice.

Resolves #331

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>