### PR TITLE
natsConnection_Buffered: fix returned value in case of error

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -3811,7 +3811,7 @@ natsConnection_Buffered(natsConnection *nc)
     int buffered = -1;
 
     if (nc == NULL)
-        return nats_setDefaultError(NATS_INVALID_ARG);
+        return buffered;
 
     natsConn_Lock(nc);
 


### PR DESCRIPTION
This function returns number of bytes in the buffer.
It is incorrect to return value from `natsStatus` enum.

We could keep setting internal error code.
But in this case we should set error code for other cases too where we return `-1`