### PR TITLE
[FIXED] JetStream: natsSubscription_Destroy should not delete JS consumer

### DIFF
--- a/src/sub.c
+++ b/src/sub.c
@@ -1139,7 +1139,7 @@ natsSubscription_GetID(natsSubscription* sub)
         natsSub_Unlock(sub);
         return 0;
     }
-    
+
     id = sub->sid;
 
     natsSub_Unlock(sub);
@@ -1452,6 +1452,11 @@ natsSubscription_Destroy(natsSubscription *sub)
     // we can suppress the UNSUB protocol.
     if (doUnsub && (sub->max > 0))
         doUnsub = sub->delivered < sub->max;
+
+    // For a JetStream subscription, disable the "delete consumer" flag
+    // because we auto-delete only on explicit calls to unsub/drain.
+    if (sub->jsi != NULL)
+        sub->jsi->dc = false;
 
     natsSub_Unlock(sub);
 

--- a/test/test.c
+++ b/test/test.c
@@ -25139,6 +25139,20 @@ test_JetStreamSubscribe(void)
     natsSubscription_Destroy(sub);
     sub = NULL;
 
+    test("Destroy sub does not delete consumer: ");
+    jsSubOptions_Init(&so);
+    so.Config.Durable = "delcons5";
+    s = js_Subscribe(&sub, js, "foo", _jsMsgHandler, (void*) &args, NULL, &so, &jerr);
+    if (s == NATS_OK)
+    {
+        natsSubscription_Destroy(sub);
+        sub = NULL;
+        s = js_GetConsumerInfo(&ci, js, "TEST", "delcons5", NULL, &jerr);
+    }
+    testCond((s == NATS_OK) && (ci != NULL) && (jerr == 0));
+    jsConsumerInfo_Destroy(ci);
+    ci = NULL;
+
     test("Queue and HB is invalid: ");
     jsSubOptions_Init(&so);
     so.Stream = "TEST";


### PR DESCRIPTION
Added comments in the js_Subscribe() calls that explains the behavior of auto created/deleted JS consumers.
It was the intent that auto-created JS consumers would be deleted only when explicitly calling unsubscribe/drain, similar to Go client.

However, in C, the user needs to call natsSubscription_Destroy to free memory. This call is calling internally natsSubscription_Unsubscribe (if the call was not made explicitly), but then we need to disable the deletion of the JS consumer in that case.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>