### PR TITLE
Code cleanup

### DIFF
--- a/src/comsock.c
+++ b/src/comsock.c
@@ -22,6 +22,7 @@
 #include "status.h"
 #include "comsock.h"
 #include "mem.h"
+#include "util.h"
 
 natsStatus
 natsSock_Init(natsSockCtx *ctx)
@@ -156,8 +157,7 @@ natsSock_ConnectTcp(natsSockCtx *ctx, const char *phost, int port)
     if (numIPs == 0)
     {
         for (i=0; i<numServInfo; i++)
-            if (servInfos[i])
-                freeaddrinfo(servInfos[i]);
+            nats_FreeAddrInfo(servInfos[i]);
 
         return NATS_UPDATE_ERR_STACK(NATS_NO_SERVER);
     }
@@ -241,8 +241,7 @@ natsSock_ConnectTcp(natsSockCtx *ctx, const char *phost, int port)
         }
     }
     for (i=0; i<numServInfo; i++)
-        if (servInfos[i])
-            freeaddrinfo(servInfos[i]);
+        nats_FreeAddrInfo(servInfos[i]);
 
     // If there was a deadline, reset the deadline with whatever is left.
     if (totalTimeout > 0)

--- a/src/util.c
+++ b/src/util.c
@@ -1373,6 +1373,16 @@ nats_ReadFile(natsBuffer **buffer, int initBufSize, const char *fn)
     return NATS_UPDATE_ERR_STACK(s);
 }
 
+void
+nats_FreeAddrInfo(struct addrinfo *res)
+{
+    // Calling freeaddrinfo(NULL) is undefined behaviour.
+    if (res == NULL)
+        return;
+
+    freeaddrinfo(res);
+}
+
 bool
 nats_HostIsIP(const char *host)
 {
@@ -1388,8 +1398,7 @@ nats_HostIsIP(const char *host)
     if (getaddrinfo(host, NULL, &hint, &res) != 0)
         isIP = false;
 
-    if (res)
-        freeaddrinfo(res);
+    nats_FreeAddrInfo(res);
 
     return isIP;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -144,4 +144,7 @@ nats_HostIsIP(const char *host);
 natsStatus
 nats_GetJWTOrSeed(char **val, const char *content, int item);
 
+void
+nats_FreeAddrInfo(struct addrinfo *res);
+
 #endif /* UTIL_H_ */

--- a/test/test.c
+++ b/test/test.c
@@ -3849,8 +3849,7 @@ _testWaitReadyServer(void *closure)
         }
     }
     natsSock_Close(sock);
-    if (servinfo)
-        freeaddrinfo(servinfo);
+    nats_FreeAddrInfo(servinfo);
 }
 
 static void
@@ -8460,8 +8459,7 @@ _startMockupServer(natsSock *serverSock, const char *host, const char *port)
     else
         natsSock_Close(sock);
 
-    if (servinfo)
-        freeaddrinfo(servinfo);
+    nats_FreeAddrInfo(servinfo);
 
     return s;
 }


### PR DESCRIPTION
**This is a draft PR.** Following the helpful feedback from @kozlovic (See #400) I want to wrap the culprit `freeaddrinfo()` with a null check. 

Sorry for disturbing you because of a minor nuisance, but could you please indicate in which header should I put it (since `util.h` is not included everywhere)?

I appreciate your help!