### PR TITLE
[ADDED] JetStream: Direct Get Message

### DIFF
--- a/src/js.h
+++ b/src/js.h
@@ -144,6 +144,9 @@ extern const int64_t    jsDefaultRequestWait;
 // jsApiMsgGetT is the endpoint to get a message, either by sequence or last per subject.
 #define jsApiMsgGetT "%.*s.STREAM.MSG.GET.%s"
 
+// jsApiMsgGetT is the endpoint to get a message, either by sequence or last per subject.
+#define jsApiDirectMsgGetT "%.*s.DIRECT.GET.%s"
+
 // Creates a subject based on the option's prefix, the subject format and its values.
 #define js_apiSubj(s, o, f, ...) (nats_asprintf((s), (f), (o)->Prefix, __VA_ARGS__) < 0 ? NATS_NO_MEMORY : NATS_OK)
 
@@ -231,3 +234,6 @@ js_retain(jsCtx *js);
 
 void
 js_release(jsCtx *js);
+
+natsStatus
+js_directGetMsgToJSMsg(const char *stream, natsMsg *msg);

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -424,6 +424,7 @@ struct __kvStore
     char                *stream;
     char                *pre;
     bool                useJSPrefix;
+    bool                useDirect;
 
 };
 

--- a/src/util.h
+++ b/src/util.h
@@ -245,4 +245,7 @@ nats_marshalULong(natsBuffer *buf, bool comma, const char *fieldName, uint64_t u
 bool
 nats_IsSubjectValid(const char *subject, bool wcAllowed);
 
+natsStatus
+nats_parseTime(char *str, int64_t *timeUTC);
+
 #endif /* UTIL_H_ */

--- a/test/list.txt
+++ b/test/list.txt
@@ -234,6 +234,8 @@ JetStreamOrderedConsAutoUnsub
 JetStreamSubscribeWithFWC
 JetStreamStreamsSealAndRollup
 JetStreamGetMsgAndLastMsg
+JetStreamConvertDirectMsg
+JetStreamDirectGetMsg
 JetStreamNakWithDelay
 JetStreamBackOffRedeliveries
 JetStreamInfoWithSubjects


### PR DESCRIPTION
This starts with a new boolean in a stream configuration:
```
// Allow higher performance, direct access to get individual messages. E.g. KeyValue
bool  AllowDirect;
```

When a stream is created with that boolean, then it is possible
to use this API to get messages:
```
natsStatus
js_DirectGetMsg(natsMsg **msg, jsCtx *js, const char *stream, jsOptions *opts, jsDirectGetMsgOptions *dgOpts);
```

The possible options to get a message are:
```
typedef struct jsDirectGetMsgOptions
{
        uint64_t        Sequence;               ///< Get the message at this sequence
        const char      *NextBySubject;         ///< Get the next message (based on sequence) for that subject
        const char      *LastBySubject;         ///< Get the last message on that subject

} jsDirectGetMsgOptions;
```

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>