### PR TITLE
[CHANGED] JetStream: Pull consumer can now use AckNone and AckAll

### DIFF
--- a/src/js.c
+++ b/src/js.c
@@ -2686,19 +2686,6 @@ js_PullSubscribe(natsSubscription **sub, jsCtx *js, const char *subject, const c
     if (errCode != NULL)
         *errCode = 0;
 
-    // Check for invalid ack policy
-    if (opts != NULL)
-    {
-        jsAckPolicy p = (opts->Config.AckPolicy);
-
-        if ((p == js_AckNone) || (p == js_AckAll))
-        {
-            const char *ap = (p == js_AckNone ? jsAckNoneStr : jsAckAllStr);
-            return nats_setError(NATS_INVALID_ARG,
-                                 "invalid ack mode '%s' for pull consumers", ap);
-        }
-    }
-
     s = _subscribe(sub, js, subject, durable, NULL, NULL, true, jsOpts, opts, errCode);
     return NATS_UPDATE_ERR_STACK(s);
 }


### PR DESCRIPTION
Since NATS Server v2.9.0, it is possible to create a pull consumer with an js_AckNone or js_AckAll acknowledgment mode, so removing the restriction at the API level.

Related to https://github.com/nats-io/nats-architecture-and-design/issues/156

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>