### PR TITLE
[FIXED] Build on MS VS 2017

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -17,6 +17,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <ctype.h>
+#include <time.h>
 
 #include "util.h"
 #include "mem.h"


### PR DESCRIPTION
Include `<time.h>` was missing in `util.c`. I am building on a
Windows 10 VM with MS VS 2015 and did not have any issue, so not
sure if it is env or MS VS version specific.

Regardless, adding the include does not hurt and still works with
other platforms.

Resolves #453

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>