### PR TITLE
Fixed InactiveThreshold consumer configuration handling

### DIFF
--- a/src/jsm.c
+++ b/src/jsm.c
@@ -1710,6 +1710,8 @@ _marshalConsumerCreateReq(natsBuffer **new_buf, const char *stream, jsConsumerCo
         s = nats_marshalLong(buf, true, "max_batch", cfg->MaxRequestBatch);
     if ((s == NATS_OK) && (cfg->MaxRequestExpires > 0))
         s = nats_marshalLong(buf, true, "max_expires", cfg->MaxRequestExpires);
+    if ((s == NATS_OK) && (cfg->InactiveThreshold > 0))
+        s = nats_marshalLong(buf, true, "inactive_threshold", cfg->InactiveThreshold);
     if ((s == NATS_OK) && (cfg->BackOff != NULL) && (cfg->BackOffLen > 0))
     {
         char    tmp[32];
@@ -1862,6 +1864,7 @@ _unmarshalConsumerConfig(nats_JSON *json, const char *fieldName, jsConsumerConfi
         IFOK(s, nats_JSONGetBool(cjson, "headers_only", &(cc->HeadersOnly)));
         IFOK(s, nats_JSONGetLong(cjson, "max_batch", &(cc->MaxRequestBatch)));
         IFOK(s, nats_JSONGetLong(cjson, "max_expires", &(cc->MaxRequestExpires)));
+        IFOK(s, nats_JSONGetLong(cjson, "inactive_threshold", &(cc->InactiveThreshold)));
         IFOK(s, nats_JSONGetArrayLong(cjson, "backoff", &(cc->BackOff), &(cc->BackOffLen)));
     }
 


### PR DESCRIPTION
The field was not (un)marshal'ed and the test that was supposed
to check the feature was actually checking the opposite, that is,
that the consumer was found instead of not found !!!

Related to #515

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>