### PR TITLE
[FIXED] KV: Support for JetStream prefix

### DIFF
--- a/src/natsp.h
+++ b/src/natsp.h
@@ -401,6 +401,7 @@ struct __kvStore
     char                *bucket;
     char                *stream;
     char                *pre;
+    bool                useJSPrefix;
 
 };
 

--- a/test/list.txt
+++ b/test/list.txt
@@ -237,6 +237,7 @@ KeyValueHistory
 KeyValueKeys
 KeyValueDeleteVsPurge
 KeyValueDeleteTombstones
+KeyValueCrossAccount
 StanPBufAllocator
 StanConnOptions
 StanSubOptions


### PR DESCRIPTION
When the JetStream context has a prefix, will use that for all
KV APIs as specified by ADR #19

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>