### PR TITLE
[FIXED] Connection fails if URL is missing port

### DIFF
--- a/src/natsp.h
+++ b/src/natsp.h
@@ -98,8 +98,6 @@
 #define WAIT_FOR_WRITE      (1)
 #define WAIT_FOR_CONNECT    (2)
 
-#define DEFAULT_PORT_STRING "4222"
-
 #define DEFAULT_DRAIN_TIMEOUT   30000 // 30 seconds
 
 #define MAX_FRAMES (50)


### PR DESCRIPTION
With missing port, we should default to 4222.

Resolves #530

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>