### PR TITLE
[FIXED] Subscription could not be closed while draining

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -201,7 +201,6 @@ _freeConn(natsConnection *nc)
     natsStrHash_Destroy(nc->respMap);
     natsCondition_Destroy(nc->reconnectCond);
     natsMutex_Destroy(nc->subsMu);
-    natsTimer_Destroy(nc->drainTimer);
     natsMutex_Destroy(nc->mu);
 
     NATS_FREE(nc);
@@ -322,6 +321,14 @@ natsConn_bufferWrite(natsConnection *nc, const char *buffer, int len)
                 nats_setError(s, "Error processing write request: %d - %s",
                               s, natsStatus_GetText(s));
         }
+
+        return NATS_UPDATE_ERR_STACK(s);
+    }
+
+    if (nc->dontSendInPlace)
+    {
+        if (len > 0)
+            s = natsBuf_Append(nc->bw, buffer, len);
 
         return NATS_UPDATE_ERR_STACK(s);
     }
@@ -2507,26 +2514,34 @@ natsConn_processMsg(natsConnection *nc, char *buf, int bufLen)
     nc->stats.inBytes += (uint64_t) bufLen;
 
     sub = natsHash_Get(nc->subs, nc->ps->ma.sid);
+
+    natsMutex_Unlock(nc->subsMu);
+
     if (sub == NULL)
-    {
-        natsMutex_Unlock(nc->subsMu);
         return NATS_OK;
-    }
 
     // Do this outside of sub's lock, even if we end-up having to destroy
     // it because we have reached the maxPendingMsgs count. This reduces
     // lock contention.
     s = _createMsg(&msg, nc, buf, bufLen, nc->ps->ma.hdr);
     if (s != NATS_OK)
-    {
-        natsMutex_Unlock(nc->subsMu);
         return s;
-    }
 
     if ((ldw = sub->libDlvWorker) != NULL)
         natsMutex_Lock(ldw->lock);
     else
         natsSub_Lock(sub);
+
+    if (sub->closed || sub->drainSkip)
+    {
+        if (ldw != NULL)
+            natsMutex_Unlock(ldw->lock);
+        else
+            natsSub_Unlock(sub);
+
+        natsMsg_Destroy(msg);
+        return NATS_OK;
+    }
 
     sub->msgList.msgs++;
     sub->msgList.bytes += bufLen;
@@ -2591,8 +2606,6 @@ natsConn_processMsg(natsConnection *nc, char *buf, int bufLen)
         natsMutex_Unlock(ldw->lock);
     else
         natsSub_Unlock(sub);
-
-    natsMutex_Unlock(nc->subsMu);
 
     if (sc)
     {
@@ -2922,9 +2935,32 @@ natsConn_subscribeImpl(natsSubscription **newSub,
     return NATS_UPDATE_ERR_STACK(s);
 }
 
+// Will queue an UNSUB protocol, making sure it is not flushed in place.
+// The connection lock is held on entry.
+natsStatus
+natsConn_enqueueUnsubProto(natsConnection *nc, int64_t sid)
+{
+    natsStatus  s       = NATS_OK;
+    char        *proto  = NULL;
+    int         res     = 0;
+
+    res = nats_asprintf(&proto, _UNSUB_NO_MAX_PROTO_, sid);
+    if (res < 0)
+        s = nats_setDefaultError(NATS_NO_MEMORY);
+    else
+    {
+        nc->dontSendInPlace = true;
+        natsConn_bufferWrite(nc, (const char*) proto, (int) strlen(proto));
+        nc->dontSendInPlace = false;
+        NATS_FREE(proto);
+    }
+
+    return NATS_UPDATE_ERR_STACK(s);
+}
+
 // Performs the low level unsubscribe to the server.
 natsStatus
-natsConn_unsubscribe(natsConnection *nc, natsSubscription *sub, int max)
+natsConn_unsubscribe(natsConnection *nc, natsSubscription *sub, int max, bool drainMode, int64_t timeout)
 {
     natsStatus      s = NATS_OK;
 
@@ -2939,19 +2975,19 @@ natsConn_unsubscribe(natsConnection *nc, natsSubscription *sub, int max)
     natsMutex_Lock(nc->subsMu);
     sub = natsHash_Get(nc->subs, sub->sid);
     natsMutex_Unlock(nc->subsMu);
-    if (sub == NULL)
+    if ((sub == NULL) || !natsSubscription_IsValid(sub))
     {
         // Already unsubscribed
         natsConn_Unlock(nc);
-        return NATS_OK;
+        return nats_setDefaultError(NATS_INVALID_SUBSCRIPTION);
     }
 
     if (max > 0)
         natsSub_setMax(sub, max);
-    else
+    else if (!drainMode)
         natsConn_removeSubscription(nc, sub);
 
-    if ((s == NATS_OK) && !natsConn_isReconnecting(nc))
+    if (!drainMode && !natsConn_isReconnecting(nc))
     {
         SET_WRITE_DEADLINE(nc);
         // We will send these for all subs when we reconnect
@@ -2970,45 +3006,13 @@ natsConn_unsubscribe(natsConnection *nc, natsSubscription *sub, int max)
             s = NATS_OK;
         }
     }
-
-    natsConn_Unlock(nc);
-
-    return s;
-}
-
-natsStatus
-natsConn_drainSub(natsConnection *nc, natsSubscription *sub, bool checkConnDrainStatus)
-{
-    natsStatus s = NATS_OK;
-
-    natsConn_Lock(nc);
-    if (natsConn_isClosed(nc))
-        s = nats_setDefaultError(NATS_CONNECTION_CLOSED);
-    else if (checkConnDrainStatus && natsConn_isDraining(nc))
-        s = nats_setDefaultError(NATS_DRAINING);
-    if (s == NATS_OK)
+    else if (drainMode)
     {
-        natsMutex_Lock(nc->subsMu);
-        sub = natsHash_Get(nc->subs, sub->sid);
-        natsMutex_Unlock(nc->subsMu);
-        if (sub == NULL)
-            s = nats_setDefaultError(NATS_INVALID_SUBSCRIPTION);
-    }
-    if (s == NATS_OK)
-    {
-        SET_WRITE_DEADLINE(nc);
-        s = _sendUnsubProto(nc, sub->sid, 0);
+        // Subscription is retained by caller, so we know reference is ok
+        s = natsSub_startDrain(sub, timeout);
     }
 
-    _retain(nc);
     natsConn_Unlock(nc);
-
-    if (s == NATS_OK)
-        s = natsConnection_Flush(nc);
-    if (s == NATS_OK)
-        natsSub_drain(sub);
-
-    natsConn_release(nc);
 
     return NATS_UPDATE_ERR_STACK(s);
 }
