### PR TITLE
[FIXED] JetStream subscription using ">"

### DIFF
--- a/test/list.txt
+++ b/test/list.txt
@@ -226,6 +226,7 @@ JetStreamSubscribeHeadersOnly
 JetStreamOrderedCons
 JetStreamOrderedConsWithErrors
 JetStreamOrderedConsAutoUnsub
+JetStreamSubscribeWithFWC
 JetStreamStreamsSealAndRollup
 JetStreamGetMsgAndLastMsg
 KeyValueManager


### PR DESCRIPTION
The issue was actually caused by JSON parsing, so that could manifest
in other situations.
But for the reported issue, if a consumer was created with a filter
subject that contained the ">" wildcard and the user creates a
subscription with that same subject, the check for filter subject
match would fail because "test.>" is different than "test.\u003e".

Resolves #502

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>