### PR TITLE
Set return code on _connect() correctly

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -1945,8 +1945,7 @@ _connect(natsConnection *nc)
             {
                 if (natsConn_isClosed(nc))
                 {
-                    if (s == NATS_OK)
-                        s = NATS_CONNECTION_CLOSED;
+                    s = NATS_CONNECTION_CLOSED;
                     break;
                 }
 


### PR DESCRIPTION
As s is not possible to be NAST_OK here.
Directly set s to NATS_CONNECTION_CLOSED.

Signed-off-by: yuchenlin <yuchenlin@synology.com>