### PR TITLE
JetStream: auto-ack callback would do sync acks

### DIFF
--- a/src/js.c
+++ b/src/js.c
@@ -1025,7 +1025,7 @@ _autoAckCB(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void *closur
     // Invoke user callback
     (jsi->usrCb)(nc, sub, msg, jsi->usrCbClosure);
 
-    natsMsg_Ack(msg, &(jsi->js->opts));
+    natsMsg_Ack(msg, NULL);
     natsMsg_clearNoDestroy(msg);
     natsMsg_Destroy(msg);
 }

--- a/test/test.c
+++ b/test/test.c
@@ -24009,6 +24009,11 @@ test_JetStreamSubscribe(void)
     for (i=0; (s == NATS_OK) && (i < 3); i++)
     {
         s = natsSubscription_NextMsg(&ack, ackSub, 1000);
+        if (s == NATS_OK)
+        {
+            // Make sure this was not a sync call...
+            s = (natsMsg_GetReply(ack) == NULL ? NATS_OK : NATS_ERR);
+        }
         natsMsg_Destroy(ack);
         ack = NULL;
     }


### PR DESCRIPTION
This is due to a change in PR #516 that is making any Ack call
that passes an option to transform the call to sync calls if
option has a Wait value set.
The auto-ack callback was calling ack with the jetstream's context
options, which has always a Wait by default of 5sec.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>