### PR TITLE
[ADDED] KeyValue: `RateLimit` option in `kvWatchOptions`

### DIFF
--- a/src/kv.c
+++ b/src/kv.c
@@ -1092,6 +1092,7 @@ kvStore_Watch(kvWatcher **new_watcher, kvStore *kv, const char *key, kvWatchOpti
                 so.Config.HeadersOnly = true;
             if (opts->IgnoreDeletes)
                 w->ignoreDel = true;
+            so.Config.RateLimit = opts->RateLimit;
         }
         // Need to explicitly bind to the stream here because the subject
         // we construct may not help find the stream when using mirrors.

--- a/src/nats.h
+++ b/src/nats.h
@@ -1223,6 +1223,7 @@ typedef struct kvWatchOptions
         bool            IncludeHistory;
         bool            MetaOnly;
         int64_t         Timeout;        ///< How long to wait (in milliseconds) for some operations to complete.
+        uint64_t        RateLimit;      ///< Expressed in bits per second. Applies to initial entries AND subsequent updates.
 
 } kvWatchOptions;
 

--- a/test/list.txt
+++ b/test/list.txt
@@ -255,6 +255,7 @@ KeyValueDiscardOldToNew
 KeyValueRePublish
 KeyValueMirrorDirectGet
 KeyValueMirrorCrossDomains
+KeyValueRateLimiting
 StanPBufAllocator
 StanConnOptions
 StanSubOptions


### PR DESCRIPTION
This is expressed in bits per second and allow the server to rate limit updates sent to the watcher. This applies to both initial and new updates.

Resolves #619

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>