### PR TITLE
[ADDED] natsOptions_SetLameDuckModeCB()

### DIFF
--- a/src/asynccb.h
+++ b/src/asynccb.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 The NATS Authors
+// Copyright 2015-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -24,6 +24,7 @@ typedef enum
     ASYNC_ERROR,
     ASYNC_DISCOVERED_SERVERS,
     ASYNC_CONNECTED,
+    ASYNC_LAME_DUCK_MODE,
 
 #if defined(NATS_HAS_STREAMING)
     ASYNC_STAN_CONN_LOST

--- a/src/nats.c
+++ b/src/nats.c
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 The NATS Authors
+// Copyright 2015-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -767,6 +767,9 @@ _asyncCbsThread(void *arg)
                 break;
             case ASYNC_DISCOVERED_SERVERS:
                 (*(nc->opts->discoveredServersCb))(nc, nc->opts->discoveredServersClosure);
+                break;
+            case ASYNC_LAME_DUCK_MODE:
+                (*(nc->opts->lameDuckCb))(nc, nc->opts->lameDuckClosure);
                 break;
             case ASYNC_ERROR:
                 (*(nc->opts->asyncErrCb))(nc, cb->sub, cb->err, nc->opts->asyncErrCbClosure);

--- a/src/nats.h
+++ b/src/nats.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 The NATS Authors
+// Copyright 2015-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -1365,6 +1365,27 @@ NATS_EXTERN natsStatus
 natsOptions_SetDiscoveredServersCB(natsOptions *opts,
                                    natsConnectionHandler discoveredServersCb,
                                    void *closure);
+
+/** \brief Sets the callback to be invoked when server enters lame duck mode.
+ *
+ * Specifies the callback to invoke when the server notifies
+ * the connection that it entered lame duck mode, that is, going to
+ * gradually disconnect all its connections before shuting down. This is
+ * often used in deployments when upgrading NATS Servers.
+ *
+ * \warning Invocation of this callback is asynchronous, which means that
+ * the state may have changed when this callback is invoked.
+ *
+ * @param opts the pointer to the #natsOptions object.
+ * @param lameDuckCb the callback to be invoked when server enters
+ * lame duck mode.
+ * @param closure a pointer to an user object that will be passed to
+ * the callback. `closure` can be `NULL`.
+ */
+NATS_EXTERN natsStatus
+natsOptions_SetLameDuckModeCB(natsOptions *opts,
+                              natsConnectionHandler lameDuckCb,
+                              void *closure);
 
 /** \brief Sets the external event loop and associated callbacks.
  *

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 The NATS Authors
+// Copyright 2015-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -159,6 +159,7 @@ typedef struct __natsServerInfo
     uint64_t    CID;
     char        *nonce;
     char        *clientIP;
+    bool        lameDuckMode;
 
 } natsServerInfo;
 
@@ -233,6 +234,9 @@ struct __natsOptions
 
     natsConnectionHandler   connectedCb;
     void                    *connectedCbClosure;
+
+    natsConnectionHandler   lameDuckCb;
+    void                    *lameDuckClosure;
 
     natsErrHandler          asyncErrCb;
     void                    *asyncErrCbClosure;

--- a/src/opts.c
+++ b/src/opts.c
@@ -1,4 +1,4 @@
-// Copyright 2015-2019 The NATS Authors
+// Copyright 2015-2020 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -956,6 +956,21 @@ natsOptions_SetDiscoveredServersCB(natsOptions *opts,
 
     opts->discoveredServersCb = discoveredServersCb;
     opts->discoveredServersClosure = closure;
+
+    UNLOCK_OPTS(opts);
+
+    return NATS_OK;
+}
+
+natsStatus
+natsOptions_SetLameDuckModeCB(natsOptions *opts,
+                              natsConnectionHandler lameDuckCb,
+                              void *closure)
+{
+    LOCK_AND_CHECK_OPTIONS(opts, 0);
+
+    opts->lameDuckCb = lameDuckCb;
+    opts->lameDuckClosure = closure;
 
     UNLOCK_OPTS(opts);
 

--- a/test/list.txt
+++ b/test/list.txt
@@ -177,6 +177,7 @@ INFOAfterFirstPONGisProcessedOK
 ServerPoolUpdatedOnClusterUpdate
 ReconnectJitter
 CustomReconnectDelay
+LameDuckMode
 StanPBufAllocator
 StanConnOptions
 StanSubOptions


### PR DESCRIPTION
This allows applications to be notified that the server it is
connected to is enterring lame duck mode. This is purely informative
as the library is currently not doing anything with this information.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>