### PR TITLE
Adjust to server direct get message time formatting

### DIFF
--- a/src/jsm.c
+++ b/src/jsm.c
@@ -1546,36 +1546,7 @@ js_directGetMsgToJSMsg(const char *stream, natsMsg *msg)
     val = NULL;
     s = natsMsgHeader_Get(msg, JSTimeStamp, &val);
     if ((s == NATS_OK) && !nats_IsStringEmpty(val))
-    {
-        // The server sends the time in this format (always UTC):
-        // 2006-01-02 15:04:05.999999999 +0000 UTC
-        // But for our parsing to work (from JSON) we will convert this
-        // to something like that:
-        // 2006-01-02T15:04:05.999999999Z
-        char tmpTime[40] = {'\0'};
-        char *ptr = NULL;
-
-        if (snprintf(tmpTime, sizeof(tmpTime), "%s", val) >= (int) sizeof(tmpTime)) {
-            tmpTime[39] = '\0';
-        }
-
-        ptr = strchr(tmpTime, ' ');
-        if (ptr != NULL)
-        {
-            *ptr = 'T';
-            ptr++;
-
-            ptr = strchr(ptr, ' ');
-            if (ptr != NULL)
-            {
-                *ptr = 'Z';
-                ptr++;
-                *ptr = '\0';
-
-                s = nats_parseTime((char*) tmpTime, &tm);
-            }
-        }
-    }
+        s = nats_parseTime((char*) val, &tm);
     if ((s != NATS_OK) || (tm == 0))
         return nats_setError(NATS_ERR, "missing or invalid timestamp '%s'", val);
 

--- a/test/test.c
+++ b/test/test.c
@@ -27880,7 +27880,7 @@ test_JetStreamConvertDirectMsg(void)
     nats_clearLastError();
 
     test("Missing subject: ");
-    s = natsMsgHeader_Set(msg, JSTimeStamp, "2006-01-02 15:04:05.999999999 +0000 UTC");
+    s = natsMsgHeader_Set(msg, JSTimeStamp, "2006-01-02T15:04:05Z");
     IFOK(s, js_directGetMsgToJSMsg("test", msg));
     testCond((s == NATS_ERR) && (strstr(nats_GetLastError(NULL), "missing or invalid subject") != NULL));
     nats_clearLastError();
@@ -27897,7 +27897,7 @@ test_JetStreamConvertDirectMsg(void)
     testCond((s == NATS_OK)
                 && (strcmp(natsMsg_GetSubject(msg), "foo") == 0)
                 && (natsMsg_GetSequence(msg) == 1)
-                && (natsMsg_GetTime(msg) == 1136214245999999999L)
+                && (natsMsg_GetTime(msg) == 1136214245000000000L)
                 && (natsMsgHeader_Get(msg, "some", &val) == NATS_OK)
                 && (strcmp(val, "header") == 0));
 
@@ -31729,6 +31729,9 @@ test_StanInternalSubsNotPooled(void)
     stanConnOptions_Destroy(sopts);
     stanSubscription_Destroy(sub);
     stanConnection_Destroy(sc);
+
+    if (valgrind)
+        nats_Sleep(900);
 
     _stopServer(pid);
 }


### PR DESCRIPTION
The direct get message time formatting was different that the regular
message get, but now they are the same so removed code that was handling
that special case.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>