### PR TITLE
Fix link to Homebrew formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This NATS Client implementation is heavily based on the [NATS GO Client](https:/
 
 There are several package managers with NATS C client library available. If you know one that is not in this list, please submit a PR to add it!
 
-- [Homebrew](https://github.com/Homebrew/homebrew-core) The "cnats" formula is [here](https://github.com/Homebrew/homebrew-core/blob/master/Formula/cnats.rb)
+- [Homebrew](https://github.com/Homebrew/homebrew-core) The "cnats" formula is [here](https://github.com/Homebrew/homebrew-core/blob/master/Formula/c/cnats.rb)
 - [vcpkg](https://vcpkg.io) The "cnats" port is [here](https://github.com/microsoft/vcpkg/tree/master/ports/cnats)
 
 ## Building


### PR DESCRIPTION
Looks like the Homebrew team moved the formulae in their repository back in August: [Homebrew/homebrew-core@442f9cc](https://github.com/Homebrew/homebrew-core/commit/442f9cc511ce6dfe75b96b2c83749d90dde914d2).

This PR readdresses the link to the `cnats.rb` formula.