### PR TITLE
Fixed errors/warnings from LGTM search

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This NATS Client implementation is heavily based on the [NATS GO Client](https:/
 [![Coverage Status](https://coveralls.io/repos/github/nats-io/nats.c/badge.svg?branch=master)](https://coveralls.io/github/nats-io/nats.c?branch=master)
 [![Release](https://img.shields.io/badge/release-v2.5.0-blue.svg?style=flat)](https://github.com/nats-io/nats.c/releases/tag/v2.5.0)
 [![Documentation](https://img.shields.io/badge/doc-Doxygen-brightgreen.svg?style=flat)](http://nats-io.github.io/nats.c)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/nats-io/nats.c.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nats-io/nats.c/alerts/)
+[![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/nats-io/nats.c.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nats-io/nats.c/context:cpp)
 
 # Table of Contents
 

--- a/src/comsock.c
+++ b/src/comsock.c
@@ -361,15 +361,14 @@ natsSock_Read(natsSockCtx *ctx, char *buffer, size_t maxBufferSize, int *n)
             if (ctx->ssl != NULL)
             {
                 int sslErr = SSL_get_error(ctx->ssl, readBytes);
-                int waitMode = WAIT_FOR_READ;
 
                 if (sslErr == SSL_ERROR_ZERO_RETURN)
                     return nats_setDefaultError(NATS_CONNECTION_CLOSED);
 
-                if ((sslErr == SSL_ERROR_WANT_READ)
-                        // Check want_write error and if so set appropriate waitMode
-                        || ((sslErr == SSL_ERROR_WANT_WRITE) && (waitMode = WAIT_FOR_WRITE)))
+                if ((sslErr == SSL_ERROR_WANT_READ) || (sslErr == SSL_ERROR_WANT_WRITE))
                 {
+                    int waitMode = (sslErr == SSL_ERROR_WANT_READ ? WAIT_FOR_READ : WAIT_FOR_WRITE);
+
                     if ((s = natsSock_WaitReady(waitMode, ctx)) != NATS_OK)
                         return NATS_UPDATE_ERR_STACK(s);
 
@@ -450,15 +449,14 @@ natsSock_Write(natsSockCtx *ctx, const char *data, int len, int *n)
             if (ctx->ssl != NULL)
             {
                 int sslErr = SSL_get_error(ctx->ssl, bytes);
-                int waitMode = WAIT_FOR_READ;
 
                 if (sslErr == SSL_ERROR_ZERO_RETURN)
                     return nats_setDefaultError(NATS_CONNECTION_CLOSED);
 
-                if ((sslErr == SSL_ERROR_WANT_READ)
-                        // Check want_write error and if so set appropriate waitMode
-                        || ((sslErr == SSL_ERROR_WANT_WRITE) && (waitMode = WAIT_FOR_WRITE)))
+                if ((sslErr == SSL_ERROR_WANT_READ) || (sslErr == SSL_ERROR_WANT_WRITE))
                 {
+                    int waitMode = (sslErr == SSL_ERROR_WANT_READ ? WAIT_FOR_READ : WAIT_FOR_WRITE);
+
                     if ((s = natsSock_WaitReady(waitMode, ctx)) != NATS_OK)
                         return NATS_UPDATE_ERR_STACK(s);
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -327,8 +327,7 @@ natsConn_bufferWrite(natsConnection *nc, const char *buffer, int len)
 
     if (nc->dontSendInPlace)
     {
-        if (len > 0)
-            s = natsBuf_Append(nc->bw, buffer, len);
+        s = natsBuf_Append(nc->bw, buffer, len);
 
         return NATS_UPDATE_ERR_STACK(s);
     }


### PR DESCRIPTION
Note that the 2 errors were actually false positive, since the
intent was really to assign, not to compare.
This was a trick to assign the waitMode based on the comparaison,
but to avoid confusion went to a more standard approach.

Added the LGTM badges.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>