### PR TITLE
[ADDED] JetStream: HeadersOnly in consumer configuration

### DIFF
--- a/src/jsm.c
+++ b/src/jsm.c
@@ -1451,6 +1451,8 @@ _marshalConsumerCreateReq(natsBuffer **new_buf, const char *stream, jsConsumerCo
         s = natsBuf_Append(buf, ",\"flow_control\":true", -1);
     if ((s == NATS_OK) && (cfg->Heartbeat > 0))
         s = nats_marshalLong(buf, true, "idle_heartbeat", cfg->Heartbeat);
+    if ((s == NATS_OK) && cfg->HeadersOnly)
+        s = natsBuf_Append(buf, ",\"headers_only\":true", -1);
     IFOK(s, natsBuf_Append(buf, "}}", -1));
 
     if (s == NATS_OK)
@@ -1584,6 +1586,7 @@ _unmarshalConsumerConfig(nats_JSON *json, const char *fieldName, jsConsumerConfi
         IFOK(s, nats_JSONGetLong(cjson, "max_ack_pending", &(cc->MaxAckPending)));
         IFOK(s, nats_JSONGetBool(cjson, "flow_control", &(cc->FlowControl)));
         IFOK(s, nats_JSONGetLong(cjson, "idle_heartbeat", &(cc->Heartbeat)));
+        IFOK(s, nats_JSONGetBool(cjson, "headers_only", &(cc->HeadersOnly)));
     }
 
     if (s == NATS_OK)

--- a/src/nats.h
+++ b/src/nats.h
@@ -85,6 +85,17 @@ extern "C" {
  */
 #define NATS_DEFAULT_URL "nats://localhost:4222"
 
+/** \brief Message header for JetStream messages representing the message payload size
+ *
+ * When creating a JetStream consumer, if the `HeadersOnly` boolean is specified,
+ * the subscription will receive messages with headers only (no message payload),
+ * and a header of this name containing the size of the message payload that was
+ * omitted.
+ *
+ * @see jsConsumerConfig
+ */
+ #define JS_MSG_SIZE    "Nats-Msg-Size"
+
 //
 // Types.
 //
@@ -529,6 +540,10 @@ typedef struct jsStreamInfo
  *
  * \note `Durable` cannot contain the character ".".
  *
+ * \note `HeadersOnly` means that the subscription will not receive any message payload,
+ * instead, it will receive only messages headers (if present) with the addition of
+ * the header #JS_MSG_SIZE ("Nats-Msg-Size"), whose value is the payload size.
+ *
  * @see jsConsumerConfig_Init
  *
  * \code{.unparsed}
@@ -563,6 +578,7 @@ typedef struct jsConsumerConfig
         int64_t                 MaxAckPending;
         bool                    FlowControl;
         int64_t                 Heartbeat;              ///< Heartbeat interval expressed in number of nanoseconds.
+        bool                    HeadersOnly;
 
 } jsConsumerConfig;
 

--- a/test/list.txt
+++ b/test/list.txt
@@ -222,6 +222,7 @@ JetStreamSubscribeConfigCheck
 JetStreamSubscribeIdleHeartbeat
 JetStreamSubscribeFlowControl
 JetStreamSubscribePull
+JetStreamSubscribeHeadersOnly
 JetStreamOrderedCons
 JetStreamOrderedConsWithErrors
 StanPBufAllocator


### PR DESCRIPTION
This allows the user to request to receive messages with headers
only, no payload, and with an header that indicates the size
of the omitted payload.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>