### PR TITLE
[UPDATED] js_CreateKeyValue updates discard policy to new

### DIFF
--- a/test/list.txt
+++ b/test/list.txt
@@ -243,6 +243,7 @@ KeyValueDeleteVsPurge
 KeyValueDeleteTombstones
 KeyValueDeleteMarkerThreshold
 KeyValueCrossAccount
+KeyValueDiscardOldToNew
 StanPBufAllocator
 StanConnOptions
 StanSubOptions


### PR DESCRIPTION
If running against a v2.7.2+ server, the discard policy of an
existing KV stream will be updated to discard new policy.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>