### PR TITLE
[ADDED] natsSubscription_GetID() and natsSubscription_GetSubject()

### DIFF
--- a/src/nats.h
+++ b/src/nats.h
@@ -4564,16 +4564,27 @@ natsSubscription_AutoUnsubscribe(natsSubscription *sub, int max);
 NATS_EXTERN natsStatus
 natsSubscription_QueuedMsgs(natsSubscription *sub, uint64_t *queuedMsgs);
 
-/** \brief Returns the subscription id and subject name.
+/** \brief Gets the subscription id.
  *
- * Returns the subscription id and subject name of this subscription.
+ * Returns the id of the given subscription.
  *
  * @param sub the pointer to the #natsSubscription object.
- * @param sid if not `NULL`, the memory location where to store the subscription id.
+ * @param id if not `NULL`, the memory location where to store the subscription id.
+ */
+NATS_EXTERN natsStatus
+natsSubscription_GetID(natsSubscription* sub, int64_t* id);
+
+/** \brief Gets the subject name.
+ *
+ * Returns the subject of the given subscription.
+ *
+ * \warning The string belongs to the subscription and must not be freed. Copy it if needed.
+ *
+ * @param sub the pointer to the #natsSubscription object.
  * @param subject if not `NULL`, the memory location where to store the subject name.
  */
 NATS_EXTERN natsStatus
-natsSubscription_GetInfo(natsSubscription* sub, int64_t* sid, char* subject);
+natsSubscription_GetSubject(natsSubscription* sub, const char* subject);
 
 /** \brief Sets the limit for pending messages and bytes.
  *

--- a/src/nats.h
+++ b/src/nats.h
@@ -4567,24 +4567,26 @@ natsSubscription_QueuedMsgs(natsSubscription *sub, uint64_t *queuedMsgs);
 /** \brief Gets the subscription id.
  *
  * Returns the id of the given subscription.
+ * 
+ * \note Invalid or closed subscriptions will cause a value of 0 to be returned.
  *
  * @param sub the pointer to the #natsSubscription object.
- * @param id if not `NULL`, the memory location where to store the subscription id.
  */
-NATS_EXTERN natsStatus
-natsSubscription_GetID(natsSubscription* sub, int64_t* id);
+NATS_EXTERN int64_t
+natsSubscription_GetID(natsSubscription* sub);
 
 /** \brief Gets the subject name.
  *
  * Returns the subject of the given subscription.
  *
+ * \note Invalid or closed subscriptions will cause a value of NULL to be returned.
+ *
  * \warning The string belongs to the subscription and must not be freed. Copy it if needed.
  *
  * @param sub the pointer to the #natsSubscription object.
- * @param subject if not `NULL`, the memory location where to store the subject name.
  */
