### PR TITLE
[ADDED] natsOptions_SetIgnoreDiscoveredServers()

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -560,7 +560,7 @@ _processInfo(natsConnection *nc, char *info, int len)
     // if advertise is disabled on that server, or servers that
     // did not include themselves in the async INFO protocol.
     // If empty, do not remove the implicit servers from the pool.
-    if ((s == NATS_OK) && (nc->info.connectURLsCount > 0))
+    if ((s == NATS_OK) && !nc->opts->ignoreDiscoveredServers && (nc->info.connectURLsCount > 0))
     {
         bool        added    = false;
         const char  *tlsName = NULL;

--- a/src/nats.h
+++ b/src/nats.h
@@ -2444,6 +2444,22 @@ natsOptions_SetDiscoveredServersCB(natsOptions *opts,
                                    natsConnectionHandler discoveredServersCb,
                                    void *closure);
 
+/** \brief Sets if the library should ignore or not discovered servers.
+ *
+ * By default, when a server joins a cluster, a client is notified
+ * of the new URL and added to the list so it can be used in case
+ * of a reconnect.
+ *
+ * The servers can be configured to disable this gossip, however, if
+ * not done at the servers level, this option allows the discovered
+ * servers to be ignored.
+ *
+ * @param opts the pointer to the #natsOptions object.
+ * @param ignore if discovered server should be ignored or not.
+ */
+NATS_EXTERN natsStatus
+natsOptions_SetIgnoreDiscoveredServers(natsOptions *opts, bool ignore);
+
 /** \brief Sets the callback to be invoked when server enters lame duck mode.
  *
  * Specifies the callback to invoke when the server notifies

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -233,6 +233,7 @@ struct __natsOptions
 
     natsConnectionHandler   discoveredServersCb;
     void                    *discoveredServersClosure;
+    bool                    ignoreDiscoveredServers;
 
     natsConnectionHandler   connectedCb;
     void                    *connectedCbClosure;

--- a/src/opts.c
+++ b/src/opts.c
@@ -957,6 +957,18 @@ natsOptions_SetDiscoveredServersCB(natsOptions *opts,
 }
 
 natsStatus
+natsOptions_SetIgnoreDiscoveredServers(natsOptions *opts, bool ignore)
+{
+    LOCK_AND_CHECK_OPTIONS(opts, 0);
+
+    opts->ignoreDiscoveredServers = ignore;
+
+    UNLOCK_OPTS(opts);
+
+    return NATS_OK;
+}
+
+natsStatus
 natsOptions_SetLameDuckModeCB(natsOptions *opts,
                               natsConnectionHandler lameDuckCb,
                               void *closure)

--- a/test/list.txt
+++ b/test/list.txt
@@ -201,6 +201,7 @@ PingReconnect
 GetServers
 GetDiscoveredServers
 DiscoveredServersCb
+IgnoreDiscoveredServers
 INFOAfterFirstPONGisProcessedOK
 ServerPoolUpdatedOnClusterUpdate
 ReconnectJitter


### PR DESCRIPTION
This allows the library to ignore gossip URLs and exclusively
use the given server urls list provided by the user.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>