### PR TITLE
[CHANGED] Travis build changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: bionic
+dist: focal
 os: linux
 
 cache:
@@ -24,6 +24,34 @@ env:
 
 jobs:
   include:
+
+    - name: "NATS server - latest release"
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: ppa:ubuntu-toolchain-r/test
+          packages:
+            - g++-9
+      env:
+        - NATS_TEST_SERVER_VERSION=latest
+        - MATRIX_EVAL="CC=gcc-9"
+        - BUILD_OPT="-DNATS_BUILD_ARCH=64 -DCMAKE_BUILD_TYPE=Release" DO_COVERAGE="no"
+
+    - name: "NATS server - dev"
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: ppa:ubuntu-toolchain-r/test
+          packages:
+            - g++-9
+      env:
+        - NATS_TEST_SERVER_VERSION=dev
+        - MATRIX_EVAL="CC=gcc-9"
+        - BUILD_OPT="-DNATS_BUILD_ARCH=64 -DCMAKE_BUILD_TYPE=Release" DO_COVERAGE="no"
 
     - name: "gcc-9 - TLS OFF"
       compiler: gcc
@@ -62,7 +90,7 @@ jobs:
             - g++-9
       env:
         - MATRIX_EVAL="CC=gcc-9"
-        - BUILD_OPT="-DNATS_BUILD_ARCH=64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=address" NATS_TEST_VALGRIND=yes DO_COVERAGE="no"
+        - BUILD_OPT="-DNATS_BUILD_ARCH=64 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=-fsanitize=address" NATS_TEST_VALGRIND=yes DO_COVERAGE="no"
 
     - name: "gcc-9 - Lib msg delivery - sanitize address"
       compiler: gcc
@@ -75,7 +103,7 @@ jobs:
             - g++-9
       env:
         - MATRIX_EVAL="CC=gcc-9"
-        - NATS_DEFAULT_TO_LIB_MSG_DELIVERY=yes BUILD_OPT="-DNATS_BUILD_ARCH=64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=address" NATS_TEST_VALGRIND=yes DO_COVERAGE="no"
+        - NATS_DEFAULT_TO_LIB_MSG_DELIVERY=yes BUILD_OPT="-DNATS_BUILD_ARCH=64 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=-fsanitize=address" NATS_TEST_VALGRIND=yes DO_COVERAGE="no"
 
     - name: "gcc-9 - Write deadline - sanitize address"
       compiler: gcc
@@ -101,7 +129,7 @@ jobs:
             - g++-9
       env:
         - MATRIX_EVAL="CC=gcc-9"
-        - BUILD_OPT="-DNATS_BUILD_ARCH=64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=thread" DO_COVERAGE="no"
+        - BUILD_OPT="-DNATS_BUILD_ARCH=64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=thread" NATS_TEST_VALGRIND=yes DO_COVERAGE="no"
 
     - name: "clang-8 - TLS OFF"
       compiler: clang

--- a/buildOnTravis.sh
+++ b/buildOnTravis.sh
@@ -17,7 +17,7 @@ if [ "$NATS_TEST_SERVER_VERSION" != "" ]; then
     rel=$(curl -s https://api.github.com/repos/nats-io/nats-server/releases/latest | jq -r '.tag_name')
   fi
 
-  if wget https://github.com/nats-io/nats-server/releases/download/$rel/nats-server-$rel-linux-amd64.tar.gz; then
+  if [ "$rel" != "${rel#v}" ] && wget https://github.com/nats-io/nats-server/releases/download/$rel/nats-server-$rel-linux-amd64.tar.gz; then
     tar -xzf nats-server-$rel-linux-amd64.tar.gz
     mv nats-server-$rel-linux-amd64 $HOME/nats-server-$rel
   else

--- a/buildOnTravis.sh
+++ b/buildOnTravis.sh
@@ -10,6 +10,23 @@ echo "coverage   = " $2
 echo "build opts = " $3
 echo "test opts  = " $4
 
+if [ "$NATS_TEST_SERVER_VERSION" != "" ]; then
+  rel=$NATS_TEST_SERVER_VERSION
+  mkdir -p $HOME/nats-server-$rel
+  if [ "$rel" = "latest" ]; then
+    rel=$(curl -s https://api.github.com/repos/nats-io/nats-server/releases/latest | jq -r '.tag_name')
+  fi
+
+  if wget https://github.com/nats-io/nats-server/releases/download/$rel/nats-server-$rel-linux-amd64.tar.gz; then
+    tar -xzf nats-server-$rel-linux-amd64.tar.gz
+    mv nats-server-$rel-linux-amd64 $HOME/nats-server-$rel
+  else
+    curl -sf "https://binaries.nats.dev/nats-io/nats-server/v2@$rel" | PREFIX=. sh
+    mv nats-server $HOME/nats-server-$rel
+  fi
+  PATH=$HOME/nats-server-$rel:$PATH
+fi
+
 if [ "$1" != "gcc" ]; then
   if [ "$2" = "coverage" ]; then
     # only coverage for gcc compiler
@@ -35,8 +52,10 @@ res=$?
 if [ $res -ne 0 ]; then
   exit $res
 fi
-export NATS_TEST_SERVER_VERSION="$(nats-server -v)"
+
 export NATS_TEST_TRAVIS=yes
+export NATS_TEST_SERVER_VERSION="$(nats-server -v)"
+echo "Using NATS server version: $NATS_TEST_SERVER_VERSION"
 ctest --timeout 60 --output-on-failure $4
 res=$?
 if [ $res -ne 0 ]; then

--- a/test/test.c
+++ b/test/test.c
@@ -16311,6 +16311,11 @@ test_ServerPoolUpdatedOnClusterUpdate(void)
         const char *urls[] = {"127.0.0.1:4222", "127.0.0.1:4223", "127.0.0.1:4224"};
         test("Check pool: ");
         s = _checkPool(conn, (char**)urls, (int)(sizeof(urls)/sizeof(char*)));
+        if (s != NATS_OK)
+        {
+            nats_Sleep(100);
+            s = _checkPool(conn, (char **)urls, (int)(sizeof(urls) / sizeof(char *)));
+        }
         testCond(s == NATS_OK);
     }
 


### PR DESCRIPTION
This PR prepares for testing with nats server v2.10 changes. It also fixes an issue with `sanitize=thread` that seemed to have appeared due to Travis `bionic` image changes.

- Use Ubuntu `focal` v20.04
- Added testing against nats-server `latest` release, and against the `dev` branch
- Changed gcc `sanitize=address` builds to Debug to get line numbers in the output
- Added `NATS_TEST_VALGRIND=yes` to `sanitize=thread` to reduce repeat counts and avoid timeouts

