### PR TITLE
[UPDATED] JetStream examples

### DIFF
--- a/examples/js-pub.c
+++ b/examples/js-pub.c
@@ -85,8 +85,10 @@ int main(int argc, char **argv)
 
             // Initialize the configuration structure.
             jsStreamConfig_Init(&cfg);
-            // Since we don't provide subjects, the subjects it will default to the stream name.
             cfg.Name = stream;
+            // Set the subject
+            cfg.Subjects = (const char*[1]){subj};
+            cfg.SubjectsLen = 1;
             // Make it a memory stream.
             cfg.Storage = js_MemoryStorage;
             // Add the stream,


### PR DESCRIPTION
- Made the created stream use the `-subj` as subject instead of
the stream name.
- Create stream (if not present) in the js-sub tool, not just
the js-pub tool.
- Add 1sec HB if flow control (`-fc`) parameter is set.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>