### PR TITLE
[ADDED] jsPubAckHandler to handle "positive" publish acks

### DIFF
--- a/src/msg.h
+++ b/src/msg.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The NATS Authors
+// Copyright 2015-2022 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -40,6 +40,10 @@
 #define natsMsg_setNoDestroy(m)     ((m)->flags  |=  (1 << 2))
 #define natsMsg_isNoDestroy(m)      (((m)->flags &   (1 << 2)) != 0)
 #define natsMsg_clearNoDestroy(m)   ((m)->flags  &= ~(1 << 2))
+
+#define natsMsg_setTimeout(m)       ((m)->flags  |=  (1 << 3))
+#define natsMsg_isTimeout(m)        (((m)->flags &   (1 << 3)) != 0)
+#define natsMsg_clearTimeout(m)     ((m)->flags  &= ~(1 << 3))
 
 struct __natsMsg
 {

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -329,6 +329,14 @@ typedef struct __natsMsgDlvWorker
 
 } natsMsgDlvWorker;
 
+typedef struct __pmInfo
+{
+    char                *subject;
+    int64_t             deadline;
+    struct __pmInfo     *next;
+
+} pmInfo;
+
 struct __jsCtx
 {
     natsMutex		    *mu;
@@ -337,12 +345,16 @@ struct __jsCtx
     int				    refs;
     natsCondition       *cond;
     natsStrHash         *pm;
+    natsTimer           *pmtmr;
+    pmInfo              *pmHead;
+    pmInfo              *pmTail;
     natsSubscription    *rsub;
     char                *rpre;
     int                 rpreLen;
     int                 pacw;
     int64_t             pmcount;
     int                 stalled;
+    bool                closed;
 };
 
 typedef struct __jsSub

--- a/test/list.txt
+++ b/test/list.txt
@@ -218,6 +218,7 @@ JetStreamMgtStreams
 JetStreamMgtConsumers
 JetStreamPublish
 JetStreamPublishAsync
+JetStreamPublishAckHandler
 JetStreamSubscribe
 JetStreamSubscribeSync
 JetStreamSubscribeConfigCheck


### PR DESCRIPTION
[FIXED] Ability to have async publish call timeout and invoke err handler

The new jsPubAckHandler takes precedence and is invoked even on
successful publish.

If the option MaxWait is specified on publish, then the library
will invoke the ack handler (or err handler) if a publish ack
is not received by then.

Resolves #538

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>