### PR TITLE
[ADDED] natsOptions_SetNKeyFromSeed() and nats_Sign()

### DIFF
--- a/src/nkeys.c
+++ b/src/nkeys.c
@@ -124,3 +124,34 @@ natsKeys_Sign(const char *encodedSeed, const unsigned char *input, int inputLen,
 
     return NATS_UPDATE_ERR_STACK(s);
 }
+
+natsStatus
+nats_Sign(const char    *encodedSeed,
+          const char    *input,
+          unsigned char **signature,
+          int           *signatureLength)
+{
+    natsStatus      s;
+    unsigned char   sig[NATS_CRYPTO_SIGN_BYTES];
+
+    if (nats_IsStringEmpty(encodedSeed))
+        return nats_setError(NATS_INVALID_ARG, "%s", "seed cannot be empty");
+
+    if (nats_IsStringEmpty(input))
+        return nats_setError(NATS_INVALID_ARG, "%s", "input cannot be empty");
+
+    if ((signature == NULL) || (signatureLength == NULL))
+        return nats_setError(NATS_INVALID_ARG, "%s", "signature and/or signatureLength cannot be NULL");
+
+    s = natsKeys_Sign(encodedSeed, (const unsigned char*) input, (int) strlen(input), sig);
+    if (s != NATS_OK)
+        return NATS_UPDATE_ERR_STACK(s);
+
+    *signature = (unsigned char*) NATS_MALLOC(NATS_CRYPTO_SIGN_BYTES);
+    if (*signature == NULL)
+        return nats_setDefaultError(NATS_NO_MEMORY);
+
+    memcpy(*signature, sig, NATS_CRYPTO_SIGN_BYTES);
+    *signatureLength = NATS_CRYPTO_SIGN_BYTES;
+    return NATS_OK;
+}

--- a/test/list.txt
+++ b/test/list.txt
@@ -35,6 +35,7 @@ natsReadFile
 natsGetJWTOrSeed
 natsHostIsIP
 natsWaitReady
+natsSign
 HeadersLift
 HeadersAPIs
 ReconnectServerStats
@@ -150,6 +151,7 @@ GetRTT
 UserCredsCallbacks
 UserCredsFromFiles
 NKey
+NKeyFromSeed
 ConnSign
 WriteDeadline
 HeadersNotSupported


### PR DESCRIPTION
The option provides the public key and the file containing the
seed. This will be used during connect to load the file and use
the seed to sign the nonce. The memory where the seed is copied
will be cleared.

Also exposing a way for user to sign any input given an encoded
seed.

Resolves #369

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>