### PR TITLE
[ADDED] natsOptions_SetFailRequestsOnDisconnect() option

### DIFF
--- a/src/nats.h
+++ b/src/nats.h
@@ -1534,6 +1534,23 @@ natsOptions_SetSendAsap(natsOptions *opts, bool sendAsap);
 NATS_EXTERN natsStatus
 natsOptions_UseOldRequestStyle(natsOptions *opts, bool useOldStyle);
 
+/** \brief Fails pending requests on disconnect event.
+ *
+ * If this option is enabled, all pending #natsConnection_Request() family
+ * calls will fail with the #NATS_CONNECTION_DISCONNECTED status.
+ *
+ * \note This does not apply to requests from connections that use the
+ * old style requests.
+ *
+ * @see natsOptions_UseOldRequestStyle
+ *
+ * @param opts the pointer to the #natsOptions object.
+ * @param failRequests a boolean indicating if pending requests should fail
+ * when a disconnect event occurs.
+ */
+NATS_EXTERN natsStatus
+natsOptions_SetFailRequestsOnDisconnect(natsOptions *opts, bool failRequests);
+
 /** \brief Sets if connection receives its own messages.
  *
  * This configures whether the server will echo back messages

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -261,6 +261,10 @@ struct __natsOptions
     // not rely on the flusher.
     bool                    sendAsap;
 
+    // If set to true, pending requests will fail with NATS_CONNECTION_DISCONNECTED
+    // when the library detects a disconnection.
+    bool                    failRequestsOnDisconnect;
+
     // NoEcho configures whether the server will echo back messages
     // that are sent on this connection if we also have matching subscriptions.
     // Note this is supported on servers >= version 1.2. Proto 1 or greater.
@@ -451,6 +455,7 @@ typedef struct __respInfo
     natsCondition       *cond;
     natsMsg             *msg;
     bool                closed;
+    natsStatus          closedSts;
     bool                removed;
     bool                pooled;
 

--- a/src/opts.c
+++ b/src/opts.c
@@ -1077,6 +1077,16 @@ natsOptions_UseOldRequestStyle(natsOptions *opts, bool useOldStype)
     return NATS_OK;
 }
 
+natsStatus
+natsOptions_SetFailRequestsOnDisconnect(natsOptions *opts, bool failRequests)
+{
+    LOCK_AND_CHECK_OPTIONS(opts, 0);
+    opts->failRequestsOnDisconnect = failRequests;
+    UNLOCK_OPTS(opts);
+
+    return NATS_OK;
+}
+
 static void
 _freeUserCreds(userCreds *uc)
 {

--- a/src/pub.c
+++ b/src/pub.c
@@ -492,7 +492,7 @@ natsConnection_RequestMsg(natsMsg **replyMsg, natsConnection *nc,
             {
                 // Set the correct error status that we return to the user
                 if (resp->closed)
-                    s = NATS_CONNECTION_CLOSED;
+                    s = resp->closedSts;
                 else
                     s = NATS_TIMEOUT;
             }

--- a/test/list.txt
+++ b/test/list.txt
@@ -78,6 +78,7 @@ IsReconnectingAndStatus
 ReconnectBufSize
 RetryOnFailedConnect
 NoPartialOnReconnect
+ReconnectFailsPendingRequests
 ErrOnConnectAndDeadlock
 ErrOnMaxPayloadLimit
 Auth


### PR DESCRIPTION
If enabled, any pending request (using new style) will fail with
NATS_CONNECTION_DISCONNECTED status.

Also fixed the failing of pending flush requests which was done
in the doReconnect thread while it should be done prior to
creating the pending buffer and starting the reconnect thread.

Resolves #391

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>