### PR TITLE
[ADDED] Custom inbox prefix option

### DIFF
--- a/src/conn.h
+++ b/src/conn.h
@@ -142,6 +142,12 @@ natsConn_sendUnsubProto(natsConnection *nc, int64_t subId, int max);
 void
 natsConn_setFilterWithClosure(natsConnection *nc, natsMsgFilter f, void* closure);
 
+natsStatus
+natsConn_initInbox(natsConnection *nc, char *buf, int bufSize, char **newInbox, bool *allocated);
+
+natsStatus
+natsConn_newInbox(natsConnection *nc, natsInbox **newInbox);
+
 void
 natsConn_close(natsConnection *nc);
 

--- a/src/nats.h
+++ b/src/nats.h
@@ -2754,6 +2754,26 @@ natsOptions_SetWriteDeadline(natsOptions *opts, int64_t deadline);
 NATS_EXTERN natsStatus
 natsOptions_DisableNoResponders(natsOptions *opts, bool disabled);
 
+/** \brief Sets a custom inbox prefix
+ *
+ * The default inbox prefix is "_INBOX.", but you can change it
+ * using this option. This can be useful when setting permissions
+ * and/or with import/exports across different accounts.
+ *
+ * The prefix must not contain the `*` or `>` wildcard and must
+ * be a well formed subject. The exception is that the prefix
+ * can be set by the user with a terminal token separator. If not
+ * set, the library will internally add it.
+ *
+ * To clear the custom inbox prefix, call this function with `NULL`
+ * or the empty string.
+ *
+ * @param opts the pointer to the #natsOptions object.
+ * @param inboxPrefix the desired inbox prefix.
+ */
+NATS_EXTERN natsStatus
+natsOptions_SetCustomInboxPrefix(natsOptions *opts, const char *inboxPrefix);
+
 /** \brief Destroys a #natsOptions object.
  *
  * Destroys the natsOptions object, freeing used memory. See the note in

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -89,12 +89,10 @@
 #define _OK_OP_LEN_         (3)
 #define _ERR_OP_LEN_        (4)
 
-#define NATS_INBOX_PRE_LEN  (7)
+#define NATS_DEFAULT_INBOX_PRE      "_INBOX."
+#define NATS_DEFAULT_INBOX_PRE_LEN  (7)
 
-#define NATS_REQ_ID_OFFSET  (NATS_INBOX_PRE_LEN + NUID_BUFFER_LEN + 1)
 #define NATS_MAX_REQ_ID_LEN (19) // to display 2^63-1 number
-
-#define NATS_INBOX_ARRAY_SIZE   (NATS_INBOX_PRE_LEN + NUID_BUFFER_LEN + 1)
 
 #define WAIT_FOR_READ       (0)
 #define WAIT_FOR_WRITE      (1)
@@ -306,6 +304,9 @@ struct __natsOptions
 
     // Disable the "no responders" feature.
     bool disableNoResponders;
+
+    // Custom inbox prefix
+    char *inboxPfx;
 };
 
 typedef struct __nats_MsgList
@@ -337,6 +338,7 @@ struct __jsCtx
     natsStrHash         *pm;
     natsSubscription    *rsub;
     char                *rpre;
+    int                 rpreLen;
     int                 pacw;
     int64_t             pmcount;
     int                 stalled;
@@ -659,6 +661,12 @@ struct __natsConnection
     int                 respPoolSize;
     int                 respPoolIdx;
 
+    // For inboxes. We now support custom prefixes, so we can't rely
+    // on constants based on hardcoded "_INBOX." prefix.
+    const char          *inboxPfx;
+    int                 inboxPfxLen;
+    int                 reqIdOffset;
+
     struct
     {
         bool            attached;
@@ -713,9 +721,6 @@ nats_sslRegisterThreadForCleanup(void);
 
 natsStatus
 nats_sslInit(void);
-
-natsStatus
-natsInbox_init(char *inbox, int inboxLen);
 
 natsStatus
 natsLib_msgDeliveryPostControlMsg(natsSubscription *sub);

--- a/src/stan/conn.c
+++ b/src/stan/conn.c
@@ -372,7 +372,7 @@ stanConnection_Connect(stanConnection **newConn, const char* clusterID, const ch
 
     // Create HB inbox and a subscription on that
     if (s == NATS_OK)
-        s = natsInbox_Create(&sc->hbInbox);
+        s = natsConn_newInbox(sc->nc, &sc->hbInbox);
     if (s == NATS_OK)
     {
         s = natsConn_subscribeNoPool(&sc->hbSubscription, sc->nc, sc->hbInbox, _processHeartBeat, NULL);
@@ -388,7 +388,7 @@ stanConnection_Connect(stanConnection **newConn, const char* clusterID, const ch
     // Prepare a subscription on ping responses
     if (s == NATS_OK)
     {
-        s = natsInbox_Create((char**) &pingInbox);
+        s = natsConn_newInbox(sc->nc, (natsInbox**) &pingInbox);
         if (s == NATS_OK)
             s = natsConn_subscribeNoPool(&pingSub, sc->nc, pingInbox, _processPingResponse, (void*) sc);
         if (s == NATS_OK)

--- a/src/stan/sub.c
+++ b/src/stan/sub.c
@@ -382,7 +382,7 @@ stanConn_subscribe(stanSubscription **newSub, stanConnection *sc,
     if (s == NATS_OK)
         s = natsPBufAllocator_Create(&sub->allocator, sizeof(Pb__MsgProto), 3);
     if (s == NATS_OK)
-        s = natsInbox_Create((natsInbox**) &sub->inbox);
+        s = natsConn_newInbox(nc, (natsInbox**) &sub->inbox);
 
     if (s == NATS_OK)
     {

--- a/test/list.txt
+++ b/test/list.txt
@@ -120,6 +120,7 @@ RequestMuxWithMappedSubject
 OldRequest
 SimultaneousRequests
 RequestClose
+CustomInbox
 FlushInCb
 ReleaseFlush
 FlushErrOnDisconnect


### PR DESCRIPTION
Ability to set a custom inbox prefix using the option:
`natsOptions_SetCustomInboxPrefix()`.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>