### PR TITLE
Fixed warning about uninitialized variable

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -1849,7 +1849,7 @@ natsStatus
 nats_Base64_Decode(const char *src, unsigned char **dst, int *dstLen)
 {
     natsStatus  s;
-    int         sl;
+    int         sl = 0;
 
     *dst = NULL;
     *dstLen = 0;


### PR DESCRIPTION
There was a warning regarding a variable that may be uninitialized.
This was a false positive in that we would not call nats_Base64_DecodeInPlace()
if nats_Base64_DecodeLen() did not return NATS_OK. When returning
OK, `sl` would be initialized. Still, easy to fix that by just
setting `sl` to 0 during declaration.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>