### PR TITLE
[FIXED] Bytes accounting while reading the INFO protocol

### DIFF
--- a/src/comsock.c
+++ b/src/comsock.c
@@ -366,6 +366,7 @@ natsSock_ReadLine(natsSockCtx *ctx, char *buffer, size_t maxBufferSize)
             // This is a partial, we need to read more data until we get to
             // the end of the line (\r\n).
             p = (char*) (p + len);
+            totalBytes += len;
         }
         else
         {


### PR DESCRIPTION
This is potential buffer overflow vulnerability that can be exploited if server is controlled by an intruder.

If we detect that the buffer contains data then we have to reduce available space for the subsequent read operation. Otherwise read can overwrite memory past the buffer.

P.S.: Just discovered that this function is called only from one place and supplied buffer is always empty there. So actualy not a vulnerabilty but as it is written should be fixed in case anyone in future will use this function with non-empty buffer.