### PR TITLE
Add note that js_DirectGetMsg() works only for server v2.9.0+

### DIFF
--- a/src/nats.h
+++ b/src/nats.h
@@ -5475,6 +5475,10 @@ jsDirectGetMsgOptions_Init(jsDirectGetMsgOptions *opts);
  * check and leave it to the server to do it and return the error returned by
  * the server.
  *
+ * \note This API can only be used against servers that support the direct
+ * get feature, which is `v2.9.0+`. If running against an older server the
+ * call will likely timeout.
+ *
  * @param msg the location where to store the pointer to the retrieved message.
  * @param js  the pointer to the #jsCtx context.
  * @param stream the name of the stream.


### PR DESCRIPTION
[ci skip]

Resolves #575

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>