### PR TITLE
[FIXED] URL parsing returns "invalid port" if path after port

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -64,8 +64,10 @@ static uint16_t crc16tab[256] = {
     0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0,
 };
 
-static int64_t
-parseInt64(const char *d, int dLen)
+// parseInt64 expects decimal positive numbers. We
+// return -1 to signal error
+int64_t
+nats_ParseInt64(const char *d, int dLen)
 {
     int     i;
     char    dec;
@@ -91,29 +93,6 @@ parseInt64(const char *d, int dLen)
     }
 
     return n;
-}
-
-// parseInt64 expects decimal positive numbers. We
-// return -1 to signal error
-int64_t
-nats_ParseInt64(const char *d, int dLen)
-{
-    return parseInt64(d, dLen);
-}
-
-natsStatus
-nats_ParsePort(int *port, const char *sport)
-{
-    natsStatus  s    = NATS_OK;
-    int64_t     n    = 0;
-
-    n = parseInt64(sport, (int) strlen(sport));
-    if ((n < 0) || (n > INT32_MAX))
-        s = nats_setError(NATS_INVALID_ARG, "invalid port '%s'", sport);
-    else
-        *port = (int) n;
-
-    return s;
 }
 
 natsStatus

--- a/src/util.h
+++ b/src/util.h
@@ -70,9 +70,6 @@ int64_t
 nats_ParseInt64(const char *d, int dLen);
 
 natsStatus
-nats_ParsePort(int *port, const char *sport);
-
-natsStatus
 nats_Trim(char **pres, const char *s);
 
 natsStatus

--- a/test/test.c
+++ b/test/test.c
@@ -1625,6 +1625,18 @@ test_natsUrl(void)
     natsUrl_Destroy(u);
     u = NULL;
 
+    test("'nats://localhost:4222/subject':");
+    s = natsUrl_Create(&u, " nats://localhost:4222/subject");
+    testCond((s == NATS_OK)
+              && (u != NULL)
+              && (u->host != NULL)
+              && (strcmp(u->host, "localhost") == 0)
+              && (u->username == NULL)
+              && (u->password == NULL)
+              && (u->port == 4222));
+    natsUrl_Destroy(u);
+    u = NULL;
+
     test("'tcp://localhost: 4222':");
     s = natsUrl_Create(&u, "tcp://localhost: 4222");
     testCond((s == NATS_INVALID_ARG)


### PR DESCRIPTION
This was introduced in v2.4.0.

Resolves #417

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>