### PR TITLE
[CHANGED] Default Ping settings

### DIFF
--- a/src/stan/copts.h
+++ b/src/stan/copts.h
@@ -22,7 +22,7 @@
 #define STAN_CONN_OPTS_DEFAULT_MAX_PUB_ACKS_INFLIGHT              (16384)
 #define STAN_CONN_OPTS_DEFAULT_MAX_PUB_ACKS_INFLIGHT_PERCENTAGE   (float) (0.5)     // 50% of MaxPubAcksInflight
 #define STAN_CONN_OPTS_DEFAULT_PING_INTERVAL                      (5)               // 5 seconds
-#define STAN_CONN_OPTS_DEFAULT_PING_MAX_OUT                       (3)
+#define STAN_CONN_OPTS_DEFAULT_PING_MAX_OUT                       (88)
 
 natsStatus
 stanConnOptions_clone(stanConnOptions **clonedOpts, stanConnOptions *opts);


### PR DESCRIPTION
The current defaults were too small and would cause a client to
mark the connection as lost after 15 seconds or so. This means
that a server restart or leadership change may lead to the client
dropping the connection.

Made the change so that the overall time the client keeps the
connection valid is as long as the server default ping settings.

Of course, user that use stanConnOptions_SetPings() are not affected.
This is only changing the default values.
Also, in the event that the server no longer has the client, the
client will detect that at the first ping interval, which is
5 seconds (the interval has not changed).

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>