### PR TITLE
nuid: use unsigned intermediate to avoid left shift undefined behavior

### DIFF
--- a/src/nuid.c
+++ b/src/nuid.c
@@ -76,7 +76,7 @@ _rand64(int64_t maxValue)
 {
     int64_t v;
 
-    v  = ((int64_t) _randCMWC() << 32);
+    v  = ((uint64_t) _randCMWC() << 32);
     v |= (int64_t) _randCMWC();
 
     if (v < 0)


### PR DESCRIPTION
Trying to left shift any `uint32_t` value greater than `0x7FFFFFFF` by 32 places as an `int64_t` is technically undefined behavior. If this is hit during runtime, clang's ubsan will report "runtime error: left shift of 2147483648 by 32 places cannot be represented in type 'int64_t' (aka 'long')". Since this is occurs in a random number generator, the behavior is nondeterministic as well, though it seems to happen quite often.

I ran into this frequently while working on wrapping `nats.c` with `zig`, which enables Clang's `-fsanitize-trap=undefined` flag by default in debug builds. There may be other similar undefined behavior lurking in some of the other bit shifts, but this is the only place I've seen it pop up in the debugger so far.

See https://godbolt.org/z/z6aabseET for a reduction of the issue.