### PR TITLE
[FIXED] Use of <ctype.h> methods if char is signed

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -3005,7 +3005,7 @@ _isQueueNameValid(const char *name)
     len = (int) strlen(name);
     for (i=0; i<len ; i++)
     {
-        if (isspace(name[i]))
+        if (isspace((unsigned char) name[i]))
             return false;
     }
     return true;

--- a/src/js.c
+++ b/src/js.c
@@ -2940,7 +2940,7 @@ natsMsg_isJSCtrl(natsMsg *msg, int *ctrlType)
     if (*p != ' ')
         return false;
 
-    while ((*p != '\0') && isspace(*p))
+    while ((*p != '\0') && isspace((unsigned char) *p))
         p++;
 
     if ((*p == '\r') || (*p == '\n') || (*p == '\0'))
@@ -2951,10 +2951,10 @@ natsMsg_isJSCtrl(natsMsg *msg, int *ctrlType)
 
     p += HDR_STATUS_LEN;
 
-    if (!isspace(*p))
+    if (!isspace((unsigned char) *p))
         return false;
 
-    while (isspace(*p))
+    while (isspace((unsigned char) *p))
         p++;
 
     if (strstr(p, "Idle") == p)

--- a/src/kv.c
+++ b/src/kv.c
@@ -106,7 +106,7 @@ validBucketName(const char *bucket)
     for (i=0; i<(int)strlen(bucket); i++)
     {
         c = bucket[i];
-        if ((isalnum(c) == 0) && (c != '_') && (c != '-'))
+        if ((isalnum((unsigned char) c) == 0) && (c != '_') && (c != '-'))
             return false;
     }
     return true;
@@ -481,8 +481,8 @@ validKey(const char *key)
         {
             return false;
         }
-        else if ((isalnum(c) == 0) && (c != '.') && (c != '_') && (c != '-')
-                    && (c != '/') && (c != '\\') && (c != '='))
+        else if ((isalnum((unsigned char) c) == 0) && (c != '.') && (c != '_')
+                    && (c != '-') && (c != '/') && (c != '\\') && (c != '='))
         {
             return false;
         }

--- a/src/msg.c
+++ b/src/msg.c
@@ -220,7 +220,7 @@ _processKeyValue(int line, natsMsg *msg, char *endPtr, char **pPtr, char **lastK
         }
         return nats_setError(NATS_PROTOCOL_ERROR, "invalid start of a key: %s", start);
     }
-    if (isspace(*ptr))
+    if (isspace((unsigned char) *ptr))
     {
         if (line == 0)
             return nats_setError(NATS_PROTOCOL_ERROR, "key cannot start with a space: %s", ptr);
@@ -240,7 +240,7 @@ _processKeyValue(int line, natsMsg *msg, char *endPtr, char **pPtr, char **lastK
         (*col) = '\0';
     }
 
-    while ((ptr != endPtr) && (isspace(*ptr)))
+    while ((ptr != endPtr) && (isspace((unsigned char) *ptr)))
         ptr++;
 
     if (ptr == endPtr)
@@ -259,7 +259,7 @@ _processKeyValue(int line, natsMsg *msg, char *endPtr, char **pPtr, char **lastK
     endval--;
     if (*endval == '\r')
         endval--;
-    while ((endval != val) && (isspace(*endval)))
+    while ((endval != val) && (isspace((unsigned char) *endval)))
         endval--;
     endval++;
     *(endval) = '\0';
@@ -404,7 +404,7 @@ _liftHeaders(natsMsg *msg, bool setOrAdd)
                     // Restore character of starting description
                     *desc = descb;
                     // Trim left spaces
-                    while ((*desc != '\0') && isspace((int) *desc))
+                    while ((*desc != '\0') && isspace((unsigned char) *desc))
                         desc++;
 
                     // If we are not at the end of description
@@ -412,7 +412,7 @@ _liftHeaders(natsMsg *msg, bool setOrAdd)
                     {
                         // Go to end of description and walk back to trim right.
                         desce = (char*) (desc + (int) strlen(desc) - 1);
-                        while ((desce != desc) && isspace((int) *desce))
+                        while ((desce != desc) && isspace((unsigned char) *desce))
                         {
                             *desce = '\0';
                             desce--;

--- a/src/util.c
+++ b/src/util.c
@@ -192,12 +192,12 @@ nats_Trim(char **pres, const char *s)
     char    *ptr   = (char*) s;
     char    *start = (char*) s;
 
-    while ((*ptr != '\0') && isspace(*ptr))
+    while ((*ptr != '\0') && isspace((unsigned char) *ptr))
         ptr++;
 
     start = ptr;
     ptr = (char*) (s + strlen(s) - 1);
-    while ((ptr != start) && isspace(*ptr))
+    while ((ptr != start) && isspace((unsigned char) *ptr))
         ptr--;
 
     // Compute len of trimmed string
@@ -571,7 +571,7 @@ _jsonGetNum(char **ptr, nats_JSONField *field)
     int         decPCount      = 0;
     int         numTyp         = 0;
 
-    while (isspace(*p))
+    while (isspace((unsigned char) *p))
         p++;
 
     sign = (*p == '-' ? -1.0 : 1.0);
@@ -579,7 +579,7 @@ _jsonGetNum(char **ptr, nats_JSONField *field)
     if ((*p == '-') || (*p == '+'))
         p++;
 
-    while (isdigit(*p))
+    while (isdigit((unsigned char) *p))
         uintVal = uintVal * 10 + (*p++ - '0');
 
     if (*p == '.')
@@ -588,7 +588,7 @@ _jsonGetNum(char **ptr, nats_JSONField *field)
         numTyp = TYPE_DOUBLE;
     }
 
-    while (isdigit(*p))
+    while (isdigit((unsigned char) *p))
     {
         decVal = decVal * 10 + (*p++ - '0');
         decPower *= 10;
@@ -608,7 +608,7 @@ _jsonGetNum(char **ptr, nats_JSONField *field)
         if ((*p == '-') || (*p == '+'))
             p++;
 
-        while (isdigit(*p))
+        while (isdigit((unsigned char) *p))
             eVal = eVal * 10 + (*p++ - '0');
 
         if (expIsNegative)
@@ -884,7 +884,7 @@ _jsonParseValue(char **str, nats_JSONField *field, int nested)
         field->typ = TYPE_BOOL;
         s = _jsonGetBool(&ptr, &field->value.vbool);
     }
-    else if (isdigit(*ptr) || (*ptr == '-'))
+    else if (isdigit((unsigned char) *ptr) || (*ptr == '-'))
     {
         field->typ = TYPE_NUM;
         s = _jsonGetNum(&ptr, field);
@@ -2244,7 +2244,7 @@ nats_IsSubjectValid(const char *subject, bool wcAllowed)
     for (i=0; i<len ; i++)
     {
         c = subject[i];
-        if (isspace(c))
+        if (isspace((unsigned char) c))
             return false;
 
         if (c == '.')


### PR DESCRIPTION
According to the C standard, the argument to the <ctype.h> methods shall be representable as an unsigned char or shall equal the value of the macro EOF.  It is implementation-defined if the char type is signed or unsigned.

Signed-off-by: Sebastian Huber <sebastian.huber@embedded-brains.de>