### PR TITLE
[FIXED] natsConnection_RequestMsg() incorrectly returns NATS_NO_SERVER_SUPPORT

### DIFF
--- a/src/pub.c
+++ b/src/pub.c
@@ -104,6 +104,10 @@ natsConn_publish(natsConnection *nc, natsMsg *msg, const char *reply, bool direc
     // accessing the headers. It should still be considered having headers.
     if ((msg->headers != NULL) || natsMsg_needsLift(msg))
     {
+        // Do the check for server's headers support only after we have completed
+        // the initial connect (we could be here with initc true - that is, initial
+        // connect in progress - when using natsOptions_SetRetryOnFailedConnect
+        // option).
         if (!nc->initc && !nc->info.headers)
         {
             natsConn_Unlock(nc);

--- a/src/pub.c
+++ b/src/pub.c
@@ -104,7 +104,7 @@ natsConn_publish(natsConnection *nc, natsMsg *msg, const char *reply, bool direc
     // accessing the headers. It should still be considered having headers.
     if ((msg->headers != NULL) || natsMsg_needsLift(msg))
     {
-        if (!nc->info.headers)
+        if (!nc->initc && !nc->info.headers)
         {
             natsConn_Unlock(nc);
 

--- a/test/test.c
+++ b/test/test.c
@@ -32674,6 +32674,9 @@ test_StanBasicPublish(void)
 
     stanConnection_Destroy(sc);
 
+    if (valgrind)
+        nats_Sleep(900);
+
     _stopServer(pid);
 }
 
@@ -32730,6 +32733,9 @@ test_StanBasicPublishAsync(void)
     stanConnection_Destroy(sc);
 
     _destroyDefaultThreadArgs(&args);
+
+    if (valgrind)
+        nats_Sleep(900);
 
     _stopServer(pid);
 }

--- a/test/test.c
+++ b/test/test.c
@@ -9530,6 +9530,8 @@ test_RetryOnFailedConnect(void)
     int64_t             end   = 0;
     natsThread          *t    = NULL;
     natsSubscription    *sub  = NULL;
+    natsMsg             *msg  = NULL;
+    natsMsg             *rmsg = NULL;
     struct threadArg    arg;
 
     s = _createDefaultThreadArgsForCbTests(&arg);
@@ -9595,6 +9597,16 @@ test_RetryOnFailedConnect(void)
     IFOK(s, natsConnection_Connect(&nc, opts));
     testCond((s == NATS_NOT_YET_CONNECTED) && (nc != NULL));
     nats_clearLastError();
+
+    // Request with a message with headers does timeout as opposed to returning
+    // the NATS_NO_SERVER_SUPPORT error.
+    test("Request with message with headers: ");
+    s = natsMsg_Create(&msg, "request.headers", NULL, "hello", 5);
+    IFOK(s, natsMsgHeader_Set(msg, "some", "header"));
+    IFOK(s, natsConnection_RequestMsg(&rmsg, nc, msg, 250));
+    testCond(s == NATS_TIMEOUT);
+    nats_clearLastError();
+    natsMsg_Destroy(msg);
 
     test("Subscription ok: ");
     arg.control = 99;


### PR DESCRIPTION
When using `natsOptions_SetRetryOnFailedConnect` option to connect and the library is not yet connected, calling `natsConnection_RequestMsg` with a message with headers would incorrectly return `NATS_NO_SERVER_SUPPORT` instead of `NATS_TIMEOUT`.

Resolves #644

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>