### PR TITLE
Ensure that JS consumer is deleted before "drain complete" notification

### DIFF
--- a/src/jsm.c
+++ b/src/jsm.c
@@ -1830,11 +1830,8 @@ js_DeleteConsumer(jsCtx *js, const char *stream, const char *consumer,
 
     // If we got a response, check for error and success result.
     IFOK(s, _unmarshalSuccessResp(&success, resp, errCode));
-    if ((s == NATS_NOT_FOUND) || ((s == NATS_OK) && !success))
-    {
-        const char *nferr = (s == NATS_NOT_FOUND ? ": not found" : "");
-        s = nats_setError(s, "failed to delete consumer '%s'%s", consumer,nferr);
-    }
+    if ((s == NATS_OK) && !success)
+        s = nats_setError(s, "failed to delete consumer '%s'", consumer);
 
     NATS_FREE(subj);
     natsMsg_Destroy(resp);

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -772,6 +772,9 @@ jsSub_free(jsSub *sub);
 natsStatus
 jsSub_deleteConsumer(natsSubscription *sub);
 
+void
+jsSub_deleteConsumerAfterDrain(natsSubscription *sub);
+
 natsStatus
 jsSub_trackSequences(jsSub *jsi, const char *reply);
 


### PR DESCRIPTION
The previous implementation would delete the JS consumer in the
"flushAndDrain" thread but after the drain was marked as complete,
which could cause users calling natsSubscription_WaitForDrainCompletion
think that the JS consumer was already deleted, but it may not have
been just yet.
Also, sync subscriptions could possibly never be marked as "drain complete"

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>