### PR TITLE
[FIXED] Crash processing inbound message for destroyed subscription

### DIFF
--- a/src/sub.h
+++ b/src/sub.h
@@ -79,6 +79,12 @@ void
 natsSubAndLdw_Unlock(natsSubscription *sub);
 
 void
+natsSubAndLdw_LockAndRetain(natsSubscription *sub);
+
+void
+natsSubAndLdw_UnlockAndRelease(natsSubscription *sub);
+
+void
 natsSub_close(natsSubscription *sub, bool connectionClosed);
 
 #endif /* SUB_H_ */


### PR DESCRIPTION
A race could cause the read loop to crash when processing a message for a subscription that is being removed in another thread.

Resolves #637