### PR TITLE
Fix possible memory leak due to an early return

### DIFF
--- a/src/sub.c
+++ b/src/sub.c
@@ -324,6 +324,10 @@ natsSub_create(natsSubscription **newSub, natsConnection *nc, const char *subj,
 {
     natsStatus          s = NATS_OK;
     natsSubscription    *sub = NULL;
+    int                 bytesLimit = nc->opts->maxPendingMsgs * 1024;
+
+    if (bytesLimit <= 0)
+        return nats_setError(NATS_INVALID_ARG, "Invalid bytes limit of %d", bytesLimit);
 
     sub = (natsSubscription*) NATS_CALLOC(1, sizeof(natsSubscription));
     if (sub == NULL)
@@ -344,10 +348,7 @@ natsSub_create(natsSubscription **newSub, natsConnection *nc, const char *subj,
     sub->msgCb          = cb;
     sub->msgCbClosure   = cbClosure;
     sub->msgsLimit      = nc->opts->maxPendingMsgs;
-    sub->bytesLimit     = sub->msgsLimit * 1024;
-
-    if (sub->bytesLimit <= 0)
-        return nats_setError(NATS_INVALID_ARG, "Invalid bytes limit of %d", sub->bytesLimit);
+    sub->bytesLimit     = bytesLimit;
 
     sub->subject = NATS_STRDUP(subj);
     if (sub->subject == NULL)


### PR DESCRIPTION
Cppcheck report a possible memory leak due to an early return after a memory allocation.

```
sub.c:350:9: error: Memory leak: sub [memleak]
        return nats_setError(NATS_INVALID_ARG, "Invalid bytes limit of %d", sub->bytesLimit);
```

Even if it cannot be triggered if options are setups using `natsOptions_Set*` helpers, the easy way to formally fix the issue is to validate the limit threshold (in bytes) before any memory allocation.

Signed-off-by: Paolo Teti <paolo.teti@gmail.com>