### PR TITLE
[ADDED] JetStream Ordered Consumers

### DIFF
--- a/src/conn.h
+++ b/src/conn.h
@@ -131,8 +131,16 @@ natsConn_userFromFile(char **userJWT, char **customErrTxt, void *closure);
 natsStatus
 natsConn_signatureHandler(char **customErrTxt, unsigned char **sig, int *sigLen, const char *nonce, void *closure);
 
+natsStatus
+natsConn_sendSubProto(natsConnection *nc, const char *subject, const char *queue, int64_t sid);
+
+natsStatus
+natsConn_sendUnsubProto(natsConnection *nc, int64_t subId, int max);
+
+#define natsConn_setFilter(c, f) natsConn_setFilterWithClosure((c), (f), NULL)
+
 void
-natsConn_setFilter(natsConnection *nc, natsMsgFilter f);
+natsConn_setFilterWithClosure(natsConnection *nc, natsMsgFilter f, void* closure);
 
 void
 natsConn_close(natsConnection *nc);

--- a/src/conn.h
+++ b/src/conn.h
@@ -132,6 +132,9 @@ natsStatus
 natsConn_signatureHandler(char **customErrTxt, unsigned char **sig, int *sigLen, const char *nonce, void *closure);
 
 void
+natsConn_setFilter(natsConnection *nc, natsMsgFilter f);
+
+void
 natsConn_close(natsConnection *nc);
 
 void

--- a/src/hash.c
+++ b/src/hash.c
@@ -619,16 +619,16 @@ natsStrHash_SetEx(natsStrHash *hash, char *key, bool copyKey, bool freeKey,
 }
 
 void*
-natsStrHash_Get(natsStrHash *hash, char *key)
+natsStrHash_GetEx(natsStrHash *hash, char *key, int keyLen)
 {
     natsStrHashEntry    *e;
-    uint32_t            hk = natsStrHash_Hash(key, (int) strlen(key));
+    uint32_t            hk = natsStrHash_Hash(key, keyLen);
 
     e = hash->bkts[hk & hash->mask];
     while (e != NULL)
     {
         if ((e->hk == hk)
-            && (strcmp(e->key, key) == 0))
+            && (strncmp(e->key, key, keyLen) == 0))
         {
             return e->data;
         }

--- a/src/hash.h
+++ b/src/hash.h
@@ -129,8 +129,10 @@ natsStatus
 natsStrHash_SetEx(natsStrHash *hash, char *key, bool copyKey, bool freeKey,
                   void *data, void **oldData);
 
+#define natsStrHash_Get(h, k) natsStrHash_GetEx((h), (k), (int) strlen(k))
+
 void*
-natsStrHash_Get(natsStrHash *hash, char *key);
+natsStrHash_GetEx(natsStrHash *hash, char *key, int keyLen);
 
 void*
 natsStrHash_Remove(natsStrHash *hash, char *key);

--- a/src/js.h
+++ b/src/js.h
@@ -53,6 +53,12 @@ extern const int64_t    jsDefaultRequestWait;
 #define jsErrNoHeartbeatForQueueSub         "a queue subscription cannot be created for a consumer with heartbeat"
 #define jsErrNoFlowControlForQueueSub       "a queue subscription cannot be created for a consumer with flow control"
 #define jsErrConsumerSeqMismatch            "consumer sequence mismatch"
+#define jsErrOrderedConsNoDurable           "durable can not be set for an ordered consumer"
+#define jsErrOrderedConsNoAckPolicy         "ack policy can not be set for an ordered consume"
+#define jsErrOrderedConsNoMaxDeliver        "max deliver can not be set for an ordered consumer"
+#define jsErrOrderedConsNoQueue             "queue can not be set for an ordered consumer"
+#define jsErrOrderedConsNoBind              "can not bind existing consumer for an ordered consumer"
+#define jsErrOrderedConsNoPullMode          "can not use pull mode for an ordered consumer"
 
 #define jsCtrlHeartbeat     (1)
 #define jsCtrlFlowControl   (2)

--- a/src/nats.h
+++ b/src/nats.h
@@ -652,6 +652,13 @@ typedef struct jsSubOptions
          * consumer.
          */
         jsConsumerConfig        Config;         ///< Consumer configuration.
+        /**
+         * This will create a fifo ephemeral consumer for in order delivery of
+         * messages. There are no redeliveries and no acks.
+         * Flow control and heartbeats are required and set by default, but
+         * the heartbeats value can be overridden in the consumer configuration.
+         */
+        bool                    Ordered;        ///< If true, this will be an ordered consumer.
 
 } jsSubOptions;
 

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -538,6 +538,9 @@ typedef struct __respInfo
 
 } respInfo;
 
