### PR TITLE
Added nats[Str]Hash_RemoveSingle to remove the sole element of a hash

### DIFF
--- a/src/hash.h
+++ b/src/hash.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 The NATS Authors
+// Copyright 2015-2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -93,6 +93,9 @@ natsHash_Get(natsHash *hash, int64_t key);
 void*
 natsHash_Remove(natsHash *hash, int64_t key);
 
+natsStatus
+natsHash_RemoveSingle(natsHash *hash, int64_t *key, void **data);
+
 void
 natsHash_Destroy(natsHash *hash);
 
@@ -131,6 +134,9 @@ natsStrHash_Get(natsStrHash *hash, char *key);
 
 void*
 natsStrHash_Remove(natsStrHash *hash, char *key);
+
+natsStatus
+natsStrHash_RemoveSingle(natsStrHash *hash, char **key, void **data);
 
 void
 natsStrHash_Destroy(natsStrHash *hash);

--- a/src/pub.c
+++ b/src/pub.c
@@ -376,17 +376,13 @@ _respHandler(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void *clos
         rt = (char*) (natsMsg_GetSubject(msg) + NATS_REQ_ID_OFFSET);
         resp = (respInfo*) natsStrHash_Remove(nc->respMap, rt);
     }
-    else if ((resp == NULL) && (natsStrHash_Count(nc->respMap) == 1))
+    else if (natsStrHash_Count(nc->respMap) == 1)
     {
         // Only if the subject is completely different, we assume that it
         // could be the server that has rewritten the subject and so if there
         // is a single entry, use that.
-        natsStrHashIter iter;
-        void            *value = NULL;
-
-        natsStrHashIter_Init(&iter, nc->respMap);
-        natsStrHashIter_Next(&iter, NULL, &value);
-        natsStrHashIter_RemoveCurrent(&iter);
+        void *value = NULL;
+        natsStrHash_RemoveSingle(nc->respMap, NULL, &value);
         resp = (respInfo*) value;
     }
     if (resp != NULL)

--- a/test/test.c
+++ b/test/test.c
@@ -2108,7 +2108,42 @@ test_natsHash(void)
 
     test("Destroy: ");
     natsHash_Destroy(hash);
+    hash = NULL;
     testCond(1);
+
+    test("Create new: ");
+    s = natsHash_Create(&hash, 4);
+    testCond(s == NATS_OK);
+
+    test("Populate: ");
+    s = natsHash_Set(hash, 1, (void*) 1, NULL);
+    IFOK(s, natsHash_Set(hash, 2, (void*) 2, NULL));
+    IFOK(s, natsHash_Set(hash, 3, (void*) 3, NULL));
+    testCond(s == NATS_OK);
+
+    test("Remove one: ");
+    s = (natsHash_Remove(hash, 2) == (void*) 2) ? NATS_OK : NATS_ERR;
+    testCond(s == NATS_OK);
+
+    test("RemoveSingle fails if more than one: ");
+    s = natsHash_RemoveSingle(hash, &key, NULL);
+    testCond(s == NATS_ERR);
+    nats_clearLastError();
+
+    test("Remove second: ");
+    s = (natsHash_Remove(hash, 1) == (void*) 1) ? NATS_OK : NATS_ERR;
+    testCond(s == NATS_OK);
+
+    test("Remove single: ");
+    key = 0;
+    oldval = NULL;
+    s = natsHash_RemoveSingle(hash, &key, &oldval);
+    testCond((s == NATS_OK)
+                && (hash->used == 0)
+                && (key == 3)
+                && (oldval == (void*) 3));
+
+    natsHash_Destroy(hash);
 }
 
 static void
@@ -2343,7 +2378,56 @@ test_natsStrHash(void)
 
     test("Destroy: ");
     natsStrHash_Destroy(hash);
+    hash = NULL;
     testCond(1);
+
+    test("Create new: ");
+    s = natsStrHash_Create(&hash, 4);
+    testCond(s == NATS_OK);
+
+    test("Populate: ");
+    s = natsStrHash_Set(hash, (char*) "1", true, (void*) 1, NULL);
+    IFOK(s, natsStrHash_Set(hash, (char*) "2", true, (void*) 2, NULL));
+    IFOK(s, natsStrHash_Set(hash, (char*) "3", true, (void*) 3, NULL));
+    testCond(s == NATS_OK);
+
+    test("Remove one: ");
+    s = (natsStrHash_Remove(hash, (char*) "2") == (void*) 2) ? NATS_OK : NATS_ERR;
+    testCond(s == NATS_OK);
+
+    test("RemoveSingle fails if more than one: ");
+    s = natsStrHash_RemoveSingle(hash, &key, NULL);
+    testCond(s == NATS_ERR);
+    nats_clearLastError();
+
+    test("Remove second: ");
+    s = (natsStrHash_Remove(hash, (char*) "1") == (void*) 1) ? NATS_OK : NATS_ERR;
+    testCond(s == NATS_OK);
+
+    test("Remove single (copy of key): ");
+    key = NULL;
+    oldval = NULL;
+    s = natsStrHash_RemoveSingle(hash, &key, &oldval);
+    testCond((s == NATS_OK)
+                && (hash->used == 0)
+                && (strcmp(key, "3") == 0)
+                && (oldval == (void*) 3));
+    free(key);
+    key = NULL;
+    oldval = NULL;
+
+    test("Add key without copy: ");
+    s = natsStrHash_Set(hash, (char*) "4", false, (void*) 4, NULL);
+    testCond(s == NATS_OK);
+
+    test("Remove single (no copy of key): ");
+    s = natsStrHash_RemoveSingle(hash, &key, &oldval);
+    testCond((s == NATS_OK)
+                && (hash->used == 0)
+                && (strcmp(key, "4") == 0)
+                && (oldval == (void*) 4));
+
+    natsStrHash_Destroy(hash);
 }
 
 static const char*


### PR DESCRIPTION
In _respHandler, there is a case when we know the hash has a single
element and we want to use that one. We had to do something like:

```
natsStrHashIter_Init(&iter, nc->respMap);
natsStrHashIter_Next(&iter, NULL, &value);
natsStrHashIter_RemoveCurrent(&iter);
natsStrHashIter_Done(&iter);
```
(which, by the way, the "done" was missing).

This is now replaced with a single call:
```
natsStrHash_RemoveSingle(nc->respMap, NULL, &value);
```

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>