### PR TITLE
[CHANGED] `const int` to `int` for `Count` field in lists

### DIFF
--- a/src/js.c
+++ b/src/js.c
@@ -1147,7 +1147,7 @@ js_PublishAsyncGetPendingList(natsMsgList *pending, jsCtx *js)
             if (js->pmcount > 0)
                 js->pmcount--;
         }
-        *(int*)&(pending->Count) = count;
+        pending->Count = count;
     }
     js_unlock(js);
 
@@ -1892,7 +1892,7 @@ natsSubscription_Fetch(natsMsgList *list, natsSubscription *sub, int batch, int6
 
         // Update the list with what we have collected.
         list->Msgs = msgs;
-        *(int*)&(list->Count) = count;
+        list->Count = count;
 
         return NATS_OK;
     }

--- a/src/jsm.c
+++ b/src/jsm.c
@@ -772,7 +772,7 @@ _fillSubjectsList(void *userInfo, const char *subject, nats_JSONField *f)
     if (s == NATS_OK)
     {
         subjs->List[i].Msgs = f->value.vuint;
-        *(int*)&(subjs->Count) = i+1;
+        subjs->Count = i+1;
     }
     return NATS_UPDATE_ERR_STACK(s);
 }

--- a/src/kv.c
+++ b/src/kv.c
@@ -1073,7 +1073,7 @@ kvStore_Keys(kvKeysList *list, kvStore *kv, kvWatchOptions *opts)
         return nats_setDefaultError(NATS_INVALID_ARG);
 
     list->Keys = NULL;
-    *(int*)&(list->Count) = 0;
+    list->Count = 0;
 
     kvWatchOptions_Init(&o);
     if (opts != NULL)
@@ -1116,7 +1116,7 @@ kvStore_Keys(kvKeysList *list, kvStore *kv, kvWatchOptions *opts)
     // Set the list's Count to `count`, not `n` since `count`
     // will reflect the actual number of keys that have been
     // properly strdup'ed.
-    *(int*)&(list->Count) = count;
+    list->Count = count;
 
     // If there was a failure (especially when strdup'ing) keys,
     // this will do the proper cleanup and re-initialize the list.
@@ -1138,7 +1138,7 @@ kvKeysList_Destroy(kvKeysList *list)
         NATS_FREE(list->Keys[i]);
     NATS_FREE(list->Keys);
     list->Keys = NULL;
-    *(int*)&(list->Count) = 0;
+    list->Count = 0;
 }
 
 natsStatus
@@ -1159,7 +1159,7 @@ kvStore_History(kvEntryList *list, kvStore *kv, const char *key, kvWatchOptions 
         return nats_setDefaultError(NATS_INVALID_ARG);
 
     list->Entries = NULL;
-    *(int*)&(list->Count) = 0;
+    list->Count = 0;
 
     kvWatchOptions_Init(&o);
     if (opts != NULL)
@@ -1184,7 +1184,7 @@ kvStore_History(kvEntryList *list, kvStore *kv, const char *key, kvWatchOptions 
         if (list->Entries == NULL)
             s = nats_setDefaultError(NATS_NO_MEMORY);
         else
-            *(int*)&(list->Count) = n;
+            list->Count = n;
     }
     // Transfer entries to the array (on success), or destroy
     // the entries if there was an error.
@@ -1218,7 +1218,7 @@ kvEntryList_Destroy(kvEntryList *list)
         kvEntry_Destroy(list->Entries[i]);
     NATS_FREE(list->Entries);
     list->Entries = NULL;
-    *(int*)&(list->Count) = 0;
+    list->Count = 0;
 }
 
 natsStatus

--- a/src/msg.c
+++ b/src/msg.c
@@ -897,5 +897,5 @@ natsMsgList_Destroy(natsMsgList *list)
         natsMsg_Destroy(list->Msgs[i]);
     NATS_FREE(list->Msgs);
     list->Msgs = NULL;
-    *(int*)&(list->Count) = 0;
+    list->Count = 0;
 }

--- a/src/nats.h
+++ b/src/nats.h
@@ -212,7 +212,7 @@ typedef char                        natsInbox;
 typedef struct natsMsgList
 {
         natsMsg         **Msgs;
-        const int       Count;
+        int             Count;
 
 } natsMsgList;
 
@@ -561,7 +561,7 @@ typedef struct jsStreamStateSubject
 typedef struct jsStreamStateSubjects
 {
         jsStreamStateSubject    *List;
-        const int               Count;
+        int                     Count;
 
 } jsStreamStateSubjects;
 
@@ -1154,7 +1154,7 @@ typedef struct kvPurgeOptions
 typedef struct kvEntryList
 {
         kvEntry         **Entries;
-        const int       Count;
+        int             Count;
 
 } kvEntryList;
 
@@ -1178,7 +1178,7 @@ typedef struct kvEntryList
 typedef struct kvKeysList
 {
         char            **Keys;
-        const int       Count;
+        int             Count;
 
 } kvKeysList;
 
@@ -4567,7 +4567,7 @@ natsSubscription_QueuedMsgs(natsSubscription *sub, uint64_t *queuedMsgs);
 /** \brief Gets the subscription id.
  *
  * Returns the id of the given subscription.
- * 
+ *
  * \note Invalid or closed subscriptions will cause a value of 0 to be returned.
  *
  * @param sub the pointer to the #natsSubscription object.


### PR DESCRIPTION
This was causing compilation errors in C++ and was not really
adding any protection. It is stated in the doc that this value
should not be changed by the user prior to calling the destroy
function for those various lists.

Resolves #545

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>