### PR TITLE
[FIXED]: segmentation fault when ConnectTo urls parameter is NULL

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -3117,11 +3117,14 @@ _processUrlString(natsOptions *opts, const char *urls)
     char        *ptr         = NULL;
     int         len;
 
-    ptr = (char*) urls;
-    while ((ptr = strchr(ptr, ',')) != NULL)
+    if (urls != NULL)
     {
-        ptr++;
-        count++;
+        ptr = (char*) urls;
+        while ((ptr = strchr(ptr, ',')) != NULL)
+        {
+            ptr++;
+            count++;
+        }
     }
     if (count == 0)
         return natsOptions_SetURL(opts, urls);

--- a/src/nats.h
+++ b/src/nats.h
@@ -2545,6 +2545,8 @@ natsConnection_ProcessWriteEvent(natsConnection *nc);
  * @param nc the location where to store the pointer to the newly created
  * #natsConnection object.
  * @param urls the URL to connect to, or the list of URLs to chose from.
+ * If `NULL` this call is equivalent to #natsConnection_ConnectTo()
+ * with #NATS_DEFAULT_URL
  */
 NATS_EXTERN natsStatus
 natsConnection_ConnectTo(natsConnection **nc, const char *urls);

--- a/test/list.txt
+++ b/test/list.txt
@@ -58,6 +58,7 @@ IPResolutionOrder
 UseDefaultURLIfNoServerSpecified
 ConnectToWithMultipleURLs
 ConnectionWithNULLOptions
+ConnectionToWithNullURLs
 ConnectionStatus
 ConnClosedCB
 CloseDisconnectedCB

--- a/test/test.c
+++ b/test/test.c
@@ -7209,6 +7209,29 @@ test_ConnectToWithMultipleURLs(void)
     _stopServer(serverPid);
 }
 
+static void
+test_ConnectionToWithNullURLs(void)
+{
+    natsStatus      s;
+    natsConnection  *nc       = NULL;
+    natsPid         serverPid = NATS_INVALID_PID;
+    char            buf[256];
+
+    test("Check NULL URLs: ");
+    serverPid = _startServer("nats://127.0.0.1:4222", NULL, true);
+    CHECK_SERVER_STARTED(serverPid);
+
+    s = natsConnection_ConnectTo(&nc, NULL);
+    if (s == NATS_OK)
+        s = natsConnection_Flush(nc);
+    if (s == NATS_OK)
+        s = natsConnection_GetConnectedUrl(nc, buf, sizeof(buf));
+
+    testCond((s == NATS_OK) && (strcmp(buf, NATS_DEFAULT_URL) == 0));
+    natsConnection_Destroy(nc);
+
+    _stopServer(serverPid);
+}
 
 static void
 test_ConnectionWithNullOptions(void)
@@ -21525,6 +21548,7 @@ static testInfo allTests[] =
     {"UseDefaultURLIfNoServerSpecified",test_UseDefaultURLIfNoServerSpecified},
     {"ConnectToWithMultipleURLs",       test_ConnectToWithMultipleURLs},
     {"ConnectionWithNULLOptions",       test_ConnectionWithNullOptions},
+    {"ConnectionToWithNullURLs",        test_ConnectionToWithNullURLs},
     {"ConnectionStatus",                test_ConnectionStatus},
     {"ConnClosedCB",                    test_ConnClosedCB},
     {"CloseDisconnectedCB",             test_CloseDisconnectedCB},


### PR DESCRIPTION
Check if `urls` list is `NULL`, before parsing it.

Internally the library will use `NATS_DEFAULT_URL` and therefore `NULL` become an an alias to `NATS_DEFAULT_URL`.

Patch include also a dedicated test case.

Signed-off-by: Paolo Teti <paolo.teti@gmail.com>