### PR TITLE
[FIXED] JetStream: Ordered Consumer could stop receiving messages

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -1112,6 +1112,15 @@ _resendSubscriptions(natsConnection *nc)
 
         adjustedMax = 0;
         natsSub_Lock(sub);
+        // If JS ordered consumer, trigger a reset. Don't check the error
+        // condition here. If there is a failure, it will be retried
+        // at the next HB interval.
+        if ((sub->jsi != NULL) && (sub->jsi->ordered))
+        {
+            jsSub_resetOrderedConsumer(sub, sub->jsi->sseq+1);
+            natsSub_Unlock(sub);
+            continue;
+        }
         if (natsSub_drainStarted(sub))
         {
             natsSub_Unlock(sub);

--- a/src/js.c
+++ b/src/js.c
@@ -3021,13 +3021,6 @@ _recreateOrderedCons(void *closure)
         DUP_STRING(s, jsi->ocCfg->DeliverSubject, sub->subject);
         if (s == NATS_OK)
         {
-            // Reset some items in jsi.
-            jsi->dseq = 1;
-            NATS_FREE(jsi->cmeta);
-            jsi->cmeta = NULL;
-            NATS_FREE(jsi->fcReply);
-            jsi->fcReply = NULL;
-            jsi->fcDelivered = 0;
             // Create consumer request for starting policy.
             cc = jsi->ocCfg;
             cc->DeliverPolicy = js_DeliverByStartSequence;
@@ -3066,6 +3059,7 @@ _recreateOrderedCons(void *closure)
         natsConn_Unlock(nc);
     }
 
+    NATS_FREE(oci->ndlv);
     NATS_FREE(oci);
     natsThread_Detach(t);
     natsThread_Destroy(t);
@@ -3085,8 +3079,9 @@ jsSub_resetOrderedConsumer(natsSubscription *sub, uint64_t sseq)
     jsOrderedConsInfo   *oci        = NULL;
     int                 max         = 0;
     bool                done        = false;
+    jsSub               *jsi        = sub->jsi;
 
-    if ((sub->jsi == NULL) || (nc == NULL) || sub->closed)
+    if ((jsi == NULL) || (nc == NULL) || sub->closed)
         return NATS_OK;
 
     // Note: if anything fail here, the reset/recreate of the ordered consumer
@@ -3099,7 +3094,7 @@ jsSub_resetOrderedConsumer(natsSubscription *sub, uint64_t sseq)
         // If we are at or anove sub->max, then we are done with this sub
         // and will send an UNSUB in the _recreateOrderedCons thread function.
         if (sub->jsi->fciseq < sub->max)
-            max = (int)(sub->max - sub->jsi->fciseq);
+            max = (int)(sub->max - jsi->fciseq);
         else
             done = true;
     }
@@ -3121,15 +3116,24 @@ jsSub_resetOrderedConsumer(natsSubscription *sub, uint64_t sseq)
     oci = NATS_CALLOC(1, sizeof(jsOrderedConsInfo));
     if (oci == NULL)
         s = nats_setDefaultError(NATS_NO_MEMORY);
+    else
+        DUP_STRING(s, oci->ndlv, (char*) newDeliver);
 
     if (s == NATS_OK)
     {
+        // Reset some items in jsi.
+        jsi->dseq = 1;
+        NATS_FREE(jsi->fcReply);
+        jsi->fcReply = NULL;
+        jsi->fcDelivered = 0;
+        NATS_FREE(jsi->cmeta);
+        jsi->cmeta = NULL;
+
         oci->osid = osid;
         oci->nsid = sub->sid;
         oci->sseq = sseq;
         oci->nc   = nc;
         oci->sub  = sub;
-        oci->ndlv = (char*) newDeliver;
         oci->max  = max;
         oci->done = done;
         natsSub_retain(sub);
@@ -3140,6 +3144,11 @@ jsSub_resetOrderedConsumer(natsSubscription *sub, uint64_t sseq)
             NATS_FREE(oci);
             natsSub_release(sub);
         }
+    }
+    if ((s != NATS_OK) && (oci != NULL))
+    {
+        NATS_FREE(oci->ndlv);
+        NATS_FREE(oci);
     }
     return s;
 }

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -388,7 +388,6 @@ typedef struct __jsSub
     char                *cmeta;
     uint64_t            sseq;
     uint64_t            dseq;
-    uint64_t            ldseq;
     // Skip sequence mismatch notification. This is used for
     // async subscriptions to notify the asyn err handler only
     // once. Should the mismatch be resolved, this will be

--- a/test/test.c
+++ b/test/test.c
@@ -27987,7 +27987,7 @@ _testOrderedCons(jsCtx *js, jsStreamInfo *si, char *asset, int assetLen, struct 
             start = nats_Now();
             while ((s == NATS_OK) && !done)
             {
-                s = natsSubscription_NextMsg(&msg, sub, 1000);
+                s = natsSubscription_NextMsg(&msg, sub, 5000);
                 if (s == NATS_OK)
                 {
                     done = (natsMsg_GetDataLength(msg) == 0 ? true : false);
@@ -27999,7 +27999,7 @@ _testOrderedCons(jsCtx *js, jsStreamInfo *si, char *asset, int assetLen, struct 
                     natsMsg_Destroy(msg);
                     msg = NULL;
                 }
-                if ((s == NATS_OK) && (nats_Now() - start > 5000))
+                if ((s == NATS_OK) && (nats_Now() - start > 5500))
                     s = NATS_TIMEOUT;
             }
         }
@@ -28511,7 +28511,7 @@ test_JetStreamOrderedConsumerWithAutoUnsub(void)
     test("Subscribe: ");
     jsSubOptions_Init(&so);
     so.Ordered = true;
-    so.Config.Heartbeat = 250*1000000;
+    so.Config.Heartbeat = NATS_MILLIS_TO_NANOS(250);
     s = js_Subscribe(&sub, js, "a", _jsMsgHandler, (void*)&args, NULL, &so, &jerr);
     testCond((s == NATS_OK) && (sub != NULL) && (jerr == 0));
 
@@ -28625,6 +28625,7 @@ test_JetStreamOrderedConsSrvRestart(void)
     js = NULL;
     s = natsOptions_Create(&opts);
     IFOK(s, natsOptions_SetReconnectedCB(opts, _reconnectedCb, (void*) &args));
+    IFOK(s, natsOptions_SetReconnectWait(opts, 100));
     IFOK(s, natsConnection_Connect(&nc, opts));
     IFOK(s, natsConnection_JetStream(&js, nc, NULL));
     testCond(s == NATS_OK);


### PR DESCRIPTION
Resetting some of the JS subscription needs to be done "in-place" as opposed to in the thread that attempts to recreate it.

Also speed up the reset on reconnect (as opposed to wait for missed hearbeats). Of course, it could be that the reset is for nothing if nothing was missing.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>