### PR TITLE
[FIXED] test: fix assign instead of compare

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -390,8 +390,8 @@ static void test_natsBuffer(void)
             && (strcmp(backend, "abcd") == 0));
 
     test("Changing backend is reflected in buffer: ");
+    backend[1] = 'x';
     testCond((s == NATS_OK)
-             && (backend[1] = 'x')
              && (natsBuf_Data(buf)[1] == 'x'));
 
     test("Append less than capacity does not expand buffer: ");


### PR DESCRIPTION
Since it is a test condition the intent here is to compare and not to assign a value

Signed-off-by: Paolo Teti <paolo.teti@gmail.com>