### PR TITLE
[CHANGED] Default connection error handler.

### DIFF
--- a/src/conn.h
+++ b/src/conn.h
@@ -152,6 +152,9 @@ bool
 natsConn_srvVersionAtLeast(natsConnection *nc, int major, int minor, int update);
 
 void
+natsConn_defaultErrHandler(natsConnection *nc, natsSubscription *sub, natsStatus err, void *closure);
+
+void
 natsConn_close(natsConnection *nc);
 
 void

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -370,6 +370,7 @@ typedef struct __jsSub
     jsCtx               *js;
     char                *stream;
     char                *consumer;
+    char                *psubj;
     char                *nxtMsgSubj;
     bool                pull;
     bool                inFetch;

--- a/src/opts.c
+++ b/src/opts.c
@@ -892,6 +892,9 @@ natsOptions_SetErrorHandler(natsOptions *opts, natsErrHandler errHandler,
     opts->asyncErrCb = errHandler;
     opts->asyncErrCbClosure = closure;
 
+    if (opts->asyncErrCb == NULL)
+        opts->asyncErrCb = natsConn_defaultErrHandler;
+
     UNLOCK_OPTS(opts);
 
     return NATS_OK;
@@ -1507,6 +1510,7 @@ natsOptions_Create(natsOptions **newOpts)
     opts->reconnectBufSize      = NATS_OPTS_DEFAULT_RECONNECT_BUF_SIZE;
     opts->reconnectJitter       = NATS_OPTS_DEFAULT_RECONNECT_JITTER;
     opts->reconnectJitterTLS    = NATS_OPTS_DEFAULT_RECONNECT_JITTER_TLS;
+    opts->asyncErrCb            = natsConn_defaultErrHandler;
 
     *newOpts = opts;
 
@@ -1586,7 +1590,7 @@ natsOptions_clone(natsOptions *opts)
             s = natsOptions_SetUserCredentialsFromMemory(cloned,
                                                         opts->userCreds->jwtAndSeedContent);
         }
-        else 
+        else
         {
             s = natsOptions_SetUserCredentialsFromFiles(cloned,
                                                         opts->userCreds->userOrChainedFile,

--- a/test/test.c
+++ b/test/test.c
@@ -2814,7 +2814,7 @@ test_natsOptions(void)
 
     test("Remove Error Handler: ");
     s = natsOptions_SetErrorHandler(opts, NULL, NULL);
-    testCond((s == NATS_OK) && (opts->asyncErrCb == NULL));
+    testCond((s == NATS_OK) && (opts->asyncErrCb == natsConn_defaultErrHandler));
 
     test("Set ClosedCB: ");
     s = natsOptions_SetClosedCB(opts, _dummyConnHandler, NULL);
@@ -3091,6 +3091,18 @@ test_natsOptions(void)
              && (strcmp(cloned->url, "url") == 0));
 
     natsOptions_Destroy(cloned);
+    opts = NULL;
+    cloned = NULL;
+
+    test("If original has default err handler, cloned has it too: ");
+    s = natsOptions_Create(&opts);
+    if (s == NATS_OK)
+        cloned = natsOptions_clone(opts);
+    testCond((s == NATS_OK) && (cloned != NULL)
+                && (cloned->asyncErrCb == natsConn_defaultErrHandler)
+                && (cloned->asyncErrCbClosure == NULL));
+    natsOptions_Destroy(cloned);
+    natsOptions_Destroy(opts);
 }
 
 static void
@@ -19047,7 +19059,7 @@ test_UserCredsFromMemory(void)
     s = natsOptions_SetUserCredentialsFromMemory(opts, "invalidCreds");
     IFOK(s, natsConnection_Connect(&nc, opts));
     testCond(s == NATS_NOT_FOUND);
-    
+
     // Use a file that contains no seed
     test("jwtAndSeed string has no seed: ");
     s = natsOptions_SetUserCredentialsFromMemory(opts, jwtWithoutSeed);
@@ -19110,7 +19122,7 @@ test_UserCredsFromMemory(void)
     t = NULL;
 
     _destroyDefaultThreadArgs(&arg);
-    
+
     natsOptions_Destroy(opts);
 }
 


### PR DESCRIPTION
If no error handler is specified by the user, the library will use a default error handler that prints some error information to stderr.

If the user did not specify an error handler but does not wish to have anything printed to stderr, the user should set a dummy error handler that does not do anything.

Resolves #622

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>