### PR TITLE
Fixed error handling and final cleanup

### DIFF
--- a/src/micro_error.c
+++ b/src/micro_error.c
@@ -107,7 +107,7 @@ micro_ErrorFromStatus(natsStatus s)
     err = NATS_CALLOC(1, sizeof(microError) + message_len + 1);
     if (err == NULL)
         return &_errorOutOfMemory;
-
+    err->message = (char *)(err + 1);
     err->status = s;
     memcpy(err->message, message, message_len + 1);
     return err;


### PR DESCRIPTION
Haven't really fixed anything yet.

WAS:
_- Fixed `micro` error callback mapping to endpoints & the test.
- Fixed the Stop/Destroy cleanup - ended up non-trivial, and potentially overly complex. @kozlovic I'd really appreciate any tips on how this can be simpler. Cases this handles:
  - A "normal" shutdown. the main/user thread calling `microService_Destroy`, draining the subs, and leaving `nc` intact,  `on_connection_closed` is never called.
  - The connection is closed - closes the subs before calling `on_connection_closed`, server stops
  - An error - the subs need to be drained._