### PR TITLE
Fix GCC 10.x warning: on output truncated before terminating with nul

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 2.8)
 project(cnats)
 include(CTest)
 include(FindPackageHandleStandardArgs)
+include(CheckFunctionExists)
+
+check_function_exists(strlcpy HAVE_STRLCPY)
 
 # Uncomment to have the build process verbose
 #set(CMAKE_VERBOSE_MAKEFILE TRUE)

--- a/src/msg.c
+++ b/src/msg.c
@@ -214,8 +214,7 @@ _canonicalKey(const char *key, char *keyStack, int keyStackLen, char **cKey, boo
     }
     else
     {
-        strncpy(keyStack, key, lenKey);
-        keyStack[lenKey] = '\0';
+        strlcpy(keyStack, key, lenKey + 1);
         k = keyStack;
     }
     // Move directly to character that we know needs change.

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -33,6 +33,10 @@
 #define NO_SSL_ERR  "The library was built without SSL support!"
 #endif
 
+#if !defined(HAVE_STRLCPY)
+size_t strlcpy(char *dst, const char *src, size_t siz);
+#endif
+
 #include "err.h"
 #include "nats.h"
 #include "buf.h"

--- a/src/strlcpy.c
+++ b/src/strlcpy.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef HAVE_STRLCPY
+
+#include <stdlib.h>
+
+/* Implementation of strlcpy() for platforms that don't already have it. */
+/*
+ * Copy src to string dst of size siz.  At most siz-1 characters
+ * will be copied.  Always NUL terminates (unless siz == 0).
+ * Returns strlen(src); if retval >= siz, truncation occurred.
+ */
+size_t
+strlcpy(char *dst, const char *src, size_t siz)
+{
+	char *d = dst;
+	const char *s = src;
+	size_t n = siz;
+	/* Copy as many bytes as will fit */
+	if (n != 0) {
+		while (--n != 0) {
+			if ((*d++ = *s++) == '\0')
+				break;
+		}
+    }
+	/* Not enough room in dst, add NUL and traverse rest of src */
+	if (n == 0) {
+		if (siz != 0)
+			*d = '\0';		/* NUL-terminate dst */
+		while (*s++)
+			;
+	}
+	return(s - src - 1);	/* count does not include NUL */
+}
+#endif

--- a/test/test.c
+++ b/test/test.c
@@ -9129,7 +9129,7 @@ test_AuthViolation(void)
     {
         char info[1024];
 
-        strncpy(info,
+        strlcpy(info,
                 "INFO {\"server_id\":\"foobar\",\"version\":\"latest\",\"go\":\"latest\",\"host\":\"localhost\",\"port\":4222,\"auth_required\":false,\"tls_required\":false,\"max_payload\":1048576}\r\n",
                 sizeof(info));
 
@@ -11086,7 +11086,7 @@ test_ReleaseFlush(void)
         char buffer[1024];
         char info[1024];
 
-        strncpy(info,
+        strlcpy(info,
                 "INFO {\"server_id\":\"foobar\",\"version\":\"latest\",\"go\":\"latest\",\"host\":\"localhost\",\"port\":4222,\"auth_required\":false,\"tls_required\":false,\"max_payload\":1048576}\r\n",
                 sizeof(info));
 
@@ -11168,7 +11168,7 @@ test_FlushErrOnDisconnect(void)
     {
         char info[1024];
 
-        strncpy(info,
+        strlcpy(info,
                 "INFO {\"server_id\":\"foobar\",\"version\":\"latest\",\"go\":\"latest\",\"host\":\"localhost\",\"port\":4222,\"auth_required\":false,\"tls_required\":false,\"max_payload\":1048576}\r\n",
                 sizeof(info));
 
@@ -15430,7 +15430,7 @@ test_StaleConnection(void)
         {
             char info[1024];
 
-            strncpy(info,
+            strlcpy(info,
                     "INFO {\"server_id\":\"foobar\",\"version\":\"latest\",\"go\":\"latest\",\"host\":\"localhost\",\"port\":4222,\"auth_required\":false,\"tls_required\":false,\"max_payload\":1048576}\r\n",
                     sizeof(info));
 
@@ -15563,7 +15563,7 @@ test_ServerErrorClosesConnection(void)
     {
         char info[1024];
 
-        strncpy(info,
+        strlcpy(info,
                 "INFO {\"server_id\":\"foobar\",\"version\":\"latest\",\"go\":\"latest\",\"host\":\"localhost\",\"port\":4222,\"auth_required\":false,\"tls_required\":false,\"max_payload\":1048576}\r\n",
                 sizeof(info));
 


### PR DESCRIPTION
GCC 10.x (also on TravisCI) raise the following warning:

```
In file included from /usr/include/string.h:494,
             from /home/travis/build/nats-io/nats.c/src/include/n-unix.h:37,
             from /home/travis/build/nats-io/nats.c/src/natsp.h:20,
             from /home/travis/build/nats-io/nats.c/src/msg.c:14:

In function ‘strncpy’,
inlined from ‘_canonicalKey.constprop’ at /home/travis/build/nats-io/nats.c/src/msg.c:217:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:10: warning: ‘__builtin_strncpy’ output
truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
  |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

/home/travis/build/nats-io/nats.c/src/msg.c: In function ‘_canonicalKey.constprop’:
/home/travis/build/nats-io/nats.c/src/msg.c:181:33: note: length computed here
181 |     int         lenKey  = (int) strlen(key);
```

This is due to the string been truncated after use strncpy().
Even if there isn't an issue in this specific case, this patch replace strncpy() and the explicit NUL termination with strlcpy() that is the preferred alternative to strncpy() that has a incomplete termination semantics.

strncpy() is banned in a lots of open-source code nowadays (git is an example)

By the way strlcpy() is not available in all platforms (it is part of muslc, but not glibc), so this patch add also a way to auto-detect if available and adds a private implementation if not.

Signed-off-by: Paolo Teti <paolo.teti@gmail.com>