### PR TITLE
[ADDED] Support for (multiple) ConsumerConfig.FilterSubjects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ cmake-build*/
 install/
 html/
 !doc/html/
+test/datastore_*/
 
 # Emacs
 *~

--- a/src/jsm.c
+++ b/src/jsm.c
@@ -2756,6 +2756,22 @@ _marshalConsumerCreateReq(natsBuffer **new_buf, const char *stream, jsConsumerCo
         IFOK(s, natsBuf_Append(buf, cfg->FilterSubject, -1));
         IFOK(s, natsBuf_AppendByte(buf, '"'));
     }
+    if ((s == NATS_OK) && (cfg->FilterSubjectsLen > 0))
+    {
+        int i;
+
+        s = natsBuf_Append(buf, ",\"filter_subjects\":[", -1);
+        for (i = 0; (s == NATS_OK) && (i < cfg->FilterSubjectsLen); i++)
+        {
+            if (i > 0)
+                s = natsBuf_AppendByte(buf, ',');
+            IFOK(s, natsBuf_AppendByte(buf, '"'));
+            IFOK(s, natsBuf_Append(buf, cfg->FilterSubjects[i], -1));
+            IFOK(s, natsBuf_AppendByte(buf, '"'));
+        }
+
+        IFOK(s, natsBuf_AppendByte(buf, ']'));
+    }
     IFOK(s, _marshalReplayPolicy(buf, cfg->ReplayPolicy))
     if ((s == NATS_OK) && (cfg->RateLimit > 0))
         s = nats_marshalULong(buf, true, "rate_limit_bps", cfg->RateLimit);
