### PR TITLE
[CHANGED] Count message headers toward subscription limits

### DIFF
--- a/src/js.c
+++ b/src/js.c
@@ -848,7 +848,7 @@ _timeoutPubAsync(natsTimer *t, void *closure)
         }
         js->rsub->msgList.tail = m;
         js->rsub->msgList.msgs++;
-        js->rsub->msgList.bytes += m->dataLen;
+        js->rsub->msgList.bytes += natsMsg_dataAndHdrLen(m);
         natsSub_Unlock(js->rsub);
 
         js->pmHead = pm->next;

--- a/src/msg.h
+++ b/src/msg.h
@@ -45,6 +45,8 @@
 #define natsMsg_isTimeout(m)        (((m)->flags &   (1 << 3)) != 0)
 #define natsMsg_clearTimeout(m)     ((m)->flags  &= ~(1 << 3))
 
+#define natsMsg_dataAndHdrLen(m)    ((m)->dataLen + (m)->hdrLen)
+
 struct __natsMsg
 {
     natsGCItem          gc;

--- a/src/nats.c
+++ b/src/nats.c
@@ -1750,7 +1750,7 @@ _deliverMsgs(void *arg)
 
         // Update before checking closed state.
         sub->msgList.msgs--;
-        sub->msgList.bytes -= msg->dataLen;
+        sub->msgList.bytes -= natsMsg_dataAndHdrLen(msg);
 
         // Need to check for closed subscription again here.
         // The subscription could have been unsubscribed from a callback

--- a/src/pub.c
+++ b/src/pub.c
@@ -120,14 +120,16 @@ natsConn_publish(natsConnection *nc, natsMsg *msg, const char *reply, bool direc
             totalLen = hdrl;
         }
     }
+    // This will represent headers + data
+    totalLen += msg->dataLen;
 
-    if (!nc->initc && ((int64_t) msg->dataLen > nc->info.maxPayload))
+    if (!nc->initc && ((int64_t) totalLen > nc->info.maxPayload))
     {
         natsConn_Unlock(nc);
 
         return nats_setError(NATS_MAX_PAYLOAD,
                              "Payload %d greater than maximum allowed: %" PRId64,
-                             msg->dataLen, nc->info.maxPayload);
+                             totalLen, nc->info.maxPayload);
     }
 
     // Check if we are reconnecting, and if so check if
@@ -142,7 +144,6 @@ natsConn_publish(natsConnection *nc, natsMsg *msg, const char *reply, bool direc
         }
     }
 
-    totalLen += msg->dataLen;
     GETBYTES_SIZE(totalLen, dlb, dli)
     dlSize = (BYTES_SIZE_MAX - dli);
 

--- a/src/sub.c
+++ b/src/sub.c
@@ -239,7 +239,7 @@ natsSub_deliverMsgs(void *arg)
             sub->msgList.tail = NULL;
 
         sub->msgList.msgs--;
-        sub->msgList.bytes -= msg->dataLen;
+        sub->msgList.bytes -= natsMsg_dataAndHdrLen(msg);
 
         msg->next = NULL;
 
@@ -731,7 +731,7 @@ natsSub_nextMsg(natsMsg **nextMsg, natsSubscription *sub, int64_t timeout, bool 
                 sub->msgList.tail = NULL;
 
             sub->msgList.msgs--;
-            sub->msgList.bytes -= msg->dataLen;
+            sub->msgList.bytes -= natsMsg_dataAndHdrLen(msg);
 
             msg->next = NULL;
 

--- a/test/test.c
+++ b/test/test.c
@@ -24142,7 +24142,7 @@ test_JetStreamPublishAsync(void)
         rsub->msgList.head = msg;
         rsub->msgList.tail = msg;
         rsub->msgList.msgs = 1;
-        rsub->msgList.bytes = msg->dataLen;
+        rsub->msgList.bytes = natsMsg_dataAndHdrLen(msg);
         natsCondition_Signal(rsub->cond);
         natsSub_Unlock(rsub);
 


### PR DESCRIPTION
When headers were introduced, the whole buffer (so data + hdr) was added as pending limits, but when messages were removed from the subscription, only the data part was removed, which caused an issue that was address in PR #420 by just accounting for the data size (not header).

Headers becoming more and more prevalent, it could be that a big part of message content is the headers, so we should probably count the headers size along with the data toward the subscription's bytes limit.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>