-NATS_EXTERN natsStatus
-natsSubscription_GetSubject(natsSubscription* sub, const char* subject);
+NATS_EXTERN const char*
+natsSubscription_GetSubject(natsSubscription* sub);
 
 /** \brief Sets the limit for pending messages and bytes.
  *

--- a/src/nats.h
+++ b/src/nats.h
@@ -4564,6 +4564,17 @@ natsSubscription_AutoUnsubscribe(natsSubscription *sub, int max);
 NATS_EXTERN natsStatus
 natsSubscription_QueuedMsgs(natsSubscription *sub, uint64_t *queuedMsgs);
 
+/** \brief Returns the subscription id and subject name.
+ *
+ * Returns the subscription id and subject name of this subscription.
+ *
+ * @param sub the pointer to the #natsSubscription object.
+ * @param sid if not `NULL`, the memory location where to store the subscription id.
+ * @param subject if not `NULL`, the memory location where to store the subject name.
+ */
+NATS_EXTERN natsStatus
+natsSubscription_GetInfo(natsSubscription* sub, int64_t* sid, char* subject);
+
 /** \brief Sets the limit for pending messages and bytes.
  *
  * Specifies the maximum number and size of incoming messages that can be

--- a/src/sub.c
+++ b/src/sub.c
@@ -1127,6 +1127,8 @@ natsSubscription_QueuedMsgs(natsSubscription *sub, uint64_t *queuedMsgs)
 int64_t
 natsSubscription_GetID(natsSubscription* sub)
 {
+    int64_t id = 0;
+
     if (sub == NULL)
         return 0;
 
@@ -1137,11 +1139,8 @@ natsSubscription_GetID(natsSubscription* sub)
         natsSub_Unlock(sub);
         return 0;
     }
-
-    int64_t id = 0;
-    SUB_DLV_WORKER_LOCK(sub);
+    
     id = sub->sid;
-    SUB_DLV_WORKER_UNLOCK(sub);
 
     natsSub_Unlock(sub);
 
@@ -1151,6 +1150,8 @@ natsSubscription_GetID(natsSubscription* sub)
 const char*
 natsSubscription_GetSubject(natsSubscription* sub)
 {
+    const char* subject = NULL;
+
     if (sub == NULL)
         return NULL;
 
@@ -1162,10 +1163,7 @@ natsSubscription_GetSubject(natsSubscription* sub)
         return NULL;
     }
 
-    const char* subject = NULL;
-    SUB_DLV_WORKER_LOCK(sub);
     subject = (const char*)sub->subject;
-    SUB_DLV_WORKER_UNLOCK(sub);
 
     natsSub_Unlock(sub);
 

--- a/src/sub.c
+++ b/src/sub.c
@@ -1125,7 +1125,7 @@ natsSubscription_QueuedMsgs(natsSubscription *sub, uint64_t *queuedMsgs)
 }
 
 natsStatus
-natsSubscription_GetInfo(natsSubscription* sub, int64_t* sid, char* subject)
+natsSubscription_GetID(natsSubscription* sub, int64_t* id)
 {
     if (sub == NULL)
         return nats_setDefaultError(NATS_INVALID_ARG);
@@ -1140,11 +1140,34 @@ natsSubscription_GetInfo(natsSubscription* sub, int64_t* sid, char* subject)
 
     SUB_DLV_WORKER_LOCK(sub);
 
-    if (sid != NULL)
-        *sid = sub->sid;
+    if (id != NULL)
+        *id = sub->sid;
+
+    SUB_DLV_WORKER_UNLOCK(sub);
+
+    natsSub_Unlock(sub);
+
+    return NATS_OK;
+}
+
+natsStatus
+natsSubscription_GetSubject(natsSubscription* sub, const char* subject)
+{
+    if (sub == NULL)
+        return nats_setDefaultError(NATS_INVALID_ARG);
+
+    natsSub_Lock(sub);
+
+    if (sub->closed)
+    {
+        natsSub_Unlock(sub);
+        return nats_setDefaultError(NATS_INVALID_SUBSCRIPTION);
+    }
+
+    SUB_DLV_WORKER_LOCK(sub);
 
     if (subject != NULL)
-        *subject = sub->subject;
+        subject = (const char*)sub->subject;
 
     SUB_DLV_WORKER_UNLOCK(sub);
 

--- a/src/sub.c
+++ b/src/sub.c
@@ -1124,56 +1124,52 @@ natsSubscription_QueuedMsgs(natsSubscription *sub, uint64_t *queuedMsgs)
     return s;
 }
 
-natsStatus
-natsSubscription_GetID(natsSubscription* sub, int64_t* id)
+int64_t
+natsSubscription_GetID(natsSubscription* sub)
 {
     if (sub == NULL)
-        return nats_setDefaultError(NATS_INVALID_ARG);
+        return 0;
 
     natsSub_Lock(sub);
 
     if (sub->closed)
     {
         natsSub_Unlock(sub);
-        return nats_setDefaultError(NATS_INVALID_SUBSCRIPTION);
+        return 0;
     }
 
+    int64_t id = 0;
     SUB_DLV_WORKER_LOCK(sub);
-
-    if (id != NULL)
-        *id = sub->sid;
-
+    id = sub->sid;
     SUB_DLV_WORKER_UNLOCK(sub);
 
     natsSub_Unlock(sub);
 
-    return NATS_OK;
+    return id;
 }
 
-natsStatus
-natsSubscription_GetSubject(natsSubscription* sub, const char* subject)
+const char*
+natsSubscription_GetSubject(natsSubscription* sub)
 {
     if (sub == NULL)
-        return nats_setDefaultError(NATS_INVALID_ARG);
+        return NULL;
 
     natsSub_Lock(sub);
 
     if (sub->closed)
     {
         natsSub_Unlock(sub);
-        return nats_setDefaultError(NATS_INVALID_SUBSCRIPTION);
+        return NULL;
     }
 
+    const char* subject = NULL;
     SUB_DLV_WORKER_LOCK(sub);
-
-    if (subject != NULL)
-        subject = (const char*)sub->subject;
-
+    subject = (const char*)sub->subject;
     SUB_DLV_WORKER_UNLOCK(sub);
 
     natsSub_Unlock(sub);
 
-    return NATS_OK;
+    return subject;
 }
 
 natsStatus

--- a/src/sub.c
+++ b/src/sub.c
@@ -1125,6 +1125,35 @@ natsSubscription_QueuedMsgs(natsSubscription *sub, uint64_t *queuedMsgs)
 }
 
 natsStatus
+natsSubscription_GetInfo(natsSubscription* sub, int64_t* sid, char* subject)
+{
+    if (sub == NULL)
+        return nats_setDefaultError(NATS_INVALID_ARG);
+
+    natsSub_Lock(sub);
+
+    if (sub->closed)
+    {
+        natsSub_Unlock(sub);
+        return nats_setDefaultError(NATS_INVALID_SUBSCRIPTION);
+    }
+
+    SUB_DLV_WORKER_LOCK(sub);
+
+    if (sid != NULL)
+        *sid = sub->sid;
+
+    if (subject != NULL)
+        *subject = sub->subject;
+
+    SUB_DLV_WORKER_UNLOCK(sub);
+
+    natsSub_Unlock(sub);
+
+    return NATS_OK;
+}
+
+natsStatus
 natsSubscription_GetPending(natsSubscription *sub, int *msgs, int *bytes)
 {
     if (sub == NULL)


### PR DESCRIPTION
This change adds the ability to get the subscription id / subject from a given natsSubscription instance.

This is done in a similar manner as the other "get functions" defined in nats.h (e.g. natsSubscription_GetStats which populates various fields such as pending bytes and dropped messages of a given subscription)