### PR TITLE
[ADDED] natsOptions_DisableNoResponders() API

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 The NATS Authors
+// Copyright 2015-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -965,7 +965,8 @@ _connectProto(natsConnection *nc, char **proto)
     if (s == NATS_OK)
     {
         // If our server does not support headers then we can't do them or no responders.
-        const char *hdrsAndNoResponders = nats_GetBoolStr(nc->info.headers);
+        const char *hdrs = nats_GetBoolStr(nc->info.headers);
+        const char *noResponders = nats_GetBoolStr(nc->info.headers && !nc->opts->disableNoResponders);
 
         res = nats_asprintf(proto,
                             "CONNECT {\"verbose\":%s,\"pedantic\":%s,%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\"tls_required\":%s," \
@@ -996,8 +997,8 @@ _connectProto(natsConnection *nc, char **proto)
                             CString, NATS_VERSION_STRING,
                             CLIENT_PROTO_INFO,
                             nats_GetBoolStr(!opts->noEcho),
-                            hdrsAndNoResponders,
-                            hdrsAndNoResponders,
+                            hdrs,
+                            noResponders,
                             _CRLF_);
         if (res < 0)
             s = nats_setDefaultError(NATS_NO_MEMORY);

--- a/src/nats.h
+++ b/src/nats.h
@@ -1788,6 +1788,43 @@ natsOptions_SetNKeyFromSeed(natsOptions *opts,
 NATS_EXTERN natsStatus
 natsOptions_SetWriteDeadline(natsOptions *opts, int64_t deadline);
 
+/** \brief Enable/Disable the "no responders" feature.
+ *
+ * By default, when a connection to a NATS Server v2.2.0+ is made,
+ * the library signals to the server that it supports the "no responders"
+ * feature, which means that if a request is made, and there are
+ * no subscriptions on the request subject (no responders), then
+ * the server sends back an empty message with the header "Status"
+ * and value "503". The request APIs capture this message and
+ * instead return a #NATS_NO_RESPONDERS status, instead of waiting
+ * for the timeout to occur and return #NATS_TIMEOUT.
+ *
+ * In case where users set up their own asynchronous subscription
+ * on the reply subject and publish the request with #natsConnection_PublishRequest
+ * and the like, then the message callback may be invoked with this
+ * "no responders" message, which can be checked with #natsMsg_IsNoResponders.
+ *
+ * However, if users don't want to have to deal with that, it is
+ * possible to instruct the server to disable this feature for
+ * a given connection. If that is the case, requests will behave
+ * as with pre-v2.2.0 servers, in that the request will timeout
+ * when there are no responders.
+ *
+ * \note This function is to disable the feature that is normally
+ * enabled by default. Passing `false` means that it would enable
+ * it again if you had previously disable the option. However, the
+ * feature may still be disabled when connecting to a server that
+ * does not support it.
+ *
+ * @see natsMsg_IsNoResponders()
+ *
+ * @param opts the pointer to the #natsOptions object.
+ * @param disabled the boolean to indicate if the feature should be
+ * disabled or not.
+ */
+NATS_EXTERN natsStatus
+natsOptions_DisableNoResponders(natsOptions *opts, bool disabled);
+
 /** \brief Destroys a #natsOptions object.
  *
  * Destroys the natsOptions object, freeing used memory. See the note in

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 The NATS Authors
+// Copyright 2015-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -299,6 +299,9 @@ struct __natsOptions
     // Custom handler to specify reconnect wait time.
     natsCustomReconnectDelayHandler customReconnectDelayCB;
     void                            *customReconnectDelayCBClosure;
+
+    // Disable the "no responders" feature.
+    bool disableNoResponders;
 };
 
 typedef struct __natsMsgList

--- a/src/opts.c
+++ b/src/opts.c
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 The NATS Authors
+// Copyright 2015-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -1321,6 +1321,18 @@ natsOptions_SetWriteDeadline(natsOptions *opts, int64_t deadline)
     LOCK_AND_CHECK_OPTIONS(opts, (deadline < 0));
 
     opts->writeDeadline = deadline;
+
+    UNLOCK_OPTS(opts);
+
+    return NATS_OK;
+}
+
+natsStatus
+natsOptions_DisableNoResponders(natsOptions *opts, bool disabled)
+{
+    LOCK_AND_CHECK_OPTIONS(opts, 0);
+
+    opts->disableNoResponders = disabled;
 
     UNLOCK_OPTS(opts);
 

--- a/src/stan/conn.c
+++ b/src/stan/conn.c
@@ -162,7 +162,6 @@ static void
 _processPingResponse(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void *closure)
 {
     stanConnection  *sc  = (stanConnection*) closure;
-    const char      *val = NULL;
 
     if (natsMsg_GetDataLength(msg) > 0)
     {
@@ -186,9 +185,7 @@ _processPingResponse(natsConnection *nc, natsSubscription *sub, natsMsg *msg, vo
         }
     }
     // Check for no responders
-    else if ((natsMsgHeader_Get(msg, STATUS_HDR, &val) == NATS_OK)
-                && (val != NULL)
-                && (strcmp(val, NO_RESP_STATUS) == 0))
+    else if (natsMsg_IsNoResponders(msg))
     {
         natsMsg_Destroy(msg);
         return;


### PR DESCRIPTION
Added an option to disable the "no responders" feature when connecting
to NATS Servers v2.2.0+.

Also made use of natsMsg_IsNoResponders() in a place in STAN code,
and optimized _liftHeaders so that we don't create the headers map
if there is no need to lift (no header in incoming message wire)
and if call was not made from Set or Add APIs.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>