### PR TITLE
[FIXED] Streaming: pings may not report failures

### DIFF
--- a/test/list.txt
+++ b/test/list.txt
@@ -203,6 +203,7 @@ StanDurableQueueSubscription
 StanCheckReceivedMsg
 StanSubscriptionAckMsg
 StanPings
+StanPingsNoResponder
 StanConnectionLostHandlerNotSet
 StanPingsUnblockPublishCalls
 StanGetNATSConnection


### PR DESCRIPTION
If client is connected to a NATS server and the streaming server
is down, then the "no responder" feature would cause the server
to send an empty message in response to the PING request (which
was sent with PublishRequest()).
If message is empty, look for "no responder" status.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>