### PR TITLE
add natsOptions_SetUserCredentialsFromMemory

### DIFF
--- a/src/conn.h
+++ b/src/conn.h
@@ -126,7 +126,7 @@ natsStatus
 natsConn_publish(natsConnection *nc, natsMsg *msg, const char *reply, bool directFlush);
 
 natsStatus
-natsConn_userFromFile(char **userJWT, char **customErrTxt, void *closure);
+natsConn_userCreds(char **userJWT, char **customErrTxt, void *closure);
 
 natsStatus
 natsConn_signatureHandler(char **customErrTxt, unsigned char **sig, int *sigLen, const char *nonce, void *closure);

--- a/src/nats.h
+++ b/src/nats.h
@@ -2970,6 +2970,23 @@ natsOptions_SetUserCredentialsFromFiles(natsOptions *opts,
                                         const char *userOrChainedFile,
                                         const char *seedFile);
 
+/** \brief Sets JWT handler and handler to sign nonce that uses seed.
+ * 
+ * This function acts similarly to natsOptions_SetUserCredentialsFromFiles but reads from memory instead
+ * from a file. Also it assumes that `memory` contains both the JWT and NKey seed.
+ * 
+ * As for the format, @cf `natsOptions_SetUserCredentialsFromFiles` documentation.
+ * 
+ * @see natsOptions_SetUserCredentialsFromFiles()
+ * 
+ * @param opts the pointer to the #natsOptions object.
+ * @param memory string containing user JWT and user NKey seed
+ * 
+*/
+NATS_EXTERN natsStatus
+natsOptions_SetUserCredentialsFromMemory(natsOptions *opts,
+                                         const char *jwtAndSeedContent);
+
 /** \brief Sets the NKey public key and signature callback.
  *
  * Any time the library creates a TCP connection to the server, the server

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -192,6 +192,7 @@ typedef struct __userCreds
 {
     char        *userOrChainedFile;
     char        *seedFile;
+    char        *jwtAndSeedContent;
 
 } userCreds;
 
@@ -281,7 +282,7 @@ struct __natsOptions
     bool                    retryOnFailedConnect;
 
     // Callback/closure used to get the user JWT. Will be set to
-    // internal natsConn_userFromFile function when userCreds != NULL.
+    // internal natsConn_userCreds function when userCreds != NULL.
     natsUserJWTHandler      userJWTHandler;
     void                    *userJWTClosure;
 
@@ -294,8 +295,9 @@ struct __natsOptions
     // to the server.
     char                    *nkey;
 
-    // If user has invoked natsOptions_SetUserCredentialsFromFiles, this
-    // will be set and points to userOrChainedFile and possibly seedFile.
+    // If user has invoked natsOptions_SetUserCredentialsFromFiles or
+    // natsOptions_SetUserCredentialsFromMemory, this will be set and points to
+    // userOrChainedFile, seedFile, or possibly directly contains the JWT+seed content.
     struct __userCreds      *userCreds;
 
     // Reconnect jitter added to reconnect wait

--- a/test/list.txt
+++ b/test/list.txt
@@ -167,6 +167,7 @@ GetRTT
 GetLocalIPAndPort
 UserCredsCallbacks
 UserCredsFromFiles
+UserCredsFromMemory
 NKey
 NKeyFromSeed
 ConnSign


### PR DESCRIPTION
I would say, this is very useful (I need it myself) because I am actually getting the JWT as env var in some docker container. I could write it to a file and then read that but it feels like unnecessary file I/O so I would rather directly read from memory.

I tested it personally and it works.

I can add UTs if you generally would accept this change (otherwise I'd rather save the time :)).