### PR TITLE
conn.c: _doReconnect: remove redundant assignment

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -1552,7 +1552,6 @@ _doReconnect(void *arg)
         // TODO: since we sleep only after the whole list has been tried, we can't
         // rely on individual *natsSrv to know if it is a TLS or non-TLS url.
         // We have to pick which type of jitter to use, for now, we use these hints:
-        jitter = nc->opts->reconnectJitter;
         if (nc->opts->secure || (nc->opts->sslCtx != NULL))
             jitter = nc->opts->reconnectJitterTLS;
     }


### PR DESCRIPTION
This is not a bug. But this is not a feature too.
I decided to merge PR into dev. But I can update PR to apply to master instead.
