### PR TITLE
[FIXED] JetStream: durable name cannot contain "." character

### DIFF
--- a/src/js.h
+++ b/src/js.h
@@ -197,3 +197,6 @@ js_unmarshalConsumerInfo(nats_JSON *json, jsConsumerInfo **new_ci);
 
 void
 js_cleanStreamState(jsStreamState *state);
+
+natsStatus
+js_checkDurName(const char *dur);

--- a/src/jsm.c
+++ b/src/jsm.c
@@ -1696,8 +1696,11 @@ js_AddConsumer(jsConsumerInfo **new_ci, jsCtx *js,
     if (nats_IsStringEmpty(stream))
         return nats_setError(NATS_INVALID_ARG, "%s", jsErrStreamNameRequired);
 
-    if (!nats_IsStringEmpty(cfg->Durable) && (strchr(cfg->Durable, '.') != NULL))
-        return nats_setError(NATS_INVALID_ARG, "invalid durable name '%s' (cannot contain '.')", cfg->Durable);
+    if (!nats_IsStringEmpty(cfg->Durable))
+    {
+        if ((s = js_checkDurName(cfg->Durable)) != NATS_OK)
+            return NATS_UPDATE_ERR_STACK(s);
+    }
 
     s = js_setOpts(&nc, &freePfx, js, opts, &o);
     if (s == NATS_OK)

--- a/src/nats.h
+++ b/src/nats.h
@@ -527,6 +527,8 @@ typedef struct jsStreamInfo
  * \note `SampleFrequency` is a sampling value, represented as a string such as "50"
  * for 50%, that causes the server to produce advisories for consumer ack metrics.
  *
+ * \note `Durable` cannot contain the character ".".
+ *
  * @see jsConsumerConfig_Init
  *
  * \code{.unparsed}
@@ -632,6 +634,10 @@ typedef struct jsSubOptions
          * This makes sense only if the delivery subject in the
          * `Config` field of #jsSubOptions is the same for the
          * members of the same group.
+         *
+         * When no `Durable` name is specified in the `Config` block, then the
+         * queue name will be used as the consumer's durable name. In this case,
+         * the queue name cannot contain the character ".".
          */
         const char              *Queue;         ///< Queue name for queue subscriptions.
         /**
@@ -5347,6 +5353,8 @@ js_SubscribeSync(natsSubscription **sub, jsCtx *js, const char *subject,
  * that is the library has to request for the messages to be delivered as needed from the server.
  *
  * \note All pull subscriptions must have a durable name.
+ *
+ * \note A durable name cannot contain the character ".".
  *
  * @param sub the location where to store the pointer to the newly created #natsSubscription object.
  * @param js the pointer to the #jsCtx object.


### PR DESCRIPTION
The check was done only when calling js_AddConsumer(), but needs
to be done on subscribe also, and also check that the queue
name does not contain "." character when it is used as the
durable name.

Resolves #473

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>