+// Used internally for testing and allow to alter/suppress an incoming message
+typedef void (*natsMsgFilter)(natsConnection *nc, natsMsg **msg);
+
 struct __natsConnection
 {
     natsMutex           *mu;
@@ -615,6 +618,10 @@ struct __natsConnection
         void            *buffer;
         void            *data;
     } el;
+
+    // Msg filters for testing.
+	// Protected by subsMu
+	natsMsgFilter       filter;
 };
 
 //

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -70,7 +70,7 @@
 
 #define _PING_PROTO_         "PING\r\n"
 #define _PONG_PROTO_         "PONG\r\n"
-#define _SUB_PROTO_          "SUB %s %s %d\r\n"
+#define _SUB_PROTO_          "SUB %s %s %" PRId64 "\r\n"
 #define _UNSUB_PROTO_        "UNSUB %" PRId64 " %d\r\n"
 #define _UNSUB_NO_MAX_PROTO_ "UNSUB %" PRId64 " \r\n"
 
@@ -349,6 +349,7 @@ typedef struct __jsSub
     char                *consumer;
     char                *nxtMsgSubj;
     bool                pull;
+    bool                ordered;
     bool                dc; // delete JS consumer in Unsub()/Drain()
 
     int64_t             hbi;
@@ -539,7 +540,7 @@ typedef struct __respInfo
 } respInfo;
 
 // Used internally for testing and allow to alter/suppress an incoming message
-typedef void (*natsMsgFilter)(natsConnection *nc, natsMsg **msg);
+typedef void (*natsMsgFilter)(natsConnection *nc, natsMsg **msg, void* closure);
 
 struct __natsConnection
 {
@@ -622,6 +623,7 @@ struct __natsConnection
     // Msg filters for testing.
 	// Protected by subsMu
 	natsMsgFilter       filter;
+    void                *filterClosure;
 };
 
 //
@@ -786,10 +788,16 @@ natsStatus
 jsSub_trackSequences(jsSub *jsi, const char *reply);
 
 natsStatus
-jsSub_processSequenceMismatch(natsSubscription *sub, natsMsg *msg, bool *sm);
+jsSub_processSequenceMismatch(natsSubscription *sub, natsMutex *mu, natsMsg *msg, bool *sm);
 
 natsStatus
 jsSub_scheduleFlowControlResponse(jsSub *jsi, natsSubscription *sub, const char *reply);
+
+natsStatus
+jsSub_checkOrderedMsg(natsSubscription *sub, natsMutex *mu, natsMsg *msg, bool *reset);
+
+natsStatus
+jsSub_resetOrderedConsumer(natsSubscription *sub, natsMutex *mu, uint64_t sseq);
 
 bool
 natsMsg_isJSCtrl(natsMsg *msg, int *ctrlType);

--- a/test/list.txt
+++ b/test/list.txt
@@ -170,6 +170,7 @@ ConnSign
 WriteDeadline
 HeadersNotSupported
 HeadersBasic
+MsgsFilter
 EventLoop
 EventLoopRetryOnFailedConnect
 EventLoopTLS

--- a/test/list.txt
+++ b/test/list.txt
@@ -222,6 +222,8 @@ JetStreamSubscribeConfigCheck
 JetStreamSubscribeIdleHeartbeat
 JetStreamSubscribeFlowControl
 JetStreamSubscribePull
+JetStreamOrderedCons
+JetStreamOrderedConsWithErrors
 StanPBufAllocator
 StanConnOptions
 StanSubOptions


### PR DESCRIPTION
The new `Ordered` option in `jsSubOptions` allows the jetstream subscription to be created as an ordered consumer.
It means that the subscription will be based on a fifo ephemeral consumer for in order delivery of messages.
There are no redeliveries and no acks. Flow control and heartbeats are required and set by default, but the heartbeats value can be overridden in the consumer configuration.