### PR TITLE
[FIXED] JetStream: `jsConsumerConfig.Name` was not unmarshal'ed

### DIFF
--- a/src/jsm.c
+++ b/src/jsm.c
@@ -2660,6 +2660,7 @@ _destroyConsumerConfig(jsConsumerConfig *cc)
     if (cc == NULL)
         return;
 
+    NATS_FREE((char*) cc->Name);
     NATS_FREE((char*) cc->Durable);
     NATS_FREE((char*) cc->Description);
     NATS_FREE((char*) cc->DeliverSubject);
@@ -2761,6 +2762,7 @@ _unmarshalConsumerConfig(nats_JSON *json, const char *fieldName, jsConsumerConfi
     if ((s == NATS_OK) && (cjson != NULL))
     {
         s = nats_JSONGetStr(cjson, "durable_name", (char**) &(cc->Durable));
+        IFOK(s, nats_JSONGetStr(cjson, "name", (char**) &(cc->Name)));
         IFOK(s, nats_JSONGetStr(cjson, "description", (char**) &(cc->Description)));
         IFOK(s, nats_JSONGetStr(cjson, "deliver_subject", (char**) &(cc->DeliverSubject)));
         IFOK(s, nats_JSONGetStr(cjson, "deliver_group", (char**) &(cc->DeliverGroup)));


### PR DESCRIPTION
The new configuration `Name` in `jsConsumerConfig` could be set when calling `js_AddConsumer`, but when getting the `jsConsumerInfo` response (from that call or any `js_GetConsumerInfo`, the `Name` was present in `jsConsumerInfo`, but was not in the `Config` field (a `jsConsumerConfig`). Although I am not sure this is needed, making sure that we unmarshal properly.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>