@@ -2815,6 +2831,8 @@ _marshalConsumerCreateReq(natsBuffer **new_buf, const char *stream, jsConsumerCo
 void
 js_destroyConsumerConfig(jsConsumerConfig *cc)
 {
+    int i;
+
     if (cc == NULL)
         return;
 
@@ -2824,7 +2842,10 @@ js_destroyConsumerConfig(jsConsumerConfig *cc)
     NATS_FREE((char*) cc->DeliverSubject);
     NATS_FREE((char*) cc->DeliverGroup);
     NATS_FREE((char*) cc->FilterSubject);
-    NATS_FREE((char*) cc->SampleFrequency);
+    for (i = 0; i < cc->FilterSubjectsLen; i++)
+        NATS_FREE((char *)cc->FilterSubjects[i]);
+    NATS_FREE((char *)cc->FilterSubjects);
+    NATS_FREE((char *)cc->SampleFrequency);
     NATS_FREE(cc->BackOff);
     NATS_FREE(cc);
 }
@@ -2931,6 +2952,7 @@ _unmarshalConsumerConfig(nats_JSON *json, const char *fieldName, jsConsumerConfi
         IFOK(s, nats_JSONGetLong(cjson, "ack_wait", &(cc->AckWait)));
         IFOK(s, nats_JSONGetLong(cjson, "max_deliver", &(cc->MaxDeliver)));
         IFOK(s, nats_JSONGetStr(cjson, "filter_subject", (char**) &(cc->FilterSubject)));
+        IFOK(s, nats_JSONGetArrayStr(cjson, "filter_subjects", (char ***)&(cc->FilterSubjects), &(cc->FilterSubjectsLen)));
         IFOK(s, _unmarshalReplayPolicy(cjson, "replay_policy", &(cc->ReplayPolicy)));
         IFOK(s, nats_JSONGetULong(cjson, "rate_limit_bps", &(cc->RateLimit)));
         IFOK(s, nats_JSONGetStr(cjson, "sample_freq", (char**) &(cc->SampleFrequency)));
@@ -3083,7 +3105,7 @@ js_AddConsumer(jsConsumerInfo **new_ci, jsCtx *js,
         {
             // No subject filter, use <stream>.<consumer name>
             // otherwise, the filter subject goes at the end.
-            if (nats_IsStringEmpty(cfg->FilterSubject))
+            if (nats_IsStringEmpty(cfg->FilterSubject) || (cfg->FilterSubjectsLen > 0))
                 res = nats_asprintf(&subj, jsApiConsumerCreateExT,
                                     js_lenWithoutTrailingDot(o.Prefix), o.Prefix,
                                     stream, cfg->Name);
@@ -3633,6 +3655,8 @@ js_cloneConsumerConfig(jsConsumerConfig *org, jsConsumerConfig **clone)
     c->Description = NULL;
     c->BackOff = NULL;
     c->FilterSubject = NULL;
+    c->FilterSubjects = NULL;
+    c->FilterSubjectsLen = 0;
     c->SampleFrequency = NULL;
     c->DeliverSubject = NULL;
     c->DeliverGroup = NULL;
@@ -3651,6 +3675,17 @@ js_cloneConsumerConfig(jsConsumerConfig *org, jsConsumerConfig **clone)
             s = nats_setDefaultError(NATS_NO_MEMORY);
         else
             memcpy(c->BackOff, org->BackOff, org->BackOffLen*sizeof(int64_t));
+    }
+    if ((s == NATS_OK) && (org->FilterSubjects != NULL) && (org->FilterSubjectsLen > 0))
+    {
+        c->FilterSubjects = (const char **)NATS_CALLOC(org->FilterSubjectsLen, sizeof(const char *));
+        if (c->FilterSubjects == NULL)
+            s = nats_setDefaultError(NATS_NO_MEMORY);
+
+        for (int i = 0; (s == NATS_OK) && (i < org->FilterSubjectsLen); i++)
+        {
+            IF_OK_DUP_STRING(s, c->FilterSubjects[i], org->FilterSubjects[i]);
+        }
     }
     if (s == NATS_OK)
         *clone = c;

--- a/src/nats.h
+++ b/src/nats.h
@@ -744,6 +744,8 @@ typedef struct jsConsumerConfig
         int64_t                 *BackOff;               ///< Redelivery durations expressed in nanoseconds
         int                     BackOffLen;
         const char              *FilterSubject;
+        const char              **FilterSubjects;        // Multiple filter subjects introduced in 2.10
+        int                     FilterSubjectsLen;
         jsReplayPolicy          ReplayPolicy;
         uint64_t                RateLimit;
         const char              *SampleFrequency;

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -103,6 +103,7 @@
 #define MAX_FRAMES (50)
 
 #define nats_IsStringEmpty(s) ((((s) == NULL) || ((s)[0] == '\0')) ? true : false)
+#define nats_HasPrefix(_s, _prefix) (nats_IsStringEmpty(_s) ? nats_IsStringEmpty(_prefix) : (strncmp((_s), (_prefix), strlen(_prefix)) == 0))
 
 #define DUP_STRING(s, s1, s2) \
         { \

--- a/test/test.c
+++ b/test/test.c
@@ -23872,6 +23872,7 @@ test_JetStreamMgtConsumers(void)
     int                 count   = 0;
     natsMsg             *msg    = NULL;
     jsConsumerConfig    *cloneCfg = NULL;
+    const char          *multiFilterSubjects[] = {"bar1", "bar2"};
 
     JS_SETUP(2, 9, 0);
 
@@ -24053,6 +24054,34 @@ test_JetStreamMgtConsumers(void)
                     natsMsg_GetDataLength(resp)) == 0));
     natsMsg_Destroy(resp);
     resp = NULL;
+
+    test("Add consumer (non durable, filter subjects): ");
+    cfg.FilterSubject = NULL;
+    cfg.FilterSubjects = multiFilterSubjects;
+    cfg.FilterSubjectsLen = 2;
+    s = js_AddConsumer(&ci, js, "MY_STREAM", &cfg, NULL, &jerr);
+    testCond((s = NATS_ERR) && (jerr == JSStreamNotFoundErr) && (ci == NULL));
+    nats_clearLastError();
+
+    test("Verify config: ");
+    s = natsSubscription_NextMsg(&resp, sub, 1000);
+    testCond((s == NATS_OK) && (resp != NULL) && (strncmp(natsMsg_GetData(resp), "{\"stream_name\":\"MY_STREAM\","
+                                                                                 "\"config\":{\"deliver_policy\":\"last\","
+                                                                                 "\"description\":\"MyDescription\","
+                                                                                 "\"deliver_subject\":\"foo\","
+                                                                                 "\"opt_start_seq\":100,"
+                                                                                 "\"opt_start_time\":\"2021-06-23T18:22:00.12345Z\",\"ack_policy\":\"explicit\","
+                                                                                 "\"ack_wait\":200,\"max_deliver\":300,\"filter_subjects\":[\"bar1\",\"bar2\"],"
+                                                                                 "\"replay_policy\":\"instant\",\"rate_limit_bps\":400,"
+                                                                                 "\"sample_freq\":\"60%%\",\"max_waiting\":500,\"max_ack_pending\":600,"
+                                                                                 "\"flow_control\":true,\"idle_heartbeat\":700,"
+                                                                                 "\"num_replicas\":1,\"mem_storage\":true}}",
+                                                          natsMsg_GetDataLength(resp)) == 0));
+    natsMsg_Destroy(resp);
+    resp = NULL;
+    cfg.FilterSubjects = NULL;
+    cfg.FilterSubjectsLen = 0;
+    cfg.FilterSubject = "bar";
 
     test("Create check sub: ");
     natsSubscription_Destroy(sub);
@@ -24347,6 +24376,29 @@ test_JetStreamMgtConsumers(void)
                 && (strcmp(ci->Config->FilterSubject, "bar.bat") == 0));
     jsConsumerInfo_Destroy(ci);
     ci = NULL;
