### PR TITLE
[ADDED] Support padding when allocating buffer for incoming messages

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -2600,10 +2600,10 @@ _createMsg(natsMsg **newMsg, natsConnection *nc, char *buf, int bufLen, int hdrL
         replyLen = natsBuf_Len(nc->ps->ma.reply);
     }
 
-    s = natsMsg_create(newMsg,
+    s = natsMsg_createWithPadding(newMsg,
                        (const char*) natsBuf_Data(nc->ps->ma.subject), subjLen,
                        (const char*) reply, replyLen,
-                       (const char*) buf, bufLen, hdrLen);
+                       (const char*) buf, bufLen, nc->opts->payloadPaddingSize, hdrLen);
     return s;
 }
 

--- a/src/msg.h
+++ b/src/msg.h
@@ -105,6 +105,13 @@ natsMsg_create(natsMsg **newMsg,
                const char *reply, int replyLen,
                const char *buf, int bufLen, int hdrLen);
 
+natsStatus
+natsMsg_createWithPadding(natsMsg **newMsg,
+                          const char *subject, int subjLen,
+                          const char *reply, int replyLen,
+                          const char *buf, int bufLen, int bufPaddingSize,
+                          int hdrLen);
+
 void
 natsMsg_freeHeaders(natsMsg *msg);
 

--- a/src/nats.h
+++ b/src/nats.h
@@ -3116,6 +3116,22 @@ natsOptions_DisableNoResponders(natsOptions *opts, bool disabled);
 NATS_EXTERN natsStatus
 natsOptions_SetCustomInboxPrefix(natsOptions *opts, const char *inboxPrefix);
 
+/** \brief Sets a custom padding when allocating buffer for incoming messages
+ *
+ * By default library allocates natsMsg with payload buffer size
+ * equal to payload size. Sometimes it can be useful to add some
+ * padding to the end of the buffer which can be tweaked using
+ * this option.
+ *
+ * To clear the custom message buffer padding, call this function with 0.
+ * Changing this option has no effect on existing NATS connections.
+ *
+ * @param opts the pointer to the #natsOptions object.
+ * @param paddingSize the desired inbox prefix.
+ */
+NATS_EXTERN natsStatus
+natsOptions_SetMessageBufferPadding(natsOptions *opts, int paddingSize);
+
 /** \brief Destroys a #natsOptions object.
  *
  * Destroys the natsOptions object, freeing used memory. See the note in

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -313,6 +313,9 @@ struct __natsOptions
 
     // Custom inbox prefix
     char *inboxPfx;
+
+    // Custom message payload padding size
+    int payloadPaddingSize;
 };
 
 typedef struct __nats_MsgList

--- a/src/opts.c
+++ b/src/opts.c
@@ -1440,6 +1440,18 @@ natsOptions_SetCustomInboxPrefix(natsOptions *opts, const char *inboxPrefix)
     return NATS_UPDATE_ERR_STACK(s);
 }
 
+natsStatus
+natsOptions_SetMessageBufferPadding(natsOptions *opts, int paddingSize)
+{
+    LOCK_AND_CHECK_OPTIONS(opts, (paddingSize < 0));
+
+    opts->payloadPaddingSize = paddingSize;
+
+    UNLOCK_OPTS(opts);
+
+    return NATS_OK;
+}
+
 static void
 _freeOptions(natsOptions *opts)
 {

--- a/test/list.txt
+++ b/test/list.txt
@@ -122,6 +122,7 @@ OldRequest
 SimultaneousRequests
 RequestClose
 CustomInbox
+MessagePadding
 FlushInCb
 ReleaseFlush
 FlushErrOnDisconnect


### PR DESCRIPTION
When json is used as messages' payload and simdjson library is used to parse them it is strictly desirable to have SIMDJSON_PADDING bytes in the end of payload buffer. Otherwise parsing can't be done in zero copy manner - simdjson will reallocate it and copy all the payload into a temporary buffer.

I would like to introduce a new NATS option which will provide ability to set such a custom padding in message delivery path.