### PR TITLE
[FIXED] GCC warning on format strings

### DIFF
--- a/examples/asynctimeout.c
+++ b/examples/asynctimeout.c
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
 
     if (s != NATS_OK)
     {
-        printf("Error: %d - %s\n", s, natsStatus_GetText(s));
+        printf("Error: %u - %s\n", s, natsStatus_GetText(s));
         nats_PrintLastErrorStack(stderr);
     }
 

--- a/examples/connect.c
+++ b/examples/connect.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 
     if (s != NATS_OK)
     {
-        printf("Error: %d - %s\n", s, natsStatus_GetText(s));
+        printf("Error: %u - %s\n", s, natsStatus_GetText(s));
         nats_PrintLastErrorStack(stderr);
         exit(1);
     }
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
 
     if (s != NATS_OK)
     {
-        printf("Error: %d - %s\n", s, natsStatus_GetText(s));
+        printf("Error: %u - %s\n", s, natsStatus_GetText(s));
         nats_PrintLastErrorStack(stderr);
         exit(1);
     }
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
 
     if (s != NATS_OK)
     {
-        printf("Error: %d - %s\n", s, natsStatus_GetText(s));
+        printf("Error: %u - %s\n", s, natsStatus_GetText(s));
         nats_PrintLastErrorStack(stderr);
         exit(1);
     }

--- a/examples/examples.h
+++ b/examples/examples.h
@@ -417,7 +417,7 @@ parseArgs(int argc, char **argv, const char *usage)
 
     if (s != NATS_OK)
     {
-        printf("Error parsing arguments: %d - %s\n",
+        printf("Error parsing arguments: %u - %s\n",
                s, natsStatus_GetText(s));
 
         nats_PrintLastErrorStack(stderr);

--- a/examples/js-pub.c
+++ b/examples/js-pub.c
@@ -24,7 +24,7 @@ _jsPubErr(jsCtx *js, jsPubAckErr *pae, void *closure)
 {
     int *errors = (int*) closure;
 
-    printf("Error: %d - Code: %d - Text: %s\n", pae->Err, pae->ErrCode, pae->ErrText);
+    printf("Error: %u - Code: %u - Text: %s\n", pae->Err, pae->ErrCode, pae->ErrText);
     printf("Original message: %.*s\n", natsMsg_GetDataLength(pae->Msg), natsMsg_GetData(pae->Msg));
 
     *errors = (*errors + 1);
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
     }
     if (s != NATS_OK)
     {
-        printf("Error: %d - %s - jerr=%d\n", s, natsStatus_GetText(s), jerr);
+        printf("Error: %u - %s - jerr=%u\n", s, natsStatus_GetText(s), jerr);
         nats_PrintLastErrorStack(stderr);
     }
 

--- a/examples/js-sub.c
+++ b/examples/js-sub.c
@@ -45,7 +45,7 @@ onMsg(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void *closure)
 static void
 asyncCb(natsConnection *nc, natsSubscription *sub, natsStatus err, void *closure)
 {
-    printf("Async error: %d - %s\n", err, natsStatus_GetText(err));
+    printf("Async error: %u - %s\n", err, natsStatus_GetText(err));
 
     natsSubscription_GetDropped(sub, (int64_t*) &dropped);
 }
@@ -218,7 +218,7 @@ int main(int argc, char **argv)
     }
     else
     {
-        printf("Error: %d - %s - jerr=%d\n", s, natsStatus_GetText(s), jerr);
+        printf("Error: %u - %s - jerr=%u\n", s, natsStatus_GetText(s), jerr);
         nats_PrintLastErrorStack(stderr);
     }
 

--- a/examples/publisher.c
+++ b/examples/publisher.c
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
     }
     else
     {
-        printf("Error: %d - %s\n", s, natsStatus_GetText(s));
+        printf("Error: %u - %s\n", s, natsStatus_GetText(s));
         nats_PrintLastErrorStack(stderr);
     }
 

--- a/examples/queuegroup.c
+++ b/examples/queuegroup.c
@@ -44,7 +44,7 @@ onMsg(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void *closure)
 static void
 asyncCb(natsConnection *nc, natsSubscription *sub, natsStatus err, void *closure)
 {
-    printf("Async error: %d - %s\n", err, natsStatus_GetText(err));
+    printf("Async error: %u - %s\n", err, natsStatus_GetText(err));
 }
 
 int main(int argc, char **argv)
@@ -127,7 +127,7 @@ int main(int argc, char **argv)
     }
     else
     {
-        printf("Error: %d - %s\n", s, natsStatus_GetText(s));
+        printf("Error: %u - %s\n", s, natsStatus_GetText(s));
         nats_PrintLastErrorStack(stderr);
     }
 

--- a/examples/replier.c
+++ b/examples/replier.c
@@ -46,7 +46,7 @@ static void
 asyncCb(natsConnection *nc, natsSubscription *sub, natsStatus err, void *closure)
 {
     if (print)
-        printf("Async error: %d - %s\n", err, natsStatus_GetText(err));
+        printf("Async error: %u - %s\n", err, natsStatus_GetText(err));
 
     natsSubscription_GetDropped(sub, (int64_t*) &dropped);
 }
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
     }
     else
     {
-        printf("Error: %d - %s\n", s, natsStatus_GetText(s));
+        printf("Error: %u - %s\n", s, natsStatus_GetText(s));
         nats_PrintLastErrorStack(stderr);
     }
 

