### PR TITLE
[FIXED] JetStream: auto-ack callback ack handling

### DIFF
--- a/examples/js-sub.c
+++ b/examples/js-sub.c
@@ -38,7 +38,7 @@ onMsg(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void *closure)
     if (++count == total)
         elapsed = nats_Now() - start;
 
-    natsMsg_Ack(msg, NULL);
+    // Since this is auto-ack callback, we don't need to ack here.
     natsMsg_Destroy(msg);
 }
 

--- a/src/msg.c
+++ b/src/msg.c
@@ -680,6 +680,9 @@ natsMsg_Destroy(natsMsg *msg)
     if (msg == NULL)
         return;
 
+    if (natsMsg_isNoDestroy(msg))
+        return;
+
     if (natsGC_collect((natsGCItem *) msg))
         return;
 

--- a/src/msg.h
+++ b/src/msg.h
@@ -37,6 +37,10 @@
 #define natsMsg_isAcked(m)          (((m)->flags &   (1 << 1)) != 0)
 #define natsMsg_clearAcked(m)       ((m)->flags  &= ~(1 << 1))
 
+#define natsMsg_setNoDestroy(m)     ((m)->flags  |=  (1 << 2))
+#define natsMsg_isNoDestroy(m)      (((m)->flags &   (1 << 2)) != 0)
+#define natsMsg_clearNoDestroy(m)   ((m)->flags  &= ~(1 << 2))
+
 struct __natsMsg
 {
     natsGCItem          gc;


### PR DESCRIPTION
If a message is already ack'ed (except for natsMsg_InProgress()),
the library should not attempt to ack the message when the
callback returns.
It is even more important if the user called natsMsg_Nak() since
if the callback ack'ed the message, it would defeat the purpose
of the Nak.

Resolves #492

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>