@@ -3392,98 +3396,198 @@ _pushDrainErr(natsConnection *nc, natsStatus s, const char *errTxt)
     natsConn_Unlock(nc);
 }
 
-static bool
-_areAllSubsDrained(natsConnection *nc)
+// Callback invoked for each of the registered subscription.
+typedef natsStatus (*subIterFunc)(natsStatus callerSts, natsConnection *nc, natsSubscription *sub);
+
+// Iterates through all registered subscriptions and execute the callback `f`.
+// If the callback returns an error, the iteration continues and the first
+// non NATS_OK error is returned.
+//
+// Connection lock is held on entry.
+static natsStatus
+_iterateSubsAndInvokeFunc(natsStatus callerSts, natsConnection *nc, subIterFunc f)
 {
-    bool done;
+    natsStatus       s    = NATS_OK;
+    natsStatus       ls   = NATS_OK;
+    natsSubscription *sub = NULL;
+    void             *p   = NULL;
+    natsHashIter     iter;
 
     natsMutex_Lock(nc->subsMu);
-    done = natsConn_isClosed(nc) || (natsHash_Count(nc->subs) == 0);
+    if (natsHash_Count(nc->subs) == 0)
+    {
+        natsMutex_Unlock(nc->subsMu);
+        return NATS_OK;
+    }
+    natsHashIter_Init(&iter, nc->subs);
+    while (natsHashIter_Next(&iter, NULL, &p))
+    {
+        sub = (natsSubscription*) p;
+        ls = (f)(callerSts, nc, sub);
+        if ((ls != NATS_OK) && (s == NATS_OK))
+            s = ls;
+    }
+    natsHashIter_Done(&iter);
     natsMutex_Unlock(nc->subsMu);
 
-    return done;
+    return NATS_UPDATE_ERR_STACK(s);
 }
 
-static void
-_drainPubsAndClose(natsConnection *nc)
+static natsStatus
+_enqueUnsubProto(natsStatus callerSts, natsConnection *nc, natsSubscription *sub)
 {
     natsStatus s;
 
-    // Flip state
-    natsConn_Lock(nc);
-    if (natsConn_isClosed(nc))
-    {
-        natsConn_Unlock(nc);
-        return;
-    }
-    nc->status = NATS_CONN_STATUS_DRAINING_PUBS;
-    natsConn_Unlock(nc);
+    natsSub_Lock(sub);
+    s = natsConn_enqueueUnsubProto(nc, sub->sid);
+    natsSub_Unlock(sub);
 
-    // Do publish drain via Flush() call.
-    s = natsConnection_Flush(nc);
-    if (s != NATS_OK)
-        _pushDrainErr(nc, s, "unable to flush");
+    return NATS_UPDATE_ERR_STACK(s);
+}
 
-    // Move to closed state.
-    natsConnection_Close(nc);
+static natsStatus
+_initSubDrain(natsStatus callerSts, natsConnection *nc, natsSubscription *sub)
+{
+    natsSub_initDrain(sub);
+    return NATS_OK;
+}
+
+static natsStatus
+_startSubDrain(natsStatus callerSts, natsConnection *nc, natsSubscription *sub)
+{
+    if (callerSts != NATS_OK)
+        natsSub_setDrainSkip(sub, callerSts);
+
+    natsSub_drain(sub);
+    return NATS_OK;
+}
+
+static natsStatus
+_setSubDrainStatus(natsStatus callerSts, natsConnection *nc, natsSubscription *sub)
+{
+    if (callerSts != NATS_OK)
+        natsSub_updateDrainStatus(sub, callerSts);
+    return NATS_OK;
 }
 
 static void