--- a/examples/requestor.c
+++ b/examples/requestor.c
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
     }
     else
     {
-        printf("Error: %d - %s\n", s, natsStatus_GetText(s));
+        printf("Error: %u - %s\n", s, natsStatus_GetText(s));
         nats_PrintLastErrorStack(stderr);
     }
 

--- a/examples/subscriber.c
+++ b/examples/subscriber.c
@@ -43,7 +43,7 @@ static void
 asyncCb(natsConnection *nc, natsSubscription *sub, natsStatus err, void *closure)
 {
     if (print)
-        printf("Async error: %d - %s\n", err, natsStatus_GetText(err));
+        printf("Async error: %u - %s\n", err, natsStatus_GetText(err));
 
     natsSubscription_GetDropped(sub, (int64_t*) &dropped);
 }
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
     }
     else
     {
-        printf("Error: %d - %s\n", s, natsStatus_GetText(s));
+        printf("Error: %u - %s\n", s, natsStatus_GetText(s));
         nats_PrintLastErrorStack(stderr);
     }
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -3470,7 +3470,7 @@ _pushDrainErr(natsConnection *nc, natsStatus s, const char *errTxt)
     if (nc->opts->asyncErrCb != NULL)
     {
         char tmp[256];
-        snprintf(tmp, sizeof(tmp), "Drain error: %s: %d (%s)", errTxt, s, natsStatus_GetText(s));
+        snprintf(tmp, sizeof(tmp), "Drain error: %s: %u (%s)", errTxt, s, natsStatus_GetText(s));
         natsAsyncCb_PostErrHandler(nc, NULL, s, NATS_STRDUP(tmp));
     }
     natsConn_Unlock(nc);

--- a/src/js.c
+++ b/src/js.c
@@ -1069,7 +1069,7 @@ jsSub_deleteConsumerAfterDrain(natsSubscription *sub)
         if (nc->opts->asyncErrCb != NULL)
         {
             char tmp[256];
-            snprintf(tmp, sizeof(tmp), "failed to delete consumer '%s': %d (%s)",
+            snprintf(tmp, sizeof(tmp), "failed to delete consumer '%s': %u (%s)",
                     consumer, s, natsStatus_GetText(s));
             natsAsyncCb_PostErrHandler(nc, sub, s, NATS_STRDUP(tmp));
         }
@@ -2515,7 +2515,7 @@ _recreateOrderedCons(void *closure)
         if (nc->opts->asyncErrCb != NULL)
         {
             char tmp[256];
-            snprintf(tmp, sizeof(tmp), "failed recreating ordered consumer: %d (%s)",
+            snprintf(tmp, sizeof(tmp), "failed recreating ordered consumer: %u (%s)",
                      s, natsStatus_GetText(s));
             natsAsyncCb_PostErrHandler(nc, sub, s, NATS_STRDUP(tmp));
         }

--- a/src/nats.c
+++ b/src/nats.c
@@ -1253,7 +1253,7 @@ nats_GetVersionNumber(void)
 static void
 _versionGetString(char *buffer, size_t bufLen, uint32_t verNumber)
 {
-    snprintf(buffer, bufLen, "%d.%d.%d",
+    snprintf(buffer, bufLen, "%u.%u.%u",
              ((verNumber >> 16) & 0xF),
              ((verNumber >> 8) & 0xF),
              (verNumber & 0xF));
@@ -1593,7 +1593,7 @@ nats_PrintLastErrorStack(FILE *file)
     if ((errTL == NULL) || (errTL->sts == NATS_OK) || (errTL->framesCount == -1))
         return;
 
-    fprintf(file, "Error: %d - %s",
+    fprintf(file, "Error: %u - %s",
             errTL->sts, natsStatus_GetText(errTL->sts));
     if (errTL->text[0] != '\0')
         fprintf(file, " - %s", errTL->text);

--- a/src/parser.c
+++ b/src/parser.c
@@ -902,7 +902,7 @@ parseErr:
     natsMutex_Lock(nc->mu);
 
     snprintf(nc->errStr, sizeof(nc->errStr),
-             "Parse Error [%d]: '%.*s'",
+             "Parse Error [%u]: '%.*s'",
              nc->ps->state,
              bufLen - i,
              buf + i);

--- a/test/test.c
+++ b/test/test.c
@@ -11263,7 +11263,7 @@ test_Flush(void)
         if ((s == NATS_OK) && (args[i].s != NATS_OK))
         {
             s = args[i].s;
-            printf("t=%d s=%d\n", i, s);
+            printf("t=%d s=%u\n", i, s);
         }
     }
     if (s == NATS_OK)


### PR DESCRIPTION
Fixes following series of GCC warnings using `-Wformat-signedness/-Wformat`

`warning: format ‘%d’ expects argument of type ‘int’, but argument XX has type ‘unsigned int’ [-Wformat=]`