### PR TITLE
[CHANGED] Set default library delivery pool size to 1 instead of 2

### DIFF
--- a/src/nats.c
+++ b/src/nats.c
@@ -1040,7 +1040,7 @@ nats_Open(int64_t lockSpinCount)
             gLib.libDefaultWriteDeadline = (int64_t) atol(defaultWriteDeadlineStr);
 
         gLib.libHandlingMsgDeliveryByDefault = (getenv("NATS_DEFAULT_TO_LIB_MSG_DELIVERY") != NULL ? true : false);
-        gLib.dlvWorkers.maxSize = 2;
+        gLib.dlvWorkers.maxSize = 1;
         gLib.dlvWorkers.workers = NATS_CALLOC(gLib.dlvWorkers.maxSize, sizeof(natsMsgDlvWorker*));
         if (gLib.dlvWorkers.workers == NULL)
             s = NATS_NO_MEMORY;

--- a/test/test.c
+++ b/test/test.c
@@ -6860,7 +6860,7 @@ test_LibMsgDelivery(void)
     // Check some pre-conditions that need to be met for the test to work.
     test("Check initial values: ")
     natsLib_getMsgDeliveryPoolInfo(&pmaxSize, &psize, &pidx, &pwks);
-    testCond((pmaxSize == 2) && (psize == 0) && (pidx == 0));
+    testCond((pmaxSize == 1) && (psize == 0) && (pidx == 0));
 
     test("Check pool size not negative: ")
     s = nats_SetMessageDeliveryPoolSize(-1);
@@ -6873,7 +6873,12 @@ test_LibMsgDelivery(void)
     // Reset stack since we know the above generated errors.
     nats_clearLastError();
 
-    test("Check pool size decreased no error: ")
+    test("Increase size to 2: ")
+    s = nats_SetMessageDeliveryPoolSize(2);
+    natsLib_getMsgDeliveryPoolInfo(&pmaxSize, &psize, &pidx, &pwks);
+    testCond((s == NATS_OK) && (pmaxSize == 2) && (psize == 0));
+
+    test("Check pool size decreased (no error): ")
     s = nats_SetMessageDeliveryPoolSize(1);
     natsLib_getMsgDeliveryPoolInfo(&pmaxSize, &psize, &pidx, &pwks);
     testCond((s == NATS_OK) && (pmaxSize == 2) && (psize == 0));


### PR DESCRIPTION
The initial size was set to 2 and since lowering the pool max size
is a no-op, one would not be able to have a pool of size 1.
Changed the default size to 1.

Resolves #439

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>