### PR TITLE
[ADDED] JetStream: js_DeleteMsg and js_EraseMsg APIs

### DIFF
--- a/src/js.c
+++ b/src/js.c
@@ -1610,7 +1610,7 @@ natsSubscription_Fetch(natsMsgList *list, natsSubscription *sub, int batch, int6
         }
     }
 
-    natsBuf_Destroy(&buf);
+    natsBuf_Cleanup(&buf);
 
     // If count > 0 it means that we have gathered some user messages,
     // so we need to return them to the user with a NATS_OK status.

--- a/src/js.h
+++ b/src/js.h
@@ -131,6 +131,9 @@ extern const int64_t    jsDefaultRequestWait;
 // jsApiRequestNextT is the prefix for the request next message(s) for a consumer in worker/pull mode.
 #define jsApiRequestNextT "%s.CONSUMER.MSG.NEXT.%s.%s"
 
+// jsApiMsgDeleteT is the endpoint to remove a message.
+#define jsApiMsgDeleteT "%.*s.STREAM.MSG.DELETE.%s"
+
 // Creates a subject based on the option's prefix, the subject format and its values.
 #define js_apiSubj(s, o, f, ...) (nats_asprintf((s), (f), (o)->Prefix, __VA_ARGS__) < 0 ? NATS_NO_MEMORY : NATS_OK)
 

--- a/src/nats.h
+++ b/src/nats.h
@@ -251,9 +251,9 @@ typedef enum
 {
         js_DeliverAll = 0,          ///< Starts from the very beginning of a stream. This is the default.
         js_DeliverLast,             ///< Starts with the last sequence received.
-	js_DeliverNew,              ///< Starts with messages sent after the consumer is created.
+        js_DeliverNew,              ///< Starts with messages sent after the consumer is created.
         js_DeliverByStartSequence,  ///< Starts from a given sequence.
-	js_DeliverByStartTime,      ///< Starts from a given UTC time (number of nanoseconds since epoch)
+        js_DeliverByStartTime,      ///< Starts from a given UTC time (number of nanoseconds since epoch)
         js_DeliverLastPerSubject,   ///< Starts with the last message for all subjects received.
 
 } jsDeliverPolicy;
@@ -4994,6 +4994,42 @@ js_PurgeStream(jsCtx *js, const char *stream, jsOptions *opts, jsErrCode *errCod
  */
 NATS_EXTERN natsStatus
 js_DeleteStream(jsCtx *js, const char *stream, jsOptions *opts, jsErrCode *errCode);
+
+/** \brief Deletes a message from the stream.
+ *
+ * Deletes the message at sequence <c>seq</c> in the stream named <c>stream</c>.
+ *
+ * \note To completely erase the content of the deleted message when stored on disk,
+ * use #js_EraseMsg instead.
+ *
+ * @see js_EraseMsg
+ *
+ * @param js the pointer to the #jsCtx context.
+ * @param stream the name of the stream.
+ * @param seq the sequence in the stream of the message to delete.
+ * @param opts the pointer to the #jsOptions object, possibly `NULL`.
+ * @param errCode the location where to store the JetStream specific error code, or `NULL`
+ * if not needed.
+ */
+NATS_EXTERN natsStatus
+js_DeleteMsg(jsCtx *js, const char *stream, uint64_t seq, jsOptions *opts, jsErrCode *errCode);
+
+/** \brief Erases a message from the stream.
+ *
+ * Similar to #js_DeleteMsg except that the content of the deleted message is
+ * erased from stable storage.
+ *
+ * @see js_DeleteMsg
+ *
+ * @param js the pointer to the #jsCtx context.
+ * @param stream the name of the stream.
+ * @param seq the sequence in the stream of the message to erase.
+ * @param opts the pointer to the #jsOptions object, possibly `NULL`.
+ * @param errCode the location where to store the JetStream specific error code, or `NULL`
+ * if not needed.
+ */
+NATS_EXTERN natsStatus
+js_EraseMsg(jsCtx *js, const char *stream, uint64_t seq, jsOptions *opts, jsErrCode *errCode);
 
 /** \brief Retreives information from a stream.
  *

--- a/src/status.h
+++ b/src/status.h
@@ -239,6 +239,7 @@ typedef enum {
     JSConsumerExistingActiveErr = 10105,                ///< Consumer already exists and is still active
     JSConsumerReplacementWithDifferentNameErr = 10106,  ///< Consumer replacement durable config not the same
     JSConsumerDescriptionTooLongErr = 10107,            ///< Consumer description is too long
+    JSConsumerWithFlowControlNeedsHeartbeatsErr = 10108,///< Consumer with flow control also needs heartbeats
 
 } jsErrCode;
 


### PR DESCRIPTION
Those were originally not included. Adding them now before doing
the new stream's Sealed/DenyPurge/DenyDelete/AllowRollup options.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>