### PR TITLE
Removed the never-implemented schema

### DIFF
--- a/examples/micro-sequence.c
+++ b/examples/micro-sequence.c
@@ -156,7 +156,6 @@ int main(int argc, char **argv)
         .Subject = "sequence",
         .Name = "sequence-service",
         .Handler = handle_sequence,
-        .Schema = NULL,
     };
     microServiceConfig cfg = {
         .Description = "Sequence adder - NATS microservice example in C",

--- a/src/micro_endpoint.c
+++ b/src/micro_endpoint.c
@@ -305,44 +305,6 @@ bool micro_is_valid_subject(const char *subject)
     return true;
 }
 
-static inline void
-destroy_schema(microSchema *schema)
-{
-    if (schema == NULL)
-        return;
-
-    NATS_FREE((char *)schema->Request);
-    NATS_FREE((char *)schema->Response);
-    NATS_FREE(schema);
-}
-
-static microError *
-clone_schema(microSchema **to, const microSchema *from)
-{
-    microError *err = NULL;
-    if (from == NULL)
-    {
-        *to = NULL;
-        return NULL;
-    }
-
-    *to = NATS_CALLOC(1, sizeof(microSchema));
-    if (*to == NULL)
-        return micro_ErrorOutOfMemory;
-
-    MICRO_CALL(err, micro_strdup((char **)&((*to)->Request), from->Request));
-    MICRO_CALL(err, micro_strdup((char **)&((*to)->Response), from->Response));
-
-    if (err != NULL)
-    {
-        destroy_schema(*to);
-        *to = NULL;
-        return err;
-    }
-
-    return NULL;
-}
-
 static inline microError *
 new_endpoint_config(microEndpointConfig **ptr)
 {
@@ -373,7 +335,6 @@ micro_clone_endpoint_config(microEndpointConfig **out, microEndpointConfig *cfg)
 
     MICRO_CALL(err, micro_strdup((char **)&new_cfg->Name, cfg->Name));
     MICRO_CALL(err, micro_strdup((char **)&new_cfg->Subject, cfg->Subject));
-    MICRO_CALL(err, clone_schema(&new_cfg->Schema, cfg->Schema));
 
     if (err != NULL)
     {
@@ -395,7 +356,6 @@ void micro_free_cloned_endpoint_config(microEndpointConfig *cfg)
     NATS_FREE((char *)cfg->Name);
     NATS_FREE((char *)cfg->Subject);
 
-    destroy_schema(cfg->Schema);
     NATS_FREE(cfg);
 }
 

--- a/src/microp.h
+++ b/src/microp.h
@@ -31,10 +31,6 @@
 
 #define MICRO_DEFAULT_ENDPOINT_NAME "default"
 
-// 4 verbs: INFO, STATS, PING, SCHEMA;
-// 3 subjects for each verb.
-#define MICRO_MONITORING_SUBS_CAP (4 * 3)
-
 struct micro_error_s
 {
     bool is_internal;

--- a/src/nats.h
+++ b/src/nats.h
@@ -7220,11 +7220,6 @@ typedef struct micro_group_s microGroup;
  */
 typedef struct micro_request_s microRequest;
 
-/**
- * The Microservice endpoint schema object.
- */
-typedef struct micro_schema_s microSchema;
-
 /** 
  * @brief the main object for a configured microservice.
  *
@@ -7347,11 +7342,6 @@ struct micro_endpoint_config_s
     const char *Subject;
 
     /**
-     * @brief The endpoint schema.
-     */
-    microSchema *Schema;
-
-    /**
      * @brief The request handler for the endpoint.
      */
     microRequestHandler Handler;
@@ -7401,15 +7391,6 @@ struct micro_endpoint_stats_s
      * @brief a copy of the last error message.
      */
     char LastErrorString[2048];
-};
-
-/**
- * @brief The Microservice endpoint schema object.
- */
-struct micro_schema_s
-{
-    const char *Request;
-    const char *Response;
 };
 
 /**
@@ -7592,16 +7573,6 @@ struct micro_service_stats_s
  * @brief For `$SRV.PING` subjects.
  */
 #define MICRO_PING_VERB "PING"
-
-/**
- * @brief The `type` set in the `$SRV.SCHEMA` response.
- */
-#define MICRO_STATS_SCHEMA_TYPE "io.nats.micro.v1.schema_response"
-
-/**
- * @brief For `$SRV.SCHEMA` subjects.
- */
-#define MICRO_SCHEMA_VERB "SCHEMA"
 
 /**
  * @brief The `type` set in the `STATS` response.


### PR DESCRIPTION
I never finished the schema implementation, but thankfully it's been removed, see https://github.com/nats-io/nats-architecture-and-design/issues/220 and https://github.com/nats-io/nats.go/pull/1270.

This PR removes it from the C implementation.