### PR TITLE
Replaced strncpy with memcpy

### DIFF
--- a/src/msg.c
+++ b/src/msg.c
@@ -214,7 +214,7 @@ _canonicalKey(const char *key, char *keyStack, int keyStackLen, char **cKey, boo
     }
     else
     {
-        strncpy(keyStack, key, lenKey);
+        memcpy((void*) keyStack, (const void*) key, (size_t) lenKey);
         keyStack[lenKey] = '\0';
         k = keyStack;
     }


### PR DESCRIPTION
Some gcc compiler would report that strncpy could truncate. In
this specific instance, we know that it would not be happening,
but to remove the warning, replaced it with memcpy.

Related to #364

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>