### PR TITLE
[FIXED] Coverity Scan unchecked return value

### DIFF
--- a/src/msg.c
+++ b/src/msg.c
@@ -73,7 +73,7 @@ natsMsgHeader_encode(natsBuffer *buf, natsMsg *msg)
     // See explanation in natsMsgHeader_encodedLen()
     if (natsMsg_needsLift(msg))
     {
-        natsBuf_Append(buf, (const char*) msg->hdr, msg->hdrLen);
+        s = natsBuf_Append(buf, (const char*) msg->hdr, msg->hdrLen);
         return NATS_UPDATE_ERR_STACK(s);
     }
 

--- a/src/util.c
+++ b/src/util.c
@@ -1967,9 +1967,10 @@ nats_ReadFile(natsBuffer **buffer, int initBufSize, const char *fn)
     else if (fclose(f) != 0)
         s = nats_setError(NATS_ERR, "error closing file '%s': '%s", fn, strerror(errno));
 
+    IFOK(s, natsBuf_AppendByte(buf, '\0'));
+
     if (s == NATS_OK)
     {
-        natsBuf_AppendByte(buf, '\0');
         *buffer = buf;
     }
     else if (buf != NULL)


### PR DESCRIPTION
Propagate error code to fix two unchecked return value issues reported by Coverity Scan.

Signed-off-by: Paolo Teti <paolo.teti@gmail.com>