### PR TITLE
[CHANGED] Headers keys are now case-sensitive

### DIFF
--- a/examples/getstarted/headers.c
+++ b/examples/getstarted/headers.c
@@ -1,4 +1,4 @@
-// Copyright 2020 The NATS Authors
+// Copyright 2020-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -94,9 +94,7 @@ int main(int argc, char **argv)
 
         // Notice that calling natsMsgHeader_Get() on a key that has
         // several values will return the first entry.
-        // Notice also that "key1" will automatically be converted
-        // to its canonical form: "My-Key1".
-        s = natsMsgHeader_Get(rmsg, "my-key1", &val);
+        s = natsMsgHeader_Get(rmsg, "My-Key1", &val);
         if (s == NATS_OK)
             printf("For key 'My-Key1', got value: '%s'\n", val);
 

--- a/src/nats.h
+++ b/src/nats.h
@@ -2310,8 +2310,8 @@ natsMsg_GetDataLength(const natsMsg *msg);
  *
  * It will replace any existing value associated with `key`.
  *
- * \note The `key` will be store in its canonical form, that is, the key "my-key"
- * is stored as "My-Key".
+ * \warning Prior to v3.0.0, the `key` was stored in its canonical form, this is no
+ * longer the case. Header keys are now case sensitive.
  *
  * \warning Headers are not thread-safe, that is, you must not set/add/get values or
  * delete keys for the same message from different threads. The internal structure
@@ -2328,8 +2328,8 @@ natsMsgHeader_Set(natsMsg *msg, const char *key, const char *value);
  *
  * It will append to any existing values associated with `key`.
  *
- * \note The `key` will be store in its canonical form, that is, the key "my-key"
- * is stored as "My-Key".
+ * \warning Prior to v3.0.0, the `key` was stored in its canonical form, this is no
+ * longer the case. Header keys are now case sensitive.
  *
  * \warning Headers are not thread-safe, that is, you must not set/add/get values or
  * delete keys for the same message from different threads. The internal structure
@@ -2347,8 +2347,8 @@ natsMsgHeader_Add(natsMsg *msg, const char *key, const char *value);
  * If more than one entry for the `key` is available, the first is returned.
  * The returned value is owned by the library and MUST not be freed or altered.
  *
- * \note The `key` will be store as its canonical form, that is, the key "my-key"
- * is stored as "My-Key".
+ * \warning Prior to v3.0.0, the `key` was stored in its canonical form, this is no
+ * longer the case. Header keys are now case sensitive.
  *
  * \warning Headers are not thread-safe, that is, you must not set/add/get values or
  * delete keys for the same message from different threads. The internal structure
@@ -2382,8 +2382,8 @@ natsMsgHeader_Get(natsMsg *msg, const char *key, const char **value);
  * }
  * \endcode
  *
- * \note The `key` will be store as its canonical form, that is, the key "my-key"
- * is stored as "My-Key".
+ * \warning Prior to v3.0.0, the `key` was stored in its canonical form, this is no
+ * longer the case. Header keys are now case sensitive.
  *
  * \warning Headers are not thread-safe, that is, you must not set/add/get values or
  * delete keys for the same message from different threads. The internal structure
@@ -2433,7 +2433,8 @@ natsMsgHeader_Keys(natsMsg *msg, const char* **keys, int *count);
 
 /** \brief Delete the value(s) associated with `key`.
  *
- * \note The canonical form of `key` is used for looking up and then deleting the entry.
+ * \warning Prior to v3.0.0, the `key` was stored in its canonical form, this is no
+ * longer the case. Header keys are now case sensitive.
  *
  * \warning Headers are not thread-safe, that is, you must not set/add/get values or
  * delete keys for the same message from different threads. The internal structure

--- a/test/test.c
+++ b/test/test.c
@@ -4208,9 +4208,7 @@ test_natsMsgHeaderAPIs(void)
 
     test("Get value with different case: ");
     s = natsMsgHeader_Get(msg, "my-Key", &val);
-    testCond((s == NATS_OK) &&
-                (val != NULL) &&
-                (strcmp(val, "value1") == 0));
+    testCond((s == NATS_NOT_FOUND) && (val == NULL));
     val = NULL;
 
     test("Key not found: ");
@@ -4223,7 +4221,7 @@ test_natsMsgHeaderAPIs(void)
     testCond(s == NATS_OK);
 
     test("Get value: ");
-    s = natsMsgHeader_Get(msg, "My-KEy", &val);
+    s = natsMsgHeader_Get(msg, "my-key", &val);
     testCond((s == NATS_OK) &&
                 (val != NULL) &&
                 (strcmp(val, "value2") == 0));
@@ -4325,11 +4323,11 @@ test_natsMsgHeaderAPIs(void)
 
         for (i=0; i<count; i++)
         {
-            if (strcmp(keys[i], "My-Key") == 0)
+            if (strcmp(keys[i], "my-key") == 0)
                 ok1 = true;
-            else if (strcmp(keys[i], "Two-Fields") == 0)
+            else if (strcmp(keys[i], "two-fields") == 0)
                 ok2 = true;
-            else if (strcmp(keys[i], "My-Other-Key") == 0)
+            else if (strcmp(keys[i], "my-other-key") == 0)
                 ok3 = true;
         }
         if (!ok1 || !ok2 || !ok3)


### PR DESCRIPTION
Prior to v3.0.0, keys were changed to their canonical form, even
when being received from the server. This is no longer the case.
The case is now preserved and all header APIs are case sensitive.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>