### PR TITLE
[FIXED] JetStream: stream and/or consumer name checks

### DIFF
--- a/src/js.c
+++ b/src/js.c
@@ -1884,7 +1884,7 @@ natsStatus
 js_checkDurName(const char *dur)
 {
     if (strchr(dur, '.') != NULL)
-        return nats_setError(NATS_INVALID_ARG, "invalid durable name '%s' (cannot contain '.')", dur);
+        return nats_setError(NATS_INVALID_ARG, "%s '%s' (cannot contain '.')", jsErrInvalidDurableName, dur);
     return NATS_OK;
 }
 

--- a/src/js.h
+++ b/src/js.h
@@ -60,6 +60,11 @@ extern const int64_t    jsDefaultRequestWait;
 #define jsErrOrderedConsNoQueue             "queue can not be set for an ordered consumer"
 #define jsErrOrderedConsNoBind              "can not bind existing consumer for an ordered consumer"
 #define jsErrOrderedConsNoPullMode          "can not use pull mode for an ordered consumer"
+#define jsErrStreamConfigRequired           "stream configuration required"
+#define jsErrInvalidStreamName              "invalid stream name"
+#define jsErrConsumerConfigRequired         "consumer configuration required"
+#define jsErrInvalidDurableName             "invalid durable name"
+#define jsErrInvalidConsumerName            "invalid consumer name"
 
 #define jsCtrlHeartbeat     (1)
 #define jsCtrlFlowControl   (2)


### PR DESCRIPTION
Some of the APIs were not properly checking for missing/invalid
stream and/or consumer names (presence of ".") which could lead
to API calls timing out because the server had no subscription
interest on the formed subject.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>