### PR TITLE
Remove unused variables

### DIFF
--- a/src/adapters/libuv.h
+++ b/src/adapters/libuv.h
@@ -269,7 +269,6 @@ uvAsyncCb(uv_async_t *handle)
     natsLibuvEvents *nle    = (natsLibuvEvents*) handle->data;
     natsStatus      s       = NATS_OK;
     natsLibuvEvent  *event  = NULL;
-    bool            remove  = false;
     bool            more    = false;
 
     while (1)

--- a/src/comsock.c
+++ b/src/comsock.c
@@ -88,7 +88,6 @@ natsSock_ConnectTcp(natsSockCtx *ctx, const char *phost, int port)
     struct addrinfo hints;
     struct addrinfo *servinfo = NULL;
     struct addrinfo *p;
-    bool            waitForConnect = false;
     bool            error = false;
     int             i;
     int             max = 1;

--- a/src/conn.c
+++ b/src/conn.c
@@ -1418,7 +1418,6 @@ _doReconnect(void *arg)
 {
     natsStatus                      s           = NATS_OK;
     natsConnection                  *nc         = (natsConnection*) arg;
-    int64_t                         elapsed     = 0;
     natsSrvPool                     *pool       = NULL;
     int64_t                         sleepTime   = 0;
     struct threadsToJoin            ttj;
@@ -1689,7 +1688,6 @@ _readProto(natsConnection *nc, natsBuffer **proto)
 {
 	natsStatus	s 			= NATS_OK;
 	char		protoEnd	= '\n';
-	int			i			= 0;
 	natsBuffer	*buf		= NULL;
 	char		oneChar[1]  = { '\0' };
 
@@ -1900,7 +1898,6 @@ _connect(natsConnection *nc)
     natsStatus  s     = NATS_OK;
     natsStatus  retSts= NATS_OK;
     natsSrvPool *pool = NULL;
-    bool        done  = false;
     int         i = 0;
     int         l = 0;
     int         max = 0;
@@ -3356,8 +3353,6 @@ natsStatus
 natsConnection_FlushTimeout(natsConnection *nc, int64_t timeout)
 {
     natsStatus  s       = NATS_OK;
-    int64_t     target  = 0;
-    natsPong    *pong   = NULL;
 
     if (nc == NULL)
         return nats_setDefaultError(NATS_INVALID_ARG);

--- a/src/nats.c
+++ b/src/nats.c
@@ -205,7 +205,7 @@ nats_ReleaseThreadMemory(void)
     natsMutex_Unlock(gLib.lock);
 }
 
-#if _WIN32
+#if defined(_WIN32) && _WIN32
 #ifndef NATS_STATIC
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, // DLL module handle
      DWORD fdwReason,                   // reason called
@@ -1639,7 +1639,6 @@ _deliverMsgs(void *arg)
     uint64_t            max;
     natsMsg             *msg;
     bool                timerNeedReset = false;
-    bool                removeSub = false;
 
     natsMutex_Lock(dlv->lock);
 

--- a/src/opts.c
+++ b/src/opts.c
@@ -411,7 +411,6 @@ natsOptions_SetCATrustedCertificates(natsOptions *opts, const char *certs)
     s = _getSSLCtx(opts);
     if (s == NATS_OK)
     {
-        X509                *cert = NULL;
         BIO                 *bio  = NULL;
         X509_STORE          *cts  = NULL;
         STACK_OF(X509_INFO) *inf  = NULL;
@@ -438,7 +437,7 @@ natsOptions_SetCATrustedCertificates(natsOptions *opts, const char *certs)
                                   NATS_SSL_ERR_REASON_STRING);
             }
         }
-        for (i = 0; ((s == NATS_OK) && (i < sk_X509_INFO_num(inf))); i++)
+        for (i = 0; ((s == NATS_OK) && (i < (int)sk_X509_INFO_num(inf))); i++)
         {
             X509_INFO *itmp = sk_X509_INFO_value(inf, i);
             if (itmp->x509)
@@ -1189,8 +1188,6 @@ natsOptions_SetUserCredentialsCallbacks(natsOptions *opts,
                                         natsSignatureHandler    sigCB,
                                         void                    *sigClosure)
 {
-    natsStatus  s   = NATS_OK;
-
     // Callbacks can all be NULL (to unset), however, if one is set,
     // the other must be.
     LOCK_AND_CHECK_OPTIONS(opts,
@@ -1225,7 +1222,6 @@ natsOptions_SetNKey(natsOptions             *opts,
                     natsSignatureHandler    sigCB,
                     void                    *sigClosure)
 {
-    natsStatus  s   = NATS_OK;
     char        *nk = NULL;
 
     // If pubKey is not empty, then signature must be specified

--- a/src/parser.c
+++ b/src/parser.c
@@ -86,7 +86,6 @@ _processMsgArgs(natsConnection *nc, char *buf, int bufLen)
 {
     natsStatus      s       = NATS_OK;
     int             start   = -1;
-    int             len     = 0;
     int             index   = 0;
     int             i;
     char            b;

--- a/src/pub.c
+++ b/src/pub.c
@@ -41,7 +41,6 @@ natsConn_publish(natsConnection *nc, const char *subj,
     int         subjLen = 0;
     int         replyLen = 0;
     int         sizeSize = 0;
-    int         pos = 0;
     bool        reconnecting = false;
 
     if (nc == NULL)
@@ -325,7 +324,6 @@ natsConnection_Request(natsMsg **replyMsg, natsConnection *nc, const char *subj,
                        const void *data, int dataLen, int64_t timeout)
 {
     natsStatus          s           = NATS_OK;
-    natsSubscription    *sub        = NULL;
     respInfo            *resp       = NULL;
     bool                createSub   = false;
     bool                needsRemoval= true;

--- a/src/sub.c
+++ b/src/sub.c
@@ -249,8 +249,6 @@ natsSubscription_SetOnCompleteCB(natsSubscription *sub, natsOnCompleteCB cb, voi
 void
 natsSub_close(natsSubscription *sub, bool connectionClosed)
 {
-    natsMsgDlvWorker *ldw = NULL;
-
     natsSub_Lock(sub);
 
     SUB_DLV_WORKER_LOCK(sub);

--- a/src/util.c
+++ b/src/util.c
@@ -633,7 +633,6 @@ nats_JSONParse(nats_JSON **newJSON, const char *jsonStr, int jsonLen)
     char            *ptr;
     char            *fieldName = NULL;
     int             state;
-    bool            gotEnd    = false;
     char            *copyStr  = NULL;
 
     if (jsonLen < 0)
@@ -1003,7 +1002,6 @@ nats_JSONGetDouble(nats_JSON *json, const char *fieldName, long double *value)
 natsStatus
 nats_JSONGetArrayField(nats_JSON *json, const char *fieldName, int fieldType, nats_JSONField **retField)
 {
-    natsStatus      s        = NATS_OK;
     nats_JSONField  *field   = NULL;
 
     field = (nats_JSONField*) natsStrHash_Get(json->fields, (char*) fieldName);
@@ -1109,7 +1107,6 @@ nats_Base32_Init(void)
 natsStatus
 nats_Base32_DecodeString(const char *src, char *dst, int dstMax, int *dstLen)
 {
-    natsStatus  s         = NATS_OK;
     char        *ptr      = (char*) src;
     int         n         = 0;
     bool        done      = false;


### PR DESCRIPTION
This commit makes nats.c buildable under stricter compiler flags.

Different use cases than libuv/NATS_HAS_TLS (probably) require more modification, but that's a start.