### PR TITLE
[ADDED] pkg-config support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,8 @@ if(UNIX)
     set(CMAKE_C_LINKER_FLAGS "${CMAKE_C_LINKER_FLAGS} -m32")
   endif(${NATS_BUILD_ARCH} MATCHES "32")
 
+
+
 elseif(WIN32)
   set(NATS_LIBDIR "lib")
   set(NATS_INCLUDE_DIR "include")
@@ -248,6 +250,20 @@ configure_file(
 	${CMAKE_SOURCE_DIR}/doc/DoxyFile.NATS.Client
 	@ONLY)
 endif(NATS_UPDATE_VERSION OR NATS_UPDATE_DOC)
+#------------
+
+#------------
+# pkg-config
+if(UNIX)
+  configure_file(
+    ${PROJECT_SOURCE_DIR}/src/libnats.pc.in
+    ${PROJECT_BINARY_DIR}/libnats.pc
+    @ONLY
+  )
+  install (
+    FILES "${PROJECT_BINARY_DIR}/libnats.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+endif(UNIX)
 #------------
 
 #----------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,8 +186,6 @@ if(UNIX)
     set(CMAKE_C_LINKER_FLAGS "${CMAKE_C_LINKER_FLAGS} -m32")
   endif(${NATS_BUILD_ARCH} MATCHES "32")
 
-
-
 elseif(WIN32)
   set(NATS_LIBDIR "lib")
   set(NATS_INCLUDE_DIR "include")

--- a/src/libnats.pc.in
+++ b/src/libnats.pc.in
@@ -1,0 +1,14 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
+includedir="${prefix}/include"
+
+Name: NATS & NATS Streaming - C Client library
+Description: A C client library for the NATS messaging system.
+URL: https://github.com/nats-io/nats.c
+Version: @NATS_VERSION_MAJOR@.@NATS_VERSION_MINOR@.@NATS_VERSION_PATCH@
+Requires: @PKGCONF_REQ_PUB@
+Requires.private: @PKGCONF_REQ_PRIV@
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -lnats
+Libs.private: -L"${libdir}" -lnats @PKGCONF_LIBS_PRIV@

--- a/src/libnats.pc.in
+++ b/src/libnats.pc.in
@@ -7,8 +7,6 @@ Name: NATS & NATS Streaming - C Client library
 Description: A C client library for the NATS messaging system.
 URL: https://github.com/nats-io/nats.c
 Version: @NATS_VERSION_MAJOR@.@NATS_VERSION_MINOR@.@NATS_VERSION_PATCH@
-Requires: @PKGCONF_REQ_PUB@
-Requires.private: @PKGCONF_REQ_PRIV@
 Cflags: -I"${includedir}"
 Libs: -L"${libdir}" -lnats
 Libs.private: -L"${libdir}" -lnats @PKGCONF_LIBS_PRIV@


### PR DESCRIPTION
Adding pkg-config support. This is particularly important for linking against C libraries from Swift.

I have tested this on Ubuntu 20.04 and macOS 10.15.