### PR TITLE
[FIXED] Slow consumer for subscriptions receiving messages with headers

### DIFF
--- a/test/list.txt
+++ b/test/list.txt
@@ -53,6 +53,7 @@ LibMsgDelivery
 AsyncINFO
 RequestPool
 NoFlusherIfSendAsapOption
+HeadersAndSubPendingBytes
 DefaultConnection
 SimplifiedURLs
 IPResolutionOrder


### PR DESCRIPTION
The accounting for subscription's pending bytes was wrong because
the whole message buffer was added (counting headers) but then
only the data portion was removed once message was dispatched.

Over time, this would lead to a subscription's pending bytes
possibly higher than the pending limit which would cause the
connection to always drop messages for this subscription.

Resolves #419

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>