### PR TITLE
[FIXED] EventLoop: possible file descriptor leak

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -203,6 +203,7 @@ _freeConn(natsConnection *nc)
     natsMutex_Destroy(nc->subsMu);
     natsTimer_Destroy(nc->drainTimer);
     natsMutex_Destroy(nc->mu);
+    natsCondition_Destroy(nc->el.cond);
 
     NATS_FREE(nc);
 
@@ -1410,6 +1411,10 @@ _doReconnect(void *arg)
 
     natsConn_Lock(nc);
 
+    // For external event loop, wait for the socket to be closed.
+    while ((nc->opts->evLoop != NULL) && !nc->el.sockClosed)
+        natsCondition_Wait(nc->el.cond, nc->mu);
+
     // Kick out all calls to natsConnection_Flush[Timeout]().
     _clearPendingFlushRequests(nc);
 
@@ -1839,6 +1844,7 @@ _processConnInit(natsConnection *nc)
             // Set this first in case the event loop triggers the first READ
             // event just after this call returns.
             nc->sockCtx.useEventLoop = true;
+            _retain(nc);
 
             s = nc->opts->evCbs.attach(&(nc->el.data),
                                        nc->opts->evLoop,
@@ -1851,6 +1857,7 @@ _processConnInit(natsConnection *nc)
             else
             {
                 nc->sockCtx.useEventLoop = false;
+                _release(nc);
 
                 nats_setError(s,
                               "Error attaching to the event loop: %d - %s",
@@ -2012,17 +2019,19 @@ _processOpError(natsConnection *nc, natsStatus s, bool initialConnect)
         // on the socket since we are going to reconnect.
         if (nc->el.attached)
         {
-            // Stop polling for READ/WRITE events on that socket.
+            // Stop polling for WRITE events on that socket. However,
+            // keep the READ event because this will be used to close
+            // the socket and notify the reconnect thread.
             nc->sockCtx.useEventLoop = false;
+            nc->el.sockClosed = false;
             nc->el.writeAdded = false;
-            ls = nc->opts->evCbs.read(nc->el.data, NATS_EVENT_ACTION_REMOVE);
-            if (ls == NATS_OK)
-                ls = nc->opts->evCbs.write(nc->el.data, NATS_EVENT_ACTION_REMOVE);
+            ls = nc->opts->evCbs.write(nc->el.data, NATS_EVENT_ACTION_REMOVE);
         }
 
         // Create the pending buffer to hold all write requests while we try
         // to reconnect.
-        ls = natsBuf_Create(&(nc->pending), nc->opts->reconnectBufSize);
+        if (ls == NATS_OK)
+            ls = natsBuf_Create(&(nc->pending), nc->opts->reconnectBufSize);
         if (ls == NATS_OK)
         {
             nc->usePending = true;
@@ -2328,6 +2337,15 @@ _removeAllSubscriptions(natsConnection *nc)
     natsMutex_Unlock(nc->subsMu);
 }
 
+static void
+_evLoopSignalReconnectThread(natsConnection *nc)
+{
+    if (nc->opts->evLoop != NULL)
+    {
+        nc->el.sockClosed = true;
+        natsCondition_Signal(nc->el.cond);
+    }
+}
 
 // Low level close call that will do correct cleanup and set
 // desired status. Also controls whether user defined callbacks
@@ -2388,7 +2406,9 @@ _close(natsConnection *nc, natsConnStatus status, bool fromPublicClose, bool doC
     {
         // If there is no readLoop, then it is our responsibility to close
         // the socket. Otherwise, _readLoop is the one doing it.
-        if ((ttj.readLoop == NULL) && (nc->opts->evLoop == NULL))
+        // This is also the case if we use an external event loop but the
+        // connection is closed before the event loop is attached.
+        if ((ttj.readLoop == NULL) && ((nc->opts->evLoop == NULL) || !nc->el.attached))
         {
             natsSock_Close(nc->sockCtx.fd);
             nc->sockCtx.fd = NATS_SOCK_INVALID;
@@ -2415,6 +2435,10 @@ _close(natsConnection *nc, natsConnStatus status, bool fromPublicClose, bool doC
 
     sub = nc->respMux;
     nc->respMux = NULL;
+
+    // If we use an external event loop, make sure that we release the reconnect
+    // thread that is possibly waiting to be notified that the socket is closed.
+    _evLoopSignalReconnectThread(nc);
 
     natsConn_Unlock(nc);
 
@@ -3051,6 +3075,8 @@ natsConn_create(natsConnection **newConn, natsOptions *options)
         s = natsCondition_Create(&(nc->pongs.cond));
     if (s == NATS_OK)
         s = natsCondition_Create(&(nc->reconnectCond));
+    if ((s == NATS_OK) && (nc->opts->evLoop != NULL))
+        s = natsCondition_Create(&(nc->el.cond));
 
     if (s == NATS_OK)
         *newConn = nc;
@@ -3806,9 +3832,37 @@ natsConnection_ProcessReadEvent(natsConnection *nc)
 
     natsConn_Lock(nc);
 
-    if (!(nc->el.attached))
+    if (!nc->el.attached || natsConn_isClosed(nc) || natsConn_isReconnecting(nc))
     {
+        bool release = false;
+
+        // When the library shuts down the socket, the external event loop library
+        // will invoke this function. It is now safe to close the socket.
+        if (nc->sockCtx.fd != NATS_SOCK_INVALID)
+        {
+            natsSock_Close(nc->sockCtx.fd);
+            nc->sockCtx.fd = NATS_SOCK_INVALID;
+            release = true;
+        }
+        // If we are reconnecting, signal the reconnect thread that we are
+        // now ready to proceed with the reconnect.
+        if (natsConn_isReconnecting(nc) && !nc->el.sockClosed)
+        {
+            nc->opts->evCbs.read(nc->el.data, NATS_EVENT_ACTION_REMOVE);
+            _evLoopSignalReconnectThread(nc);
+        }
+        // If this is the final close for this connection, we need to
+        // cleanup some things if the connection was SSL. This would
+        // normally be done at the end of the _readLoop for clients that
+        // don't use an external event loop.
+        if (natsConn_isClosed(nc) && (nc->sockCtx.ssl != NULL))
+            natsConn_clearSSL(nc);
+
         natsConn_Unlock(nc);
+
+        if (release)
+            natsConn_release(nc);
+
         return;
     }
 
@@ -3816,14 +3870,11 @@ natsConnection_ProcessReadEvent(natsConnection *nc)
     {
         s = natsParser_Create(&(nc->ps));
         if (s != NATS_OK)
-            nats_setDefaultError(NATS_NO_MEMORY);
-    }
-
-    if ((s != NATS_OK) || natsConn_isClosed(nc) || natsConn_isReconnecting(nc))
-    {
-        (void) NATS_UPDATE_ERR_STACK(s);
-        natsConn_Unlock(nc);
-        return;
+        {
+            (void) NATS_UPDATE_ERR_STACK(s);
+            natsConn_Unlock(nc);
+            return;
+        }
     }
 
     _retain(nc);

--- a/src/conn.c
+++ b/src/conn.c
@@ -1412,7 +1412,9 @@ _doReconnect(void *arg)
     natsConn_Lock(nc);
 
     // For external event loop, wait for the socket to be closed.
-    while ((nc->opts->evLoop != NULL) && !nc->el.sockClosed)
+    // However, if we are here on initial connect failure (with option
+    // RetryOnFailedConnect) then there was no opened socket, so no need to wait.
+    while (!nc->initc && (nc->opts->evLoop != NULL) && !nc->el.sockClosed)
         natsCondition_Wait(nc->el.cond, nc->mu);
 
     // Kick out all calls to natsConnection_Flush[Timeout]().

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -531,6 +531,8 @@ struct __natsConnection
         bool            writeAdded;
         void            *buffer;
         void            *data;
+        natsCondition   *cond;
+        bool            sockClosed;
     } el;
 };
 

--- a/test/list.txt
+++ b/test/list.txt
@@ -156,6 +156,7 @@ ConnSign
 WriteDeadline
 HeadersNotSupported
 HeadersBasic
+EventLoop
 SSLBasic
 SSLVerify
 SSLCAFromMemory
@@ -165,6 +166,7 @@ SSLSkipServerVerification
 SSLCiphers
 SSLMultithreads
 SSLConnectVerboseOption
+SSLSocketLeakEventLoop
 ServersOption
 AuthServers
 AuthFailToReconnect

--- a/test/list.txt
+++ b/test/list.txt
@@ -157,6 +157,7 @@ WriteDeadline
 HeadersNotSupported
 HeadersBasic
 EventLoop
+EventLoopRetryOnFailedConnect
 SSLBasic
 SSLVerify
 SSLCAFromMemory


### PR DESCRIPTION
Two issues: if using an event loop and SSL but the connection
fails before the event loop is attached, the library needs
to close the socket.
On normal socket shutdown, since there is no readloop in the
context of external event loop, ensure that the library closes
the socket properly.

Resolves #374

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>