### PR TITLE
Removing more unused variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ if(UNIX)
      endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   endif(NATS_COMPILER_HARDENING)
 
-  set(NATS_WARNINGS "-fstrict-aliasing -Wall -W -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wstrict-prototypes -Wwrite-strings")
+  set(NATS_WARNINGS "-fstrict-aliasing -Wall -W -Wno-unused-parameter -Wno-unused-function -Wstrict-prototypes -Wwrite-strings")
   set(NATS_PLATFORM_INCLUDE "unix")
   
   if(APPLE)

--- a/examples/publisher.c
+++ b/examples/publisher.c
@@ -22,7 +22,6 @@ int main(int argc, char **argv)
     natsConnection  *conn  = NULL;
     natsStatistics  *stats = NULL;
     natsOptions     *opts  = NULL;
-    int64_t         last   = 0;
     natsStatus      s;
     int             dataLen=0;
 

--- a/examples/stan/sub.c
+++ b/examples/stan/sub.c
@@ -112,7 +112,6 @@ int main(int argc, char **argv)
     stanSubOptions      *subOpts    = NULL;
     stanConnection      *sc         = NULL;
     stanSubscription    *sub        = NULL;
-    int64_t             last        = 0;
     bool                connLost    = false;
 
     opts = parseArgs(argc, argv, usage);

--- a/src/nats.c
+++ b/src/nats.c
@@ -32,6 +32,8 @@
 #include "nkeys.h"
 #include "crypto.h"
 
+static const char *inboxPrefix = "_INBOX.";
+
 #define WAIT_LIB_INITIALIZED \
         natsMutex_Lock(gLib.lock); \
         while (!(gLib.initialized) && !(gLib.initAborted)) \

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -90,8 +90,7 @@
 #define _OK_OP_LEN_         (3)
 #define _ERR_OP_LEN_        (4)
 
-static const char *inboxPrefix = "_INBOX.";
-#define NATS_INBOX_PRE_LEN (7)
+#define NATS_INBOX_PRE_LEN  (7)
 
 #define NATS_REQ_ID_OFFSET  (NATS_INBOX_PRE_LEN + NUID_BUFFER_LEN + 1)
 #define NATS_MAX_REQ_ID_LEN (19) // to display 2^63 number

--- a/src/stan/conn.c
+++ b/src/stan/conn.c
@@ -602,7 +602,6 @@ stanConnClose(stanConnection *sc, bool sendProto)
     int                 reqSize   = 0;
     char                *reqBytes = NULL;
     natsMsg             *replyMsg = NULL;
-    _pubAck             *pa       = NULL;
     natsConnection      *nc       = NULL;
     char                *cid      = NULL;
     char                *closeSubj= NULL;

--- a/src/stan/pub.c
+++ b/src/stan/pub.c
@@ -273,7 +273,6 @@ _stanPublish(stanConnection *sc, const char *channel, const void *data, int data
     if (s == NATS_OK)
     {
         Pb__PubMsg  pubReq;
-        const void  *pubBytes = NULL;
         int         pubSize   = 0;
 
         pb__pub_msg__init(&pubReq);

--- a/src/stan/sub.c
+++ b/src/stan/sub.c
@@ -156,7 +156,6 @@ stanSubscription_AckMsg(stanSubscription *sub, stanMsg *msg)
 {
     natsStatus      s       = NATS_OK;
     natsConnection  *nc     = NULL;
-    char            *ackBuf = NULL;
     bool            flush   = false;
     char            *ackSub = NULL;
     int             ackSize = 0;

--- a/test/test.c
+++ b/test/test.c
@@ -5628,8 +5628,6 @@ test_AsyncINFO(void)
                                "INFO {\"connect_urls\":[]}\r\n"};
     const char      *wrong[] = {"IxNFO {}\r\n", "INxFO {}\r\n", "INFxO {}\r\n",
                                 "INFOx {}\r\n", "INFO{}\r\n", "INFO {}"};
-    const char      *allURLs[] = {"localhost:4222", "localhost:5222", "localhost:6222", "localhost:7222",
-                                  "localhost:8222", "localhost:9222", "localhost:10222", "localhost:11222"};
     const char      *lastErr = NULL;
 
     s = natsOptions_Create(&opts);
@@ -10587,7 +10585,6 @@ test_Stats(void)
     uint64_t            outBytes = 0;
     uint64_t            inMsgs = 0;
     uint64_t            inBytes = 0;
-    uint64_t            reconnects = 0;
 
     test("Check invalid arg: ");
     s = natsStatistics_GetCounts(NULL, NULL, NULL, NULL, NULL, NULL);
@@ -11189,7 +11186,6 @@ static void
 _slowConsErrCB(natsConnection *nc, natsSubscription *sub, natsStatus err, void *closure)
 {
     struct threadArg *arg    = (struct threadArg*) closure;
-    int64_t          dropped = 0;
 
     natsMutex_Lock(arg->m);
     if (err == NATS_SLOW_CONSUMER)
@@ -11691,9 +11687,6 @@ test_AsyncSubscriptionPendingDrain(void)
     int                 total     = 100;
     int                 msgs      = 0;
     int                 bytes     = 0;
-    int                 mlen      = 10;
-    int                 totalSize = total * mlen;
-    uint64_t            queuedMsgs= 0;
     int64_t             delivered = 0;
     int                 i;
     struct threadArg    arg;
@@ -12243,7 +12236,6 @@ test_SubOnComplete(void)
     natsStatus          s;
     natsConnection      *nc       = NULL;
     natsSubscription    *sub      = NULL;
-    natsMsg             *msg      = NULL;
     natsPid             serverPid = NATS_INVALID_PID;
     struct threadArg    arg;
 
@@ -15168,7 +15160,6 @@ test_DrainSub(void)
     natsSubscription    *sub= NULL;
     natsSubscription    *sub2 = NULL;
     natsSubscription    *sub3 = NULL;
-    natsSubscription    *sub4 = NULL;
     natsPid             pid = NATS_INVALID_PID;
     struct threadArg    arg;
 
@@ -16105,7 +16096,6 @@ _sigCB(char **customErrTxt, unsigned char **psig, int *sigLen, const char* nonce
             104, 191, 138, 217, 227,   1,  92,  14,
     };
     unsigned char *sig = NULL;
-    unsigned char *ptr = NULL;
 
     if (closure != NULL)
     {
@@ -17658,7 +17648,6 @@ test_SSLMultithreads(void)
 {
 #if defined(NATS_HAS_TLS)
     natsStatus          s;
-    natsConnection      *nc       = NULL;
     natsOptions         *opts     = NULL;
     natsPid             serverPid = NATS_INVALID_PID;
     natsThread          *t[SSL_THREADS];
@@ -18457,7 +18446,6 @@ static void
 _stanPubAckHandler(const char *guid, const char *errTxt, void* closure)
 {
     struct threadArg *args= (struct threadArg*) closure;
-    char             *val = NULL;
 
     natsMutex_Lock(args->m);
     args->status = NATS_OK;


### PR DESCRIPTION
Removed the `-Wno-unused-variable` so we get report in the future.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>