### PR TITLE
[FIXED] Random authentication error due to missing signature

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -1799,7 +1799,7 @@ _base64Encode(const char *map, bool padding, const unsigned char *src, int srcLe
 
     *pDest = NULL;
 
-    if ((src == NULL) || (src[0] == '\0'))
+    if ((src == NULL) || (srcLen == 0))
         return NATS_OK;
 
     n = srcLen;

--- a/test/test.c
+++ b/test/test.c
@@ -4424,8 +4424,8 @@ test_natsBase64Encode(void)
             "ZGZzbGZkbGtqc2ZkbGxramZkcyBkZnNqbGtsa2ZzZGEgZGZzYWxramtsZmRzYWxraiBhZGZza2psbGtqZmRhc2xramZkc2xr",
             "VGhpcyBpcyBhbm90aGVyIHdpdGggbnVtYmVycyBsaWtlIDEyMzQ1Njc4LjkwIGFuZCBzcGVjaWFsIGNoYXJhY3RlcnMgIUAjJCVeJiooKS09Ky8=",
     };
-    const uint8_t   someBytes[] = {1, 2, 0, 3, 4, 5, 0, 6, 7, 8, 0, 9, 0};
-    const char      *sbe = "AQIAAwQFAAYHCAAJAA==";
+    const uint8_t   someBytes[] = {0, 2, 0, 3, 4, 5, 0, 6, 7, 8, 0, 9, 0};
+    const char      *sbe = "AAIAAwQFAAYHCAAJAA==";
     int             sbl  = 13;
     int             sl   = 0;
     int             dl   = 0;
@@ -4456,7 +4456,7 @@ test_natsBase64Encode(void)
     test("EncodeURL bytes: ");
     {
         s = nats_Base64RawURL_EncodeString((const unsigned char*) &someBytes, sbl, &enc);
-        if ((s == NATS_OK) && ((enc == NULL) || (strcmp(enc, "AQIAAwQFAAYHCAAJAA") != 0)))
+        if ((s == NATS_OK) && ((enc == NULL) || (strcmp(enc, "AAIAAwQFAAYHCAAJAA") != 0)))
             s = NATS_ERR;
 
         free(enc);


### PR DESCRIPTION
Sometimes there is an authentication error due to a missing signature when `natsOptions_SetUserCredentialsFromMemory` is used:

```
[1] 2023/12/29 13:23:44.880932 [ERR] 172.18.0.1:33898 - cid:36 - authentication error
```

The problem is that _base64Encode doesn't do anything if the first byte is zero. Since the function works with strings and bytes, it makes sense to check `srcLen` instead of the first byte.