### PR TITLE
Add a null check before freeaddrinfo()

### DIFF
--- a/src/comsock.c
+++ b/src/comsock.c
@@ -156,7 +156,8 @@ natsSock_ConnectTcp(natsSockCtx *ctx, const char *phost, int port)
     if (numIPs == 0)
     {
         for (i=0; i<numServInfo; i++)
-            freeaddrinfo(servInfos[i]);
+            if (servInfos[i])
+                freeaddrinfo(servInfos[i]);
 
         return NATS_UPDATE_ERR_STACK(NATS_NO_SERVER);
     }
@@ -240,7 +241,8 @@ natsSock_ConnectTcp(natsSockCtx *ctx, const char *phost, int port)
         }
     }
     for (i=0; i<numServInfo; i++)
-        freeaddrinfo(servInfos[i]);
+        if (servInfos[i])
+            freeaddrinfo(servInfos[i]);
 
     // If there was a deadline, reset the deadline with whatever is left.
     if (totalTimeout > 0)

--- a/src/util.c
+++ b/src/util.c
@@ -1388,7 +1388,8 @@ nats_HostIsIP(const char *host)
     if (getaddrinfo(host, NULL, &hint, &res) != 0)
         isIP = false;
 
-    freeaddrinfo(res);
+    if (res)
+        freeaddrinfo(res);
 
     return isIP;
 }

--- a/test/test.c
+++ b/test/test.c
@@ -3849,7 +3849,8 @@ _testWaitReadyServer(void *closure)
         }
     }
     natsSock_Close(sock);
-    freeaddrinfo(servinfo);
+    if (servinfo)
+        freeaddrinfo(servinfo);
 }
 
 static void
@@ -8459,7 +8460,8 @@ _startMockupServer(natsSock *serverSock, const char *host, const char *port)
     else
         natsSock_Close(sock);
 
-    freeaddrinfo(servinfo);
+    if (servinfo)
+        freeaddrinfo(servinfo);
 
     return s;
 }


### PR DESCRIPTION
Calling `freeaddrinfo()` with a `NULL` is undefined behavior.

Consider the [freeBSD manpage of freeaddrinfo(3)](https://www.freebsd.org/cgi/man.cgi?freeaddrinfo(3)):
```
IMPLEMENTATION NOTES
     The behavior of freeadrinfo(NULL) is left unspecified by both Version 4 of
     the Single UNIX Specification (“SUSv4”) and RFC 3493.  The current
     implementation ignores a NULL argument for compatibility with programs that
     rely on the implementation details of other operating systems.
```

Encountered this problem when targeting musl libc. See [the musl implementation here](https://git.musl-libc.org/cgit/musl/tree/src/network/freeaddrinfo.c). No-op is not guaranteed in the standard.

It is my first PR to `nats.c` so any feedback is very welcome.