### PR TITLE
[FIXED] TLS fails to reconnect after some protocol error

### DIFF
--- a/test/list.txt
+++ b/test/list.txt
@@ -180,6 +180,7 @@ SSLCiphers
 SSLMultithreads
 SSLConnectVerboseOption
 SSLSocketLeakEventLoop
+SSLReconnectWithAuthError
 ServersOption
 AuthServers
 AuthFailToReconnect


### PR DESCRIPTION
If a client is connected with TLS, then reconnects to a server
and the TLS hanshake is successful, but an error occurs as
part of the NATS connect handshake, then it would leave the
TLS connection in a bad state that would prevent to successfully
reconnect.

Resolves #425

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>