### PR TITLE
[ADDED] Stream alternates in `jsStreamInfo`

### DIFF
--- a/src/nats.h
+++ b/src/nats.h
@@ -636,6 +636,17 @@ typedef struct jsStreamSourceInfo
 } jsStreamSourceInfo;
 
 /**
+ * Information about an alternate stream represented by a mirror.
+ */
+typedef struct jsStreamAlternate
+{
+        const char              *Name;
+        const char              *Domain;
+        const char              *Cluster;
+
+} jsStreamAlternate;
+
+/**
  * Configuration and current state for this stream.
  *
  * \note `Created` is the timestamp when the stream was created, expressed as
@@ -650,6 +661,8 @@ typedef struct jsStreamInfo
         jsStreamSourceInfo      *Mirror;
         jsStreamSourceInfo      **Sources;
         int                     SourcesLen;
+        jsStreamAlternate       **Alternates;
+        int                     AlternatesLen;
 
 } jsStreamInfo;
 

--- a/src/status.h
+++ b/src/status.h
@@ -258,6 +258,13 @@ typedef enum {
     JSStreamMoveInProgressErr = 10124,                  ///< Stream move already in progress
     JSConsumerMaxRequestBatchExceededErr = 10125,       ///< Consumer max request batch exceeds server limit
     JSConsumerReplicasExceedsStreamErr = 10126,         ///< Consumer config replica count exceeds parent stream
+    JSConsumerNameContainsPathSeparatorsErr = 10127,    ///< Consumer name can not contain path separators
+    JSStreamNameContainsPathSeparatorsErr = 10128,      ///< Stream name can not contain path separators
+    JSStreamMoveNotInProgressErr = 10129,               ///< Stream move not in progress
+    JSStreamNameExistRestoreFailedErr = 10130,          ///< Stream name already in use, cannot restore
+    JSConsumerCreateFilterSubjectMismatchErr = 10131,   ///< Consumer create request did not match filtered subject from create subject
+    JSConsumerCreateDurableAndNameMismatchErr = 10132,  ///< Consumer Durable and Name have to be equal if both are provided
+    JSReplicasCountCannotBeNegativeErr = 10133,         ///< Replicas count cannot be negative
 
 } jsErrCode;
 

--- a/test/list.txt
+++ b/test/list.txt
@@ -241,6 +241,7 @@ JetStreamDirectGetMsg
 JetStreamNakWithDelay
 JetStreamBackOffRedeliveries
 JetStreamInfoWithSubjects
+JetStreamInfoAlternates
 KeyValueManager
 KeyValueBasics
 KeyValueWatch


### PR DESCRIPTION
`jsStreamInfo` will now possibly have a list of stream alternates represented by a mirror:
```
typedef struct jsStreamInfo
{
        (...)
        jsStreamAlternate       **Alternates;
        int                     AlternatesLen;

} jsStreamInfo;
```
The definition of a stream alternate is:
```
typedef struct jsStreamAlternate
{
        const char              *Name;
        const char              *Domain;
        const char              *Cluster;

} jsStreamAlternate;
```

Also added some of the new JS specific error codes.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>