+
+    test("Update (filter subjects) works ok: ");
+    cfg.FilterSubject = NULL;
+    cfg.FilterSubjects = multiFilterSubjects;
+    cfg.FilterSubjectsLen = 2;
+    s = js_UpdateConsumer(&ci, js, "MY_STREAM", &cfg, NULL, &jerr);
+    testCond((s == NATS_OK) && (jerr == 0) && (ci != NULL) && (ci->Config != NULL)
+                && (strcmp(ci->Config->Description, "my description") == 0)
+                && (ci->Config->AckWait == NATS_SECONDS_TO_NANOS(2))
+                && (ci->Config->MaxDeliver == 1)
+                && (strcmp(ci->Config->SampleFrequency, "30") == 0)
+                && (ci->Config->MaxAckPending == 10)
+                && (ci->Config->HeadersOnly)
+                && (ci->Config->FilterSubject == NULL)
+                && (ci->Config->FilterSubjectsLen == 2)
+                && (ci->Config->FilterSubjects != NULL)
+                && (strcmp(ci->Config->FilterSubjects[0], "bar1") == 0)
+                && (strcmp(ci->Config->FilterSubjects[1], "bar2") == 0));
+    jsConsumerInfo_Destroy(ci);
+    ci = NULL;
+    cfg.FilterSubject = "bar.bat";
+    cfg.FilterSubjects = NULL;
+    cfg.FilterSubjectsLen = 0;
 
     test("Add pull consumer: ");
     jsConsumerConfig_Init(&cfg);
@@ -24659,9 +24711,11 @@ test_JetStreamMgtConsumers(void)
     cfg.Durable = "B";
     cfg.Description = "C";
     cfg.FilterSubject = "D";
-    cfg.SampleFrequency = "E";
-    cfg.DeliverSubject = "F";
-    cfg.DeliverGroup = "G";
+    cfg.FilterSubjects = (const char*[]){"E", "F"};
+    cfg.FilterSubjectsLen = 2;
+    cfg.SampleFrequency = "G";
+    cfg.DeliverSubject = "H";
+    cfg.DeliverGroup = "I";
     cfg.BackOff = (int64_t[]){NATS_MILLIS_TO_NANOS(50), NATS_MILLIS_TO_NANOS(250)};
     cfg.BackOffLen = 2;
     s = js_cloneConsumerConfig(&cfg, &cloneCfg);