-_checkAllSubsAreDrained(natsTimer *t, void *closure)
+_flushAndDrain(void *closure)
 {
-    natsConnection  *nc          = (natsConnection*) closure;
-    bool            doneWithSubs = false;
-    bool            timedOut     = false;
+    natsConnection  *nc      = (natsConnection*) closure;
+    natsThread      *t       = NULL;
+    int64_t         timeout  = 0;
+    int64_t         deadline = 0;
+    bool            doSubs   = false;
+    bool            subsDone = false;
+    bool            timedOut = false;
+    bool            closed   = false;
+    natsStatus      s        = NATS_OK;
+    int64_t         start;
 
     natsConn_Lock(nc);
-    if (nc->status == NATS_CONN_STATUS_CLOSED)
-    {
-        natsTimer_Stop(nc->drainTimer);
-        natsConn_Unlock(nc);
-        return;
-    }
-    doneWithSubs = _areAllSubsDrained(nc);
-    if (!doneWithSubs
-            && (nc->drainDeadline > 0)
-            && (nats_Now() > nc->drainDeadline))
-    {
-        timedOut     = true;
-        doneWithSubs = true;
-    }
-    if (doneWithSubs)
-    {
-        // Done checking for subs
-        natsTimer_Stop(nc->drainTimer);
-    }
+    t       = nc->drainThread;
+    timeout = nc->drainTimeout;
+    closed  = natsConn_isClosed(nc);
+    natsMutex_Lock(nc->subsMu);
+    doSubs = (natsHash_Count(nc->subs) > 0 ? true : false);
+    natsMutex_Unlock(nc->subsMu);
     natsConn_Unlock(nc);
 
-    if (timedOut)
-        _pushDrainErr(nc, NATS_TIMEOUT, "timeout waiting for subscriptions to drain");
+    if (timeout < 0)
+        timeout = 0;
+    else
+        deadline = nats_setTargetTime(timeout);
 
-    if (doneWithSubs)
+    start = nats_Now();
+    if (!closed && doSubs)
     {
-        // Move to pubs and close connection
-        _drainPubsAndClose(nc);
-    }
-}
+        if (timeout == 0)
+            s = natsConnection_Flush(nc);
+        else
+            s = natsConnection_FlushTimeout(nc, timeout);
 
