### PR TITLE
added `natsConn_(get|set)(Error|Closed)Callback`

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -4432,3 +4432,59 @@ natsConn_defaultErrHandler(natsConnection *nc, natsSubscription *sub, natsStatus
     }
     fflush(stderr);
 }
+
+natsStatus
+natsConn_getErrorCallback(natsErrHandler *cb, void **closure, natsConnection *nc)
+{
+    if ((nc == NULL) || (cb == NULL) || (closure == NULL))
+        return nats_setDefaultError(NATS_INVALID_ARG);
+
+    natsConn_Lock(nc);
+    *cb = nc->opts->asyncErrCb;
+    *closure = nc->opts->asyncErrCbClosure;
+    natsConn_Unlock(nc);
+
+    return NATS_OK;
+}
+
+natsStatus
+natsConn_setErrorCallback(natsConnection *nc, natsErrHandler cb, void *closure)
+{
+    if ((nc == NULL) || (cb == NULL))
+        return nats_setDefaultError(NATS_INVALID_ARG);
+
+    natsConn_Lock(nc);
+    nc->opts->asyncErrCb = cb;
+    nc->opts->asyncErrCbClosure = closure;
+    natsConn_Unlock(nc);
+
+    return NATS_OK;
+}
+
+natsStatus
+natsConn_getClosedCallback(natsConnectionHandler *cb, void **closure, natsConnection *nc)
+{
+    if ((nc == NULL) || (cb == NULL) || (closure == NULL))
+        return nats_setDefaultError(NATS_INVALID_ARG);
+
+    natsConn_Lock(nc);
+    *cb = nc->opts->closedCb;
+    *closure = nc->opts->closedCbClosure;
+    natsConn_Unlock(nc);
+
+    return NATS_OK;
+}
+
+natsStatus
+natsConn_setClosedCallback(natsConnection *nc, natsConnectionHandler cb, void *closure)
+{
+    if ((nc == NULL) || (cb == NULL))
+        return nats_setDefaultError(NATS_INVALID_ARG);
+
+    natsConn_Lock(nc);
+    nc->opts->closedCb = cb;
+    nc->opts->closedCbClosure = closure;
+    natsConn_Unlock(nc);
+
+    return NATS_OK;
+}

--- a/src/conn.h
+++ b/src/conn.h
@@ -160,4 +160,17 @@ natsConn_close(natsConnection *nc);
 void
 natsConn_destroy(natsConnection *nc, bool fromPublicDestroy);
 
+natsStatus
+natsConn_setErrorCallback(natsConnection *nc, natsErrHandler cb, void *closure);
+
+natsStatus 
+natsConn_getErrorCallback(natsErrHandler *cb, void **closure, natsConnection *nc);
+
+natsStatus
+natsConn_setClosedCallback(natsConnection *nc, natsConnectionHandler cb, void *closure);
+
+natsStatus 
+natsConn_getClosedCallback(natsConnectionHandler *cb, void **closure, natsConnection *nc);
+
+
 #endif /* CONN_H_ */

--- a/src/nats.c
+++ b/src/nats.c
@@ -765,6 +765,9 @@ _asyncCbsThread(void *arg)
 
         // callback handlers can be updated on a live connection, so we need to
         // lock.
+        cbHandler = NULL;
+        errHandler = NULL;
+        cbClosure = NULL;
         natsMutex_Lock(nc->mu);
         switch (cb->type)
         {
@@ -811,7 +814,6 @@ _asyncCbsThread(void *arg)
             if (cb->errTxt != NULL)
                 nats_setErrStatusAndTxt(cb->err, cb->errTxt);
             (*(errHandler))(nc, cb->sub, cb->err, cbClosure);
-            break;
         }
 #if defined(NATS_HAS_STREAMING)
         else if (cb->type == ASYNC_STAN_CONN_LOST)

--- a/src/nats.c
+++ b/src/nats.c
@@ -768,41 +768,41 @@ _asyncCbsThread(void *arg)
         cbHandler = NULL;
         errHandler = NULL;
         cbClosure = NULL;
-        natsMutex_Lock(nc->mu);
+
+#define __set_handler(_h, _cb, _cl) \
+        { \
+            natsMutex_Lock(nc->mu); \
+            _h = nc->opts->_cb; \
+            cbClosure = nc->opts->_cl; \
+            natsMutex_Unlock(nc->mu); \
+        }
+
         switch (cb->type)
         {
             case ASYNC_CLOSED:
-               cbHandler = nc->opts->closedCb;
-               cbClosure = nc->opts->closedCbClosure;
-               break;
+                __set_handler(cbHandler, closedCb, closedCbClosure);
+                break;
             case ASYNC_DISCONNECTED:
-                cbHandler = nc->opts->disconnectedCb;
-                cbClosure = nc->opts->disconnectedCbClosure;
+                __set_handler(cbHandler, disconnectedCb, disconnectedCbClosure);
                 break;
             case ASYNC_RECONNECTED:
-                cbHandler = nc->opts->reconnectedCb;
-                cbClosure = nc->opts->reconnectedCbClosure;
+                __set_handler(cbHandler, reconnectedCb, reconnectedCbClosure);
                 break;
             case ASYNC_CONNECTED:
-                cbHandler = nc->opts->connectedCb;
-                cbClosure = nc->opts->connectedCbClosure;
+                __set_handler(cbHandler, connectedCb, connectedCbClosure);
                 break;
             case ASYNC_DISCOVERED_SERVERS:
-                cbHandler = nc->opts->discoveredServersCb;
-                cbClosure = nc->opts->discoveredServersClosure;
+                __set_handler(cbHandler, discoveredServersCb, discoveredServersClosure);
                 break;
             case ASYNC_LAME_DUCK_MODE:
-                cbHandler = nc->opts->lameDuckCb;
-                cbClosure = nc->opts->lameDuckClosure;
+                __set_handler(cbHandler, lameDuckCb, lameDuckClosure);
                 break;
             case ASYNC_ERROR:
-                errHandler = nc->opts->asyncErrCb;
-                cbClosure =  nc->opts->asyncErrCbClosure;
+                __set_handler(errHandler, asyncErrCb, asyncErrCbClosure);
                 break;
             default:
                 break;
         }
-        natsMutex_Unlock(nc->mu);
 
         // Invoke the callback
         if (cbHandler != NULL)

--- a/test/list.txt
+++ b/test/list.txt
@@ -67,6 +67,7 @@ ConnectionWithNULLOptions
 ConnectionToWithNullURLs
 ConnectionStatus
 ConnClosedCB
+SetConnClosedCB
 CloseDisconnectedCB
 ServerStopDisconnectedCB
 ClosedConnections
@@ -147,7 +148,7 @@ AsyncSubscriptionPendingDrain
 SyncSubscriptionPending
 SyncSubscriptionPendingDrain
 AsyncErrHandler
-AsyncSetErrHandler
+SetAsyncErrHandler
 AsyncSubscriberStarvation
 AsyncSubscriberOnClose
 NextMsgCallOnAsyncSub

--- a/test/list.txt
+++ b/test/list.txt
@@ -147,6 +147,7 @@ AsyncSubscriptionPendingDrain
 SyncSubscriptionPending
 SyncSubscriptionPendingDrain
 AsyncErrHandler
+AsyncSetErrHandler
 AsyncSubscriberStarvation
 AsyncSubscriberOnClose
 NextMsgCallOnAsyncSub


### PR DESCRIPTION
To use in the microservices implementation, to wrap connection handlers on an active connection.

(still need to add a test for `setClosedCallback`)