@@ -24670,9 +24724,14 @@ test_JetStreamMgtConsumers(void)
                 && (cloneCfg->Durable != NULL) && (strcmp(cloneCfg->Durable, "B") == 0)
                 && (cloneCfg->Description != NULL) && (strcmp(cloneCfg->Description, "C") == 0)
                 && (cloneCfg->FilterSubject != NULL) && (strcmp(cloneCfg->FilterSubject, "D") == 0)
-                && (cloneCfg->SampleFrequency != NULL) && (strcmp(cloneCfg->SampleFrequency, "E") == 0)
-                && (cloneCfg->DeliverSubject != NULL) && (strcmp(cloneCfg->DeliverSubject, "F") == 0)
-                && (cloneCfg->DeliverGroup != NULL) && (strcmp(cloneCfg->DeliverGroup, "G") == 0)
+                && (cloneCfg->FilterSubject != NULL) && (strcmp(cloneCfg->FilterSubject, "D") == 0)
+                && (cloneCfg->FilterSubjectsLen == 0)
+                && (cloneCfg->FilterSubjects != NULL)
+                && (strcmp(cloneCfg->FilterSubjects[0], "E") == 0)
+                && (strcmp(cloneCfg->FilterSubjects[1], "F") == 0)
+                && (cloneCfg->SampleFrequency != NULL) && (strcmp(cloneCfg->SampleFrequency, "G") == 0)
+                && (cloneCfg->DeliverSubject != NULL) && (strcmp(cloneCfg->DeliverSubject, "H") == 0)
+                && (cloneCfg->DeliverGroup != NULL) && (strcmp(cloneCfg->DeliverGroup, "I") == 0)
                 && (cloneCfg->BackOffLen == 2)
                 && (cloneCfg->BackOff != NULL)
                 && (cloneCfg->BackOff[0] == NATS_MILLIS_TO_NANOS(50))
@@ -26197,6 +26256,26 @@ test_JetStreamSubscribe(void)
     testCond((s == NATS_ERR) && (sub == NULL)
                 && (strstr(nats_GetLastError(NULL), "filter subject") != NULL));
     nats_clearLastError();
+
+    test("Create consumer with multiple filters: ");
+    jsConsumerConfig_Init(&cc);
+    cc.Durable = "dur-multi-filter";
+    cc.DeliverSubject = "push.dur.sub.2";
+    cc.FilterSubjectsLen = 2;
+    cc.FilterSubjects = (const char*[2]){"sub.1", "sub.2"};
+    s = js_AddConsumer(NULL, js, "MULTIPLE_SUBJS", &cc, NULL, &jerr);
+    testCond((s == NATS_OK) && (jerr == 0));
+
+    test("Subscribe subj != filters: ");
+    so.Consumer = "dur-multi-filter";
+    s = js_Subscribe(&sub, js, "foo", _jsMsgHandler, &args, NULL, &so, &jerr);
+    testCond((s == NATS_ERR) && (sub == NULL)
+                && (strstr(nats_GetLastError(NULL), "filter subject") != NULL));
+    nats_clearLastError();
+    cc.FilterSubject = "sub.2";
+    cc.FilterSubjects = NULL;
+    cc.FilterSubjectsLen = 0;
+    so.Consumer = "dur";
 
     test("Subject not required when binding to stream/consumer: ");
     s = js_Subscribe(&sub, js, NULL, _jsMsgHandler, &args, NULL, &so, &jerr);


### PR DESCRIPTION
@mtmk @piotrpio @Jarema I am not sure how much client logic there needs to be if both `FilterSubject` and `FilterSubjects` are set; I tried to match the `subscription<>consumer filter` logic, otherwise the changes are minimal, just added the fields. LMK if you think more needs to be done here.