-static void
-_drainTimerStopCB(natsTimer *t, void *closure)
-{
-    natsConnection *nc = (natsConnection*) closure;
+        if (s != NATS_OK)
+            _pushDrainErr(nc, s, "unable to flush all subscriptions UNSUB protocols");
+
+        // Start the draining of all registered subscriptions.
+        // Update the drain status with possibly failed flush.
+        natsConn_Lock(nc);
+        _iterateSubsAndInvokeFunc(s, nc, _startSubDrain);
+        natsConn_Unlock(nc);
+
+        // Reset status now.
+        s = NATS_OK;
+
+        // Now wait for the number of subscriptions to go down to 0, or deadline is reached.
+        while (deadline - nats_Now() > 0)
+        {
+            natsConn_Lock(nc);
+            closed = natsConn_isClosed(nc);
+            if (!closed)
+            {
+                natsMutex_Lock(nc->subsMu);
+                subsDone = (natsHash_Count(nc->subs) == 0 ? true : false);
+                natsMutex_Unlock(nc->subsMu);
+            }
+            natsConn_Unlock(nc);
+            if (closed || subsDone)
+                break;
+            nats_Sleep(100);
+        }
+        if (closed)
+        {
+            _iterateSubsAndInvokeFunc(NATS_CONNECTION_CLOSED, nc, _setSubDrainStatus);
+            _pushDrainErr(nc, NATS_CONNECTION_CLOSED, "connection closed while draining the subscriptions");
+        }
+        else if (!subsDone)
+        {
+            _iterateSubsAndInvokeFunc(NATS_TIMEOUT, nc, _setSubDrainStatus);
+            _pushDrainErr(nc, NATS_TIMEOUT, "timeout waiting for subscriptions to drain");
+            timedOut = true;
+        }
+    }
+
+    // Now switch to draining PUBS, unless already closed.
+    natsConn_Lock(nc);
+    closed = natsConn_isClosed(nc);
+    if (!closed)
+        nc->status = NATS_CONN_STATUS_DRAINING_PUBS;
+    natsConn_Unlock(nc);
+
+    // Attempt to flush, unless we have already timed out, or connection is closed.
+    if (!closed && !timedOut)
+    {
+        // Reset status
+        s = NATS_OK;
+
+        // We drain the publish calls
+        if (timeout == 0)
+            s = natsConnection_Flush(nc);
+        else
+        {
+            // If there is a timeout, see how long do we have left.
+            int64_t elapsed = nats_Now() - start;
+
+            if (elapsed < timeout)
+                s = natsConnection_FlushTimeout(nc, timeout-elapsed);
+        }
+        if (s != NATS_OK)
+            _pushDrainErr(nc, s, "unable to flush publish calls");
+    }
+
+    // Finally, close the connection.
+    if (!closed)
+        natsConnection_Close(nc);
+
+    natsThread_Detach(t);
+    natsThread_Destroy(t);
     natsConn_release(nc);
 }
 
 static natsStatus
 _drain(natsConnection *nc, int64_t timeout)
 {
-    natsStatus          s       = NATS_OK;
-    natsSubscription    **subs  = NULL;
-    natsSubscription    *sub    = NULL;
-    int                 numSubs = 0;
-    bool                subsDone= true;
-    bool                draining= false;
-    natsHashIter        iter;
+    natsStatus s = NATS_OK;
 
     if (nc == NULL)
         return nats_setDefaultError(NATS_INVALID_ARG);
@@ -3495,90 +3599,27 @@ _drain(natsConnection *nc, int64_t timeout)
         s = nats_setError(NATS_ILLEGAL_STATE, "%s", "Illegal to call Drain for connection owned by a streaming connection");
     else if (_isConnecting(nc) || natsConn_isReconnecting(nc))
         s = nats_setError(NATS_ILLEGAL_STATE, "%s", "Illegal to call Drain while the connection is reconnecting");
-    else if (natsConn_isDraining(nc))
-        draining = true;
-    if ((s == NATS_OK) && !draining)
+    else if (!natsConn_isDraining(nc))
     {
-        natsMutex_Lock(nc->subsMu);
-        if (natsHash_Count(nc->subs) > 0)
+        // Enqueue UNSUB protocol for all current subscriptions.
+        s = _iterateSubsAndInvokeFunc(NATS_OK, nc, _enqueUnsubProto);
+        if (s == NATS_OK)
         {
-            // Create array to contain them all
-            subs = NATS_CALLOC(natsHash_Count(nc->subs), sizeof(natsSubscription*));
-            if (subs == NULL)
-                s = NATS_NO_MEMORY;
+            nc->drainTimeout = timeout;
+            s = natsThread_Create(&nc->drainThread, _flushAndDrain, (void*) nc);
             if (s == NATS_OK)
             {
-                void *p = NULL;
+                // Prevent new subscriptions to be added.
+                nc->status = NATS_CONN_STATUS_DRAINING_SUBS;
 
-                natsHashIter_Init(&iter, nc->subs);
-                while (natsHashIter_Next(&iter, NULL, &p))
-                {
-                    sub = (natsSubscription*) p;
-                    natsSub_retain(sub);
-                    subs[numSubs++] = sub;
-                }
-                natsHashIter_Done(&iter);
+                // Switch drain state to "started" for all subs. This does not fail.
+                _iterateSubsAndInvokeFunc(NATS_OK, nc, _initSubDrain);
+
+                _retain(nc);
             }
         }
-        natsMutex_Unlock(nc->subsMu);
     }
-    // If already draining or an error, bail now.
-    if ((s != NATS_OK) || draining)
-    {
-        natsConn_Unlock(nc);
-        return NATS_UPDATE_ERR_STACK(s);
-    }
-
-    nc->status = NATS_CONN_STATUS_DRAINING_SUBS;
-    if (timeout > 0)
-        nc->drainDeadline = nats_setTargetTime(timeout);
-    _retain(nc);
-
     natsConn_Unlock(nc);
-
-    // Do subs first
-    if (numSubs > 0)
-    {
-        natsStatus  ls;
-        int         i;
-
-        for (i=0; i<numSubs; i++)
-        {
-            sub = subs[i];
-            ls = natsConn_drainSub(nc, sub, false);
-            // Notify but continue
-            if (ls != NATS_OK)
-                _pushDrainErr(nc, s, "drain of subscription failed");
-            natsSub_release(sub);
-        }
-
-        NATS_FREE(subs);
-
-        natsConn_Lock(nc);
-
-        // The above calls are not blocking, but it is possible
-        // that the subs are all drained already, in this case
-        // we don't have to set the timer.
-        if (!_areAllSubsDrained(nc))
-        {
-            _retain(nc);
-            s = natsTimer_Create(&nc->drainTimer, _checkAllSubsAreDrained,
-                                 _drainTimerStopCB, 100, (void*) nc);
-            if (s == NATS_OK)
-                subsDone = false;
-            else
-                _release(nc);
-        }
-
-        natsConn_Unlock(nc);
-    }
-
-    // If no subs or already all drained, move on to pubs.
-    if ((s == NATS_OK) && subsDone)
-        _drainPubsAndClose(nc);
-
-    // Release the connection that was retained before doing the subs
-    natsConn_release(nc);
 
     return NATS_UPDATE_ERR_STACK(s);
 }
