### PR TITLE
[FIXED] Event loop reconnect issue with TLS connections

### DIFF
--- a/test/list.txt
+++ b/test/list.txt
@@ -166,6 +166,7 @@ HeadersNotSupported
 HeadersBasic
 EventLoop
 EventLoopRetryOnFailedConnect
+EventLoopTLS
 SSLBasic
 SSLVerify
 SSLCAFromMemory


### PR DESCRIPTION
When TLS connection is used, some internal state needed to be cleaned-up
after a disconnect before attempting to reconnect.

Resolves #412

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>