### PR TITLE
[IMPROVED] JS: Subscribe returns error if consumer config does not match

### DIFF
--- a/src/jsm.c
+++ b/src/jsm.c
@@ -1380,6 +1380,14 @@ _marshalConsumerCreateReq(natsBuffer **new_buf, const char *stream, jsConsumerCo
     natsStatus      s    = NATS_OK;
     natsBuffer      *buf = NULL;
 
+    // If not set, set some defaults
+    if ((int) cfg->DeliverPolicy < 0)
+        cfg->DeliverPolicy = js_DeliverAll;
+    if ((int) cfg->AckPolicy < 0)
+        cfg->AckPolicy = js_AckExplicit;
+    if ((int) cfg->ReplayPolicy < 0)
+        cfg->ReplayPolicy = js_ReplayInstant;
+
     s = natsBuf_Create(&buf, 256);
     IFOK(s, natsBuf_Append(buf, "{\"stream_name\":\"", -1));
     IFOK(s, natsBuf_Append(buf, stream, -1));
@@ -1841,6 +1849,9 @@ jsConsumerConfig_Init(jsConsumerConfig *cc)
         return nats_setDefaultError(NATS_INVALID_ARG);
 
     memset(cc, 0, sizeof(jsConsumerConfig));
+    cc->AckPolicy       = -1;
+    cc->DeliverPolicy   = -1;
+    cc->ReplayPolicy    = -1;
     return NATS_OK;
 }
 

--- a/src/nats.h
+++ b/src/nats.h
@@ -526,8 +526,6 @@ typedef struct jsStreamInfo
  *
  * \note `SampleFrequency` is a sampling value, represented as a string such as "50"
  * for 50%, that causes the server to produce advisories for consumer ack metrics.
- * If the percent sign is in the string, and since `%` is an escape character, it
- * needs to be doubled, such as `cfg.SampleFrequency = "50%%";`.
  *
  * @see jsConsumerConfig_Init
  *

--- a/test/list.txt
+++ b/test/list.txt
@@ -217,6 +217,7 @@ JetStreamPublish
 JetStreamPublishAsync
 JetStreamSubscribe
 JetStreamSubscribeSync
+JetStreamSubscribeConfigCheck
 JetStreamSubscribeIdleHeartbeat
 JetStreamSubscribeFlowControl
 JetStreamSubscribePull


### PR DESCRIPTION
This is done to alert the user that consumer config is not changed
as one would expect.

Also fixed setting optional start seq/time needs to set the
proper deliver policy.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>