### PR TITLE
[CHANGED] KeyValue: library will no longer try to update the stream

### DIFF
--- a/src/kv.c
+++ b/src/kv.c
@@ -296,32 +296,9 @@ js_CreateKeyValue(kvStore **new_kv, jsCtx *js, kvConfig *cfg)
             sc.Discard = js_DiscardNew;
 
         s = js_AddStream(&si, js, &sc, NULL, &jerr);
-        if ((s != NATS_OK) && (jerr == JSStreamNameExistErr))
-        {
-            jsStreamInfo_Destroy(si);
-            si = NULL;
-
-            nats_clearLastError();
-            s = js_GetStreamInfo(&si, js, sc.Name, NULL, NULL);
-            if (s == NATS_OK)
-            {
-                si->Config->Discard = sc.Discard;
-                if (_sameStreamCfg(si->Config, &sc))
-                {
-                    jsStreamInfo_Destroy(si);
-                    si = NULL;
-                    s = js_UpdateStream(&si, js, &sc, NULL, NULL);
-                }
-                else
-                    s = nats_setError(NATS_ERR, "%s",
-                        "Existing configuration is different");
-            }
-        }
+        // If the stream allow direct get message calls, then we will do so.
         if (s == NATS_OK)
-        {
-            // If the stream allow direct get message calls, then we will do so.
             kv->useDirect = si->Config->AllowDirect;
-        }
         jsStreamInfo_Destroy(si);
     }
     if (s == NATS_OK)


### PR DESCRIPTION
Until now, the js_CreateKeyValue() call would possibly attempt to update the underlying stream to set some properties that were added from release to release. This had an unexpected side effect when a stream in a newer server has new properties that the application linked to an older library was not aware of and would not unmarshal. Even if a stream comparison (minus the property we would want to update) would return OK, it could be wrong because we would disregard new properties not known by the old client library.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>