### PR TITLE
[FIXED] AutoUnsubscribe() should remove sub if max <= delivered

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -3036,8 +3036,14 @@ natsConn_unsubscribe(natsConnection *nc, natsSubscription *sub, int max, bool dr
     }
 
     if (max > 0)
-        natsSub_setMax(sub, max);
-    else if (!drainMode)
+    {
+        // If we try to set a max but number of delivered messages
+        // is already higher than that, then we will do an actual
+        // remove.
+        if (!natsSub_setMax(sub, max))
+            max = 0;
+    }
+    if ((max == 0) && !drainMode)
         natsConn_removeSubscription(nc, sub);
 
     if (!drainMode && !natsConn_isReconnecting(nc))

--- a/src/sub.c
+++ b/src/sub.c
@@ -298,14 +298,18 @@ natsSub_deliverMsgs(void *arg)
     natsSub_release(sub);
 }
 
-void
+bool
 natsSub_setMax(natsSubscription *sub, uint64_t max)
 {
+    bool accepted = false;
+
     natsSub_Lock(sub);
     SUB_DLV_WORKER_LOCK(sub);
-    sub->max = max;
+    sub->max = (max <= sub->delivered ? 0 : max);
+    accepted = sub->max != 0;
     SUB_DLV_WORKER_UNLOCK(sub);
     natsSub_Unlock(sub);
+    return accepted;
 }
 
 natsStatus

--- a/src/sub.h
+++ b/src/sub.h
@@ -48,7 +48,7 @@ natsSub_create(natsSubscription **newSub, natsConnection *nc, const char *subj,
                const char *queueGroup, int64_t timeout, natsMsgHandler cb, void *cbClosure,
                bool noLibDlvPool, jsSub *jsi);
 
-void
+bool
 natsSub_setMax(natsSubscription *sub, uint64_t max);
 
 void


### PR DESCRIPTION
If the number of delivered messages is greater than the max value
specified by AutoUnsubscribe(), the library should remove the
subscription, and not send an UNSUB with a max value that is lower
than the current number of delivered messages.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>