### PR TITLE
Better validate subject helper

### DIFF
--- a/src/nats.h
+++ b/src/nats.h
@@ -2756,14 +2756,12 @@ natsOptions_DisableNoResponders(natsOptions *opts, bool disabled);
 
 /** \brief Sets a custom inbox prefix
  *
- * The default inbox prefix is "_INBOX.", but you can change it
+ * The default inbox prefix is "_INBOX", but you can change it
  * using this option. This can be useful when setting permissions
  * and/or with import/exports across different accounts.
  *
- * The prefix must not contain the `*` or `>` wildcard and must
- * be a well formed subject. The exception is that the prefix
- * can be set by the user with a terminal token separator. If not
- * set, the library will internally add it.
+ * The prefix must be a valid subject and not contain any of the
+ * wildcards tokens `*` nor `>`.
  *
  * To clear the custom inbox prefix, call this function with `NULL`
  * or the empty string.

--- a/src/util.h
+++ b/src/util.h
@@ -237,4 +237,7 @@ nats_marshalLong(natsBuffer *buf, bool comma, const char *fieldName, int64_t lva
 natsStatus
 nats_marshalULong(natsBuffer *buf, bool comma, const char *fieldName, uint64_t uval);
 
+bool
+nats_IsSubjectValid(const char *subject, bool wcAllowed);
+
 #endif /* UTIL_H_ */


### PR DESCRIPTION
Also changed the custom inbox prefix option setter to make "." as
the last character invalid (to align with Go client).

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>