@@ -4123,7 +4164,7 @@ natsConnection_GetRTT(natsConnection *nc, int64_t *rtt)
     else
     {
         start = nats_NowInNanoSeconds();
-        s = _flushTimeout(nc, 10000);
+        s = _flushTimeout(nc, DEFAULT_FLUSH_TIMEOUT);
         if (s == NATS_OK)
             *rtt = nats_NowInNanoSeconds()-start;
     }

--- a/src/conn.h
+++ b/src/conn.h
@@ -90,7 +90,10 @@ natsConn_subscribeImpl(natsSubscription **newSub,
                        bool preventUseOfLibDlvPool);
 
 natsStatus
-natsConn_unsubscribe(natsConnection *nc, natsSubscription *sub, int max);
+natsConn_unsubscribe(natsConnection *nc, natsSubscription *sub, int max, bool drainMode, int64_t timeout);
+
+natsStatus
+natsConn_enqueueUnsubProto(natsConnection *nc, int64_t sid);
 
 natsStatus
 natsConn_drainSub(natsConnection *nc, natsSubscription *sub, bool checkConnDrainStatus);

--- a/src/nats.c
+++ b/src/nats.c
@@ -1705,12 +1705,16 @@ _deliverMsgs(void *arg)
                 // Subscription is draining, we are past the last message,
                 // remove the subscription. This will schedule another
                 // control message for the close.
+                natsSub_setDrainCompleteState(sub);
                 natsConn_removeSubscription(nc, sub);
             }
             else if (closed)
             {
                 natsOnCompleteCB cb         = NULL;
                 void             *closure   = NULL;
+
+                // Call this in case the subscription was draining.
+                natsSub_setDrainCompleteState(sub);
 
                 // Check for completion callback
                 natsSub_Lock(sub);
@@ -1791,6 +1795,8 @@ _deliverMsgs(void *arg)
         // the max (after the callback returns).
         if ((max > 0) && (delivered >= max))
         {
+            // Call this blindly, it will be a no-op if the subscription was not draining.
+            natsSub_setDrainCompleteState(sub);
             // If we have hit the max for delivered msgs, remove sub.
             natsConn_removeSubscription(nc, sub);
         }

--- a/src/sub.c
+++ b/src/sub.c
@@ -43,6 +43,12 @@ void natsSub_Unlock(natsSubscription *sub)   { natsMutex_Unlock(sub->mu); }
 #define SUB_DLV_WORKER_UNLOCK(s)    if ((s)->libDlvWorker != NULL) \
                                         natsMutex_Unlock((s)->libDlvWorker->lock)
 
+#define SUB_DRAIN_STARTED     ((uint8_t) 1)
+#define SUB_DRAIN_COMPLETE    ((uint8_t) 2)
+
+#define natsSub_drainStarted(s)     (((s)->drainState & SUB_DRAIN_STARTED) != 0)
+#define natsSub_drainComplete(s)    (((s)->drainState & SUB_DRAIN_COMPLETE) != 0)
+
 static void
 _freeSubscription(natsSubscription *sub)
 {
@@ -100,6 +106,37 @@ natsSub_release(natsSubscription *sub)
 
     if (refs == 0)
         _freeSubscription(sub);
+}
+
+static void
+_setDrainCompleteState(natsSubscription *sub)
+{
+    // It is possible that we are here without being in "drain in progress"
+    // due to auto-unsubscribe. So if the drain was initiated then consider
+    // the drain complete.
+    if (natsSub_drainStarted(sub) && !natsSub_drainComplete(sub))
+    {
+        // If drain status is not already set (could be done in _flushAndDrain
+        // if flush fails, or timeout occurs), set it here to report if the
+        // connection or subscription has been closed prior to drain completion.
+        if (sub->drainStatus == NATS_OK)
+        {
+            if (sub->connClosed)
+                sub->drainStatus = NATS_CONNECTION_CLOSED;
+            else if (sub->closed)
+                sub->drainStatus = NATS_INVALID_SUBSCRIPTION;
+        }
+        sub->drainState |= SUB_DRAIN_COMPLETE;
+        natsCondition_Broadcast(sub->cond);
+    }
+}
+
+void
+natsSub_setDrainCompleteState(natsSubscription *sub)
+{
+    natsSub_Lock(sub);
+    _setDrainCompleteState(sub);
+    natsSub_Unlock(sub);
 }
 
 // _deliverMsgs is used to deliver messages to asynchronous subscribers.
@@ -201,13 +238,15 @@ natsSub_deliverMsgs(void *arg)
             break;
         }
     }
-    if (rmSub)
-        natsConn_removeSubscription(nc, sub);
 
     natsSub_Lock(sub);
     onCompleteCB        = sub->onCompleteCB;
     onCompleteCBClosure = sub->onCompleteCBClosure;
+    _setDrainCompleteState(sub);
     natsSub_Unlock(sub);
+
+    if (rmSub)
+        natsConn_removeSubscription(nc, sub);
 
     if (onCompleteCB != NULL)
         (*onCompleteCB)(onCompleteCBClosure);
@@ -654,12 +693,14 @@ natsSubscription_NextMsg(natsMsg **nextMsg, natsSubscription *sub, int64_t timeo
             if (sub->draining && (sub->msgList.msgs == 0))
                 removeSub = true;
         }
+        if (removeSub)
+        {
+            _setDrainCompleteState(sub);
+            _retain(sub);
+        }
     }
     if (s == NATS_OK)
         *nextMsg = msg;
-
-    if (removeSub)
-        _retain(sub);
 
     natsSub_Unlock(sub);
 
@@ -673,7 +714,7 @@ natsSubscription_NextMsg(natsMsg **nextMsg, natsSubscription *sub, int64_t timeo
 }
 
 static natsStatus
-_unsubscribe(natsSubscription *sub, int max)
+_unsubscribe(natsSubscription *sub, int max, bool drainMode, int64_t timeout)
 {
     natsStatus      s   = NATS_OK;
     natsConnection  *nc = NULL;
@@ -682,29 +723,12 @@ _unsubscribe(natsSubscription *sub, int max)
         return nats_setDefaultError(NATS_INVALID_ARG);
 
     natsSub_Lock(sub);
-
-    if (sub->connClosed)
-        s = NATS_CONNECTION_CLOSED;
-    else if (sub->closed)
-        s = NATS_INVALID_SUBSCRIPTION;
-    else if (sub->draining)
-        s = NATS_DRAINING;
-
-    if (s != NATS_OK)
-    {
-        natsSub_Unlock(sub);
-        return nats_setDefaultError(s);
-    }
-
     nc = sub->conn;
     _retain(sub);
 
     natsSub_Unlock(sub);
 
-    if (natsConnection_IsDraining(nc))
-        s = nats_setDefaultError(NATS_DRAINING);
-    else
-        s = natsConn_unsubscribe(nc, sub, max);
+    s = natsConn_unsubscribe(nc, sub, max, drainMode, timeout);
 
     natsSub_release(sub);
 
@@ -714,14 +738,14 @@ _unsubscribe(natsSubscription *sub, int max)
 natsStatus
 natsSubscription_Unsubscribe(natsSubscription *sub)
 {
-    natsStatus s = _unsubscribe(sub, 0);
+    natsStatus s = _unsubscribe(sub, 0, false, 0);
     return NATS_UPDATE_ERR_STACK(s);
 }
 
 natsStatus
 natsSubscription_AutoUnsubscribe(natsSubscription *sub, int max)
 {
-    natsStatus s = _unsubscribe(sub, max);
+    natsStatus s = _unsubscribe(sub, max, false, 0);
     return NATS_UPDATE_ERR_STACK(s);
 }
 
@@ -730,6 +754,12 @@ natsSub_drain(natsSubscription *sub)
 {
     natsSub_Lock(sub);
     SUB_DLV_WORKER_LOCK(sub);
+    if (sub->closed)
+    {
+        SUB_DLV_WORKER_UNLOCK(sub);
+        natsSub_Unlock(sub);
+        return;
+    }
     sub->draining = true;
     if (sub->libDlvWorker != NULL)
     {
@@ -758,30 +788,148 @@ natsSub_drain(natsSubscription *sub)
     natsSub_Unlock(sub);
 }
 
-natsStatus
-natsSubscription_Drain(natsSubscription *sub)
+static void
+_updateDrainStatus(natsSubscription *sub, natsStatus s)
 {
-    natsStatus      s   = NATS_OK;
-    natsConnection  *nc = NULL;
+    // Do not override a drain status if already set.
+    if (sub->drainStatus == NATS_OK)
+        sub->drainStatus = s;
+}
 
-    if (sub == NULL)
-        return nats_setDefaultError(NATS_INVALID_ARG);
+void
+natsSub_updateDrainStatus(natsSubscription *sub, natsStatus s)
+{
+    natsSub_Lock(sub);
+    _updateDrainStatus(sub, s);
+    natsSub_Unlock(sub);
+}
+
+// Mark the subscription such that connection stops to try to push messages into its list.
+void
+natsSub_setDrainSkip(natsSubscription *sub, natsStatus s)
+{
+    natsSub_Lock(sub);
+    SUB_DLV_WORKER_LOCK(sub);
+    _updateDrainStatus(sub, s);
+    sub->drainSkip = true;
+    SUB_DLV_WORKER_UNLOCK(sub);
+    natsSub_Unlock(sub);
+}
+
+static void
+_flushAndDrain(void *closure)
+{
+    natsSubscription *sub     = (natsSubscription*) closure;
+    natsConnection   *nc      = NULL;
+    natsThread       *t       = NULL;
+    int64_t          timeout  = 0;
+    int64_t          deadline = 0;
+    natsStatus       s;
 
     natsSub_Lock(sub);
-    // If not closed and draining, return OK.
-    if (!sub->closed && sub->draining)
+    nc      = sub->conn;
+    t       = sub->drainThread;
+    timeout = sub->drainTimeout;
+    natsSub_Unlock(sub);
+
+    // Make sure that negative value is considered no timeout.
+    if (timeout < 0)
+        timeout = 0;
+    else
+        deadline = nats_setTargetTime(timeout);
+
+    // Flush to make sure server has processed UNSUB and no new messages are coming.
+    if (timeout == 0)
+        s = natsConnection_Flush(nc);
+    else
+        s = natsConnection_FlushTimeout(nc, timeout);
+
+    // If flush failed, update drain status and prevent connection from
+    // pushing new messages to this subscription.
+    if (s != NATS_OK)
+        natsSub_setDrainSkip(sub, s);
+
+    // Switch to drain regardless of status
+    natsSub_drain(sub);
+
+    // We are going to check for completion only if a timeout is specified.
+    // If that is the case, the library will forcibly close the subscription.
+    if (timeout > 0)
+    {
+        // Reset status from possibly failed flush. We are now checking for
+        // the drain timeout.
+        s = NATS_OK;
+        // Wait for drain to complete or deadline is reached.
+        natsSub_Lock(sub);
+        while ((s != NATS_TIMEOUT) && !natsSub_drainComplete(sub))
+            s = natsCondition_AbsoluteTimedWait(sub->cond, sub->mu, deadline);
+        natsSub_Unlock(sub);
+
+        if (s != NATS_OK)
+        {
+            natsSub_updateDrainStatus(sub, s);
+            natsConn_removeSubscription(nc, sub);
+        }
+    }
+
+    natsThread_Detach(t);
+    natsThread_Destroy(t);
+    natsSub_release(sub);
+}
+
+// Switch subscription's drain state to "started".
+void
+natsSub_initDrain(natsSubscription *sub)
+{
+    natsSub_Lock(sub);
+    sub->drainState |= SUB_DRAIN_STARTED;
+    natsSub_Unlock(sub);
+}
+
+// Initiates draining, unless already done.
+// Note that this runs under the associated connection lock.
+natsStatus
+natsSub_startDrain(natsSubscription *sub, int64_t timeout)
+{
+    natsStatus s;
+
+    natsSub_Lock(sub);
+    if (natsSub_drainStarted(sub))
     {
         natsSub_Unlock(sub);
         return NATS_OK;
     }
-    nc = sub->conn;
-    _retain(sub);
+    // Make sure that we just add to buffer but we don't flush it in place
+    // to make sure that this call will not block.
+    s = natsConn_enqueueUnsubProto(sub->conn, sub->sid);
+    if (s == NATS_OK)
+        s = natsThread_Create(&(sub->drainThread), _flushAndDrain, (void*) sub);
+    if (s == NATS_OK)
+    {
+        sub->drainTimeout = timeout;
+        sub->drainState |= SUB_DRAIN_STARTED;
+        _retain(sub);
+    }
     natsSub_Unlock(sub);
 
-    s = natsConn_drainSub(nc, sub, true);
+    return NATS_UPDATE_ERR_STACK(s);
+}
 
-    natsSub_release(sub);
+natsStatus
+natsSubscription_Drain(natsSubscription *sub)
+{
+    natsStatus s;
 
+    s = _unsubscribe(sub, 0, true, DEFAULT_DRAIN_TIMEOUT);
+    return NATS_UPDATE_ERR_STACK(s);
+}
+
+natsStatus
+natsSubscription_DrainTimeout(natsSubscription *sub, int64_t timeout)
+{
+    natsStatus s;
+
+    s = _unsubscribe(sub, 0, true, timeout);
     return NATS_UPDATE_ERR_STACK(s);
 }
 
@@ -795,30 +943,46 @@ natsSubscription_WaitForDrainCompletion(natsSubscription *sub, int64_t timeout)
         return nats_setDefaultError(NATS_INVALID_ARG);
 
     natsSub_Lock(sub);
-    if (!sub->draining)
+    if (!natsSub_drainStarted(sub))
     {
         natsSub_Unlock(sub);
         return nats_setError(NATS_ILLEGAL_STATE, "%s", "Subscription not in draining mode");
     }
     _retain(sub);
-    natsSub_Unlock(sub);
 
     if (timeout > 0)
         deadline = nats_setTargetTime(timeout);
 
-    while (natsSubscription_IsValid(sub))
+    while ((s != NATS_TIMEOUT) && !natsSub_drainComplete(sub))
     {
-        nats_Sleep(100);
-        if (deadline > 0 && (nats_Now() >= deadline))
-        {
-            s = nats_setError(NATS_TIMEOUT,
-                    "The subscription's drain took more than the timeout of %" PRId64 "ms",
-                    timeout);
-            break;
-        }
+        if (timeout > 0)
+            s = natsCondition_AbsoluteTimedWait(sub->cond, sub->mu, deadline);
+        else
+            natsCondition_Wait(sub->cond, sub->mu);
     }
+    natsSub_Unlock(sub);
 
     natsSub_release(sub);
+
+    // Here, we return a status as a result, not as if there was something wrong
+    // with the execution of this function. So we do not update the error stack.
+    return s;
+}
+
+natsStatus
+natsSubscription_DrainCompletionStatus(natsSubscription *sub)
+{
+    natsStatus s;
+
+    if (sub == NULL)
+        return nats_setDefaultError(NATS_INVALID_ARG);
+
+    natsSub_Lock(sub);
+    if (!natsSub_drainComplete(sub))
+        s = NATS_ILLEGAL_STATE;
+    else
+        s = sub->drainStatus;
+    natsSub_Unlock(sub);
 
     return s;
 }

--- a/src/sub.h
+++ b/src/sub.h
@@ -44,6 +44,21 @@ void
 natsSub_setMax(natsSubscription *sub, uint64_t max);
 
 void
+natsSub_initDrain(natsSubscription *sub);
+
+natsStatus
+natsSub_startDrain(natsSubscription *sub, int64_t timeout);
+
+void
+natsSub_setDrainCompleteState(natsSubscription *sub);
+
+void
+natsSub_setDrainSkip(natsSubscription *sub, natsStatus s);
+
+void
+natsSub_updateDrainStatus(natsSubscription *sub, natsStatus s);
+
+void
 natsSub_drain(natsSubscription *sub);
 
 void

--- a/src/sub.h
+++ b/src/sub.h
@@ -29,6 +29,14 @@ void natsSub_Unlock(natsSubscription *sub);
 
 #endif // DEV_MODE
 
+#define SUB_DRAIN_STARTED     ((uint8_t) 1)
+#define SUB_DRAIN_COMPLETE    ((uint8_t) 2)
+
+#define natsSub_drainStarted(s)     (((s)->drainState & SUB_DRAIN_STARTED) != 0)
+#define natsSub_drainComplete(s)    (((s)->drainState & SUB_DRAIN_COMPLETE) != 0)
+
+extern bool testDrainAutoUnsubRace;
+
 void
 natsSub_retain(natsSubscription *sub);
 

--- a/test/list.txt
+++ b/test/list.txt
@@ -145,6 +145,7 @@ ServerErrorClosesConnection
 NoEcho
 NoEchoOldServer
 DrainSub
+DrainSubStops
 DrainConn
 NoDoubleCloseCbOnDrain
 GetClientID

--- a/test/list.txt
+++ b/test/list.txt
@@ -147,6 +147,8 @@ NoEcho
 NoEchoOldServer
 DrainSub
 DrainSubStops
+DrainSubRaceOnAutoUnsub
+DrainSubNotResentOnReconnect
 DrainConn
 NoDoubleCloseCbOnDrain
 GetClientID

--- a/test/list.txt
+++ b/test/list.txt
@@ -106,6 +106,7 @@ ReplyArg
 SyncReplyArg
 Unsubscribe
 DoubleUnsubscribe
+SubRemovedWhileProcessingMsg
 RequestTimeout
 Request
 RequestNoBody

--- a/test/test.c
+++ b/test/test.c
@@ -10432,8 +10432,8 @@ test_SubRemovedWhileProcessingMsg(void)
     testCond(s == NATS_OK);
 
     test("Close sub: ");
-    natsSub_close(sub, false);
     natsSub_Unlock(sub);
+    natsSub_close(sub, false);
     testCond(s == NATS_OK);
 
     test("Check msg not given: ");
@@ -10464,14 +10464,16 @@ test_SubRemovedWhileProcessingMsg(void)
     testCond(s == NATS_OK);
 
     test("Close sub: ");
-    natsSub_close(sub, false);
     natsMutex_Unlock(sub->libDlvWorker->lock);
     natsSub_Unlock(sub);
+    natsSub_close(sub, false);
     testCond(s == NATS_OK);
 
     test("Check msg not given: ");
     natsSub_Lock(sub);
+    natsMutex_Lock(sub->libDlvWorker->lock);
     testCond(sub->msgList.msgs == 0);
+    natsMutex_Unlock(sub->libDlvWorker->lock);
     natsSub_Unlock(sub);
 
     natsSubscription_Destroy(sub);


### PR DESCRIPTION
This addresses several issues related to drain:
- Subscriptions could not be closed (unsubscribe) by the user once
draining had started
- The natsConnection_Drain() and natsSubscription_Drain() were
possibly blocking since those functions would internally call
natsConnection_Flush().

The calls are now not blocking (the flush is done in a library
thread), the subscription can be closed while drain is in progress.

Two new APIs were added:
- natsSubscription_DrainTimeout(): this allows to specify a timeout.
When the timeout is reached and if the subscription is not fully
drained, the subscription will automatically closed.
- natsSubscription_DrainCompletionStatus(): once the user has verified
that the drain is complete, this function can be used to know if the
drain completed successfully or not. It returns NATS_OK if drain
was completed without error, but would return NATS_INVALID_SUBSCRIPTION
if the subscription was closed prematurely, or NATS_CONNECTION_CLOSED
if it was the connection.

Resolves #394
Resolves #383

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>