### PR TITLE
[FIXED] Streaming: Subscribe timeout should send a close request

### DIFF
--- a/test/list.txt
+++ b/test/list.txt
@@ -221,3 +221,4 @@ StanGetNATSConnection
 StanNoRetryOnFailedConnect
 StanInternalSubsNotPooled
 StanSubOnComplete
+StanSubTimeout


### PR DESCRIPTION
If an application gets a timeout on a Subscribe() call, it does not
know if the server is actually going to process the request. The request
could have been just processed but the client timed-out before getting
the response back, or there is a bit of a backlog of requests in the
server and the request will be processed after the request times out
in the client.

If that happens, and if the application maintains its connection, then
it is possible that the server processes the subscription and keep that
subscription alive, although the application does not have an handle
on this subscription (the Subscribe() call has failed).

On timeout, the library will now send a request to close the subscription.
However, the protocol normally requires the AckInbox which is assigned by
the server and sent back as part of the subscription response protocol.
The library will send the request with the subscription inbox. Newer
servers (v0.21.0+) will be able to handle that, older will report that no
subscription was found for the subscription close request.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>