### PR TITLE
Fixed auto-unsub for ordered consumers

### DIFF
--- a/test/list.txt
+++ b/test/list.txt
@@ -225,6 +225,7 @@ JetStreamSubscribePull
 JetStreamSubscribeHeadersOnly
 JetStreamOrderedCons
 JetStreamOrderedConsWithErrors
+JetStreamOrderedConsAutoUnsub
 StanPBufAllocator
 StanConnOptions
 StanSubOptions


### PR DESCRIPTION
If the user creates an ordered consumer and then set an auto-unsub
value, if the consumer is reset internally, we need to resend
an UNSUB with an adjusted max value.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>