### PR TITLE
[FIXED] Streaming: segfault if connection lost but no handler was set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,8 +1378,12 @@ connectionLostCB(stanConnection *sc, const char *errTxt, void *closure)
 }
 ```
 
-Note that the only way to be notified is to set the callback. If the callback is not set, PINGs are still sent and the connection
-will be closed if needed, but the application won't know if it has only subscriptions.
+Note that the only way to be notified in your application is to set the callback. If the callback is not set, PINGs are still sent and the connection
+will be closed if needed, but the application won't know if it has only subscriptions. A default callback is used to simply
+print to standard error the clusterID, the clientID and the error that caused the connection to be lost:
+```
+Connection permanently lost: clusterID=test-cluster clientID=client error=connection lost due to PING failure
+```
 
 When the connection is lost, your application would have to re-create it and all subscriptions if any.
 

--- a/src/stan/conn.h
+++ b/src/stan/conn.h
@@ -42,6 +42,9 @@ stanConn_retain(stanConnection *nc);
 void
 stanConn_release(stanConnection *nc);
 
+void
+stanConn_defaultConnLostHandler(stanConnection *sc, const char* errorTxt, void *closure);
+
 natsStatus
 stanConnClose(stanConnection *sc, bool sendProto);
 

--- a/src/stan/copts.c
+++ b/src/stan/copts.c
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "conn.h"
 #include "copts.h"
 #include "../opts.h"
 
@@ -57,6 +58,7 @@ stanConnOptions_Create(stanConnOptions **newOpts)
         opts->maxPubAcksInFlightPercentage = STAN_CONN_OPTS_DEFAULT_MAX_PUB_ACKS_INFLIGHT_PERCENTAGE;
         opts->pingInterval = STAN_CONN_OPTS_DEFAULT_PING_INTERVAL;
         opts->pingMaxOut = STAN_CONN_OPTS_DEFAULT_PING_MAX_OUT;
+        opts->connectionLostCB = stanConn_defaultConnLostHandler;
     }
 
     if (s == NATS_OK)

--- a/src/stan/stanp.h
+++ b/src/stan/stanp.h
@@ -119,6 +119,7 @@ struct __stanConnection
 
     natsConnection      *nc;
 
+    char                *clusterID;
     char                *clientID;
     char                *connID;
     int                 connIDLen;

--- a/test/list.txt
+++ b/test/list.txt
@@ -197,6 +197,7 @@ StanDurableQueueSubscription
 StanCheckReceivedMsg
 StanSubscriptionAckMsg
 StanPings
+StanConnectionLostHandlerNotSet
 StanPingsUnblockPublishCalls
 StanGetNATSConnection
 StanNoRetryOnFailedConnect


### PR DESCRIPTION
Although it is strongly recommended for the application to set its
own handler, if no handler is set, the library will now use a default
handler that simply prints the error.

Resolves #342

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>