### PR TITLE
[FIXED] stanSubscription_AckMsg() returned NATS_OK for NULL sub.

### DIFF
--- a/src/stan/sub.c
+++ b/src/stan/sub.c
@@ -166,10 +166,7 @@ stanSubscription_AckMsg(stanSubscription *sub, stanMsg *msg)
     int             ackSize = 0;
     Pb__Ack         ack;
 
-    if (sub == NULL)
-        return NATS_OK;
-
-    if (msg == NULL)
+    if ((sub == NULL) || (msg == NULL))
         return nats_setDefaultError(NATS_INVALID_ARG);
 
     stanSub_Lock(sub);

--- a/test/test.c
+++ b/test/test.c
@@ -20900,9 +20900,16 @@ test_StanSubscriptionAckMsg(void)
         s = stanConnection_Subscribe(&sub2, sc, "foo", _dummyStanMsgHandler, NULL, opts);
     testCond(s == NATS_OK);
 
+    test("NULL Sub should fail: ");
+    s = stanSubscription_AckMsg(NULL, args.sMsg);
+    testCond(s == NATS_INVALID_ARG);
+
+    test("NULL Msg should fail: ");
+    s = stanSubscription_AckMsg(sub2, NULL);
+    testCond(s == NATS_INVALID_ARG);
+
     test("Sub acking not own message fails: ");
-    if (s == NATS_OK)
-        s = stanSubscription_AckMsg(sub2, args.sMsg);
+    s = stanSubscription_AckMsg(sub2, args.sMsg);
     testCond((s == NATS_ILLEGAL_STATE)
                 && (nats_GetLastError(NULL) != NULL)
                 && (strstr(nats_GetLastError(NULL), STAN_ERR_SUB_NOT_OWNER) != NULL));


### PR DESCRIPTION
It should have returned NATS_INVALID_ARG for NULL sub and/or message.

Resolves #388

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>