### PR TITLE
[FIXED] JetStream: do not send acks for js_AckNone subscriptions

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -2633,6 +2633,9 @@ natsConn_processMsg(natsConnection *nc, char *buf, int bufLen)
         {
             bool signal= false;
 
+            if ((jsi != NULL) && jsi->ackNone)
+                natsMsg_setAcked(msg);
+
             if (sub->msgList.msgs > sub->msgsMax)
                 sub->msgsMax = sub->msgList.msgs;
 

--- a/src/js.c
+++ b/src/js.c
@@ -2060,9 +2060,10 @@ PROCESS_INFO:
                 jsi->pull   = isPullMode;
                 jsi->ordered= opts->Ordered;
                 jsi->dseq   = 1;
+                jsi->ackNone= opts->Config.AckPolicy == js_AckNone;
                 js_retain(js);
 
-                if ((usrCB != NULL) && !opts->ManualAck && (opts->Config.AckPolicy != js_AckNone))
+                if ((usrCB != NULL) && !opts->ManualAck && !jsi->ackNone)
                 {
                     // Keep track of user provided CB and closure
                     jsi->usrCb          = usrCB;

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -351,6 +351,7 @@ typedef struct __jsSub
     bool                pull;
     bool                ordered;
     bool                dc; // delete JS consumer in Unsub()/Drain()
+    bool                ackNone;
 
     int64_t             hbi;
     int64_t             active;


### PR DESCRIPTION
When a subscription is for a consumer with js_AckNone AckPolicy,
there is no point sending ACK messages to the server since these
would be ignored.

Resolves #494

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>