### PR TITLE
[FIXED] Possible memory leak when mem alloc failed creating an URL

### DIFF
--- a/src/url.c
+++ b/src/url.c
@@ -179,14 +179,14 @@ natsUrl_Create(natsUrl **newUrl, const char *urlStr)
                 *pwd = '\0';
 
                 if (url->password == NULL)
-                    return nats_setDefaultError(NATS_NO_MEMORY);
+                    s = nats_setDefaultError(NATS_NO_MEMORY);
             }
 
             if ((s == NATS_OK) && (strlen(ptr) > 0))
             {
                 url->username = NATS_STRDUP(ptr);
                 if (url->username == NULL)
-                    return nats_setDefaultError(NATS_NO_MEMORY);
+                    s = nats_setDefaultError(NATS_NO_MEMORY);
             }
         }
     }


### PR DESCRIPTION
GCC 10.0.1, when used with with `-fanalyzer`, reports:

`warning: leak of ‘url’ [CWE-401] [-Wanalyzer-malloc-leak]`

Issue is due to an early return. The easy way to fix it, without changing
too much, is to propagate the error code. In this way the function will
take care to free data structure calling `natsUrl_Destroy(url)`.

Signed-off-by: Paolo Teti <paolo.teti@gmail.com>