### PR TITLE
[ADDED] kvStore_GetRevision() API

### DIFF
--- a/src/kv.h
+++ b/src/kv.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The NATS Authors
+// Copyright 2021-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -22,3 +22,4 @@
 #define kvErrBadBucket              "bucket not valid key-value store"
 #define kvErrBucketNotFound         "bucket not found"
 #define kvErrInvalidKey             "invalid key"
+#define kvErrInvalidRevision        "invalid revision"

--- a/src/nats.h
+++ b/src/nats.h
@@ -6082,6 +6082,21 @@ kvEntry_Destroy(kvEntry *e);
 NATS_EXTERN natsStatus
 kvStore_Get(kvEntry **new_entry, kvStore *kv, const char *key);
 
+/** \brief Returns the entry at the specific revision for the key.
+ *
+ * Returns the entry at the specific revision for the key, or #NATS_NOT_FOUND if there is no
+ * entry for that key and revision.
+ *
+ * \note The entry should be destroyed to release memory using #kvEntry_Destroy.
+ *
+ * @param new_entry the location where to store the pointer to the entry associated with the `key`.
+ * @param kv the pointer to the #kvStore object.
+ * @param key the name of the key.
+ * @param revision the revision of the entry (must be > 0).
+ */
+NATS_EXTERN natsStatus
+kvStore_GetRevision(kvEntry **new_entry, kvStore *kv, const char *key, uint64_t revision);
+
 /** \brief Places the new value for the key into the store.
  *
  * Places the new value for the key into the store.


### PR DESCRIPTION
Ability to get a key at a specific revision. Returns #NATS_NOT_FOUND
if no entry exists for this key at this revision.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>