### PR TITLE
[IMPROVED] Suppress UNSUB when auto-unsub max is reached

### DIFF
--- a/src/sub.c
+++ b/src/sub.c
@@ -1401,6 +1401,11 @@ natsSubscription_Destroy(natsSubscription *sub)
     natsSub_Lock(sub);
 
     doUnsub = !(sub->closed);
+    // If not yet closed but user is closing from message callback but it
+    // happens that auto-unsub was used and the max number was delivered, then
+    // we can suppress the UNSUB protocol.
+    if (doUnsub && (sub->max > 0))
+        doUnsub = sub->delivered < sub->max;
 
     natsSub_Unlock(sub);
 

--- a/test/list.txt
+++ b/test/list.txt
@@ -132,6 +132,7 @@ SubBadSubjectAndQueueNames
 ClientAsyncAutoUnsub
 ClientSyncAutoUnsub
 ClientAutoUnsubAndReconnect
+AutoUnsubNoUnsubOnDestroy
 NextMsgOnClosedSub
 CloseSubRelease
 IsValidSubscriber


### PR DESCRIPTION
In case where the subscription is destroyed by the user from the
message callback but it was the message that would cause the
limit to be reached, the UNSUB protocol was still sent to the
server.

Resolves #558

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>