### PR TITLE
[CHANGED] PurgeDeletes() will now keep markers that are less than 30min old

### DIFF
--- a/src/kv.c
+++ b/src/kv.c
@@ -556,10 +556,12 @@ kvStore_UpdateString(uint64_t *rev, kvStore *kv, const char *key, const char *da
 }
 
 static natsStatus
-_delete(kvStore *kv, const char *key, bool purge)
+_delete(kvStore *kv, const char *key, bool purge, kvPurgeOptions *opts)
 {
-    natsStatus  s;
-    natsMsg     *msg = NULL;
+    natsStatus      s;
+    natsMsg         *msg = NULL;
+    jsPubOptions    o;
+    jsPubOptions    *po = NULL;
     DEFINE_BUF_FOR_SUBJECT;
 
     if (kv == NULL)
@@ -582,7 +584,13 @@ _delete(kvStore *kv, const char *key, bool purge)
             s = natsMsgHeader_Set(msg, kvOpHeader, kvOpDeleteStr);
         }
     }
-    IFOK(s, js_PublishMsg(NULL, kv->js, msg, NULL, NULL));
+    if (purge && (opts != NULL) && (opts->Timeout > 0))
+    {
+        jsPubOptions_Init(&o);
+        o.MaxWait = opts->Timeout;
+        po = &o;
+    }
+    IFOK(s, js_PublishMsg(NULL, kv->js, msg, po, NULL));
 
     natsBuf_Cleanup(&buf);
     natsMsg_Destroy(msg);
@@ -592,19 +600,29 @@ _delete(kvStore *kv, const char *key, bool purge)
 natsStatus
 kvStore_Delete(kvStore *kv, const char *key)
 {
-    natsStatus s = _delete(kv, key, false);
+    natsStatus s = _delete(kv, key, false, NULL);
     return NATS_UPDATE_ERR_STACK(s);
 }
 
 natsStatus
-kvStore_Purge(kvStore *kv, const char *key)
+kvStore_Purge(kvStore *kv, const char *key, kvPurgeOptions *opts)
 {
-    natsStatus s = _delete(kv, key, true);
+    natsStatus s = _delete(kv, key, true, opts);
     return NATS_UPDATE_ERR_STACK(s);
 }
 
 natsStatus
-kvStore_PurgeDeletes(kvStore *kv, kvWatchOptions *opts)
+kvPurgeOptions_Init(kvPurgeOptions *opts)
+{
+    if (opts == NULL)
+        return nats_setDefaultError(NATS_INVALID_ARG);
+
+    memset(opts, 0, sizeof(kvPurgeOptions));
+    return NATS_OK;
+}
+
+natsStatus
+kvStore_PurgeDeletes(kvStore *kv, kvPurgeOptions *opts)
 {
     natsStatus      s;
     kvWatcher       *w = NULL;
@@ -613,8 +631,16 @@ kvStore_PurgeDeletes(kvStore *kv, kvWatchOptions *opts)
     kvEntry         *t = NULL;
     natsBuffer      buf;
     char            buffer[128];
+    kvWatchOptions  wo;
+    kvWatchOptions  *wpo = NULL;
 
-    s = kvStore_WatchAll(&w, kv, opts);
+    if ((opts != NULL) && (opts->Timeout > 0))
+    {
+        kvWatchOptions_Init(&wo);
+        wo.Timeout = opts->Timeout;
+        wpo = &wo;
+    }
+    s = kvStore_WatchAll(&w, kv, wpo);
     if (s != NATS_OK)
         return NATS_UPDATE_ERR_STACK(s);
 
@@ -637,7 +663,16 @@ kvStore_PurgeDeletes(kvStore *kv, kvWatchOptions *opts)
     }
     if ((s == NATS_OK) && (h != NULL))
     {
-        jsOptions po;
+        jsOptions   po;
+        int64_t     olderThan = (opts != NULL ? opts->DeleteMarkersOlderThan : 0);
+        int64_t     limit = 0;
+
+        // Negative value is used to instruct to always remove markers, regardless
+        // of age. If set to 0 (or not set), use our default value.
+        if (olderThan == 0)
+            olderThan = NATS_SECONDS_TO_NANOS(30*60); // 30 minutes
+        else if (olderThan > 0)
+            limit = nats_NowInNanoSeconds() - olderThan;
 
         jsOptions_Init(&po);
 
@@ -654,6 +689,12 @@ kvStore_PurgeDeletes(kvStore *kv, kvWatchOptions *opts)
             if (s == NATS_OK)
             {
                 po.Stream.Purge.Subject = (const char*) natsBuf_Data(&buf);
+                po.Stream.Purge.Keep = 0;
+                if ((olderThan > 0) && (kvEntry_Created(h) >= limit))
+                {
+                    // Keep this marker since it is more recent than the threshold.
+                    po.Stream.Purge.Keep = 1;
+                }
                 s = js_PurgeStream(kv->js, kv->stream, &po, NULL);
             }
             e = h;
@@ -1023,6 +1064,12 @@ kvStore_History(kvEntryList *list, kvStore *kv, const char *key, kvWatchOptions 
         else
             kvEntry_Destroy(e);
     }
+    // Go client returns "not found" if the subject exists, but
+    // there is nothing to return, so basically after a purge deletes,
+    // a key has no data and no marker, and we return "not found".
+    if ((s == NATS_OK) && (list->Count == 0))
+        return NATS_NOT_FOUND;
+
     return NATS_UPDATE_ERR_STACK(s);
 }
 

--- a/test/list.txt
+++ b/test/list.txt
@@ -240,6 +240,7 @@ KeyValueHistory
 KeyValueKeys
 KeyValueDeleteVsPurge
 KeyValueDeleteTombstones
+KeyValueDeleteMarkerThreshold
 KeyValueCrossAccount
 StanPBufAllocator
 StanConnOptions


### PR DESCRIPTION
There is a breaking change where kvStore_PurgeDeletes() accepts now
kvPurgeOptions instead of kvWatchOptions.

We needed from kvWatchOptions only the timeout, and as it standed, it was
bad since user could have passed watcher options that would have
affected the internal watcher that we make to collect delete markers.

Also, when invoking kvStore_PurgeDeletes(), the delete markers that
are older than a default of 30 minutes will be deleted, however more
recent ones will be kept. The data is always removed, even if a marker
is not.

The user can change the 30 minutes threshold using a new purge
option called kvPurgeOptions.DeleteMarkersOlderThan. If set to -1,
it restores the old behavior of deleting delete/purge markers,
regardless of their age.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>