### PR TITLE
[FIXED] nuid: fix wrong sizeof in memset

### DIFF
--- a/src/nuid.c
+++ b/src/nuid.c
@@ -208,7 +208,7 @@ natsNUID_init(void)
     natsStatus      s;
     unsigned int    seed = (unsigned int) nats_NowInNanoSeconds();
 
-    memset(&globalNUID, 0, sizeof(natsNUID));
+    memset(&globalNUID, 0, sizeof(natsLockedNUID));
 
     srand(seed);
     _initCMWC(seed);


### PR DESCRIPTION
Fixes following Coverity issue:

Passing argument &globalNUID of type natsLockedNUID * and
argument 32UL (sizeof (natsNUID)) to function memset is suspicious
because sizeof (natsLockedNUID) /*40*/ is expected.


Signed-off-by: Paolo Teti <paolo.teti@gmail.com>