### PR TITLE
[ADDED] `Name` in consumer configuration

### DIFF
--- a/src/js.c
+++ b/src/js.c
@@ -2128,10 +2128,11 @@ _processConsInfo(const char **dlvSubject, jsConsumerInfo *info, jsConsumerConfig
 }
 
 natsStatus
-js_checkDurName(const char *dur)
+js_checkConsName(const char *cons, bool isDurable)
 {
-    if (strchr(dur, '.') != NULL)
-        return nats_setError(NATS_INVALID_ARG, "%s '%s' (cannot contain '.')", jsErrInvalidDurableName, dur);
+    if (strchr(cons, '.') != NULL)
+        return nats_setError(NATS_INVALID_ARG, "%s '%s' (cannot contain '.')",
+            (isDurable ? jsErrInvalidDurableName : jsErrInvalidConsumerName), cons);
     return NATS_OK;
 }
 
@@ -2243,7 +2244,7 @@ _subscribe(natsSubscription **new_sub, jsCtx *js, const char *subject, const cha
     // If a durable name is specified, check that it is valid
     if (!nats_IsStringEmpty(durable))
     {
-        if ((s = js_checkDurName(durable)) != NATS_OK)
+        if ((s = js_checkConsName(durable, true)) != NATS_OK)
             return NATS_UPDATE_ERR_STACK(s);
     }
 

--- a/src/js.h
+++ b/src/js.h
@@ -126,6 +126,12 @@ extern const int64_t    jsDefaultRequestWait;
 // jsApiDurableCreateT is used to create durable consumers.
 #define jsApiDurableCreateT "%.*s.CONSUMER.DURABLE.CREATE.%s.%s"
 
+// jsApiConsumerCreateExT is used to create a named consumer.
+#define jsApiConsumerCreateExT "%.*s.CONSUMER.CREATE.%s.%s"
+
+// jsApiConsumerCreateExWithFilterT is used to create a named consumer with a filter subject.
+#define jsApiConsumerCreateExWithFilterT "%.*s.CONSUMER.CREATE.%s.%s.%s"
+
 // jsApiConsumerInfoT is used to get information about consumers.
 #define jsApiConsumerInfoT "%.*s.CONSUMER.INFO.%s.%s"
 
@@ -218,7 +224,7 @@ void
 js_cleanStreamState(jsStreamState *state);
 
 natsStatus
-js_checkDurName(const char *dur);
+js_checkConsName(const char *cons, bool isDurable);
 
 natsStatus
 js_getMetaData(const char *reply,

--- a/src/nats.h
+++ b/src/nats.h
@@ -684,6 +684,7 @@ typedef struct jsStreamInfo
  */
 typedef struct jsConsumerConfig
 {
+        const char              *Name;
         const char              *Durable;
         const char              *Description;
         jsDeliverPolicy         DeliverPolicy;


### PR DESCRIPTION
When this is used, the library will send request to a different API subject space where the stream and consumer names are in the subject, along with a filter subject if one is specified.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>