### PR TITLE
Fix identical inner and outer 'if' condition

### DIFF
--- a/src/msg.c
+++ b/src/msg.c
@@ -842,11 +842,8 @@ natsMsg_create(natsMsg **newMsg,
     if (replyLen > 0)
     {
         msg->reply = (const char*) ptr;
-        if (replyLen > 0)
-        {
-            memcpy(ptr, reply, replyLen);
-            ptr += replyLen;
-        }
+        memcpy(ptr, reply, replyLen);
+        ptr += replyLen;
         *(ptr++) = '\0';
     }
     else


### PR DESCRIPTION
This patch fixes the following `cppckeck` warnings:

```
msg.c:842:18: note: outer condition: replyLen>0
    if (replyLen > 0)
                 ^
msg.c:845:22: note: identical inner condition: replyLen>0
        if (replyLen > 0)
```

and it is obvious that `memcpy()` length parameter is already guarded by the outer condition.

Signed-off-by: Paolo Teti <paolo.teti@gmail.com>