### PR TITLE
Disable a Travis-ci matrix run until Ubuntu bug resolved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,18 +118,18 @@ jobs:
         - MATRIX_EVAL="CC=gcc-9"
         - NATS_DEFAULT_LIB_WRITE_DEADLINE=2000 BUILD_OPT="-DNATS_BUILD_ARCH=64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=address" NATS_TEST_VALGRIND=yes DO_COVERAGE="no"
 
-    - name: "gcc-9 - Default - sanitize thread"
-      compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: ppa:ubuntu-toolchain-r/test
-          packages:
-            - g++-9
-      env:
-        - MATRIX_EVAL="CC=gcc-9"
-        - BUILD_OPT="-DNATS_BUILD_ARCH=64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=thread" NATS_TEST_VALGRIND=yes DO_COVERAGE="no"
+    # - name: "gcc-9 - Default - sanitize thread"
+    #   compiler: gcc
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #         - sourceline: ppa:ubuntu-toolchain-r/test
+    #       packages:
+    #         - g++-9
+    #   env:
+    #     - MATRIX_EVAL="CC=gcc-9"
+    #     - BUILD_OPT="-DNATS_BUILD_ARCH=64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fsanitize=thread" NATS_TEST_VALGRIND=yes DO_COVERAGE="no"
 
     - name: "clang-8 - TLS OFF"
       compiler: clang


### PR DESCRIPTION
gcc9 - Default - sanitize thread fails with following error:
```
CMake Error at /home/travis/deps/cmake-install/share/cmake-3.20/Modules/CMakeTestCCompiler.cmake:66 (message):
  The C compiler
    "/usr/bin/gcc-9"
  is not able to compile a simple test program.
  It fails with the following output:
    Change Dir: /home/travis/build/nats-io/nats.c/build/CMakeFiles/CMakeTmp

    Run Build Command(s):/usr/bin/make -f Makefile cmTC_613bf/fast && /usr/bin/make  -f CMakeFiles/cmTC_613bf.dir/build.make CMakeFiles/cmTC_613bf.dir/build
    make[1]: Entering directory '/home/travis/build/nats-io/nats.c/build/CMakeFiles/CMakeTmp'
    Building C object CMakeFiles/cmTC_613bf.dir/testCCompiler.c.o
    /usr/bin/gcc-9   -fsanitize=thread  -o CMakeFiles/cmTC_613bf.dir/testCCompiler.c.o -c /home/travis/build/nats-io/nats.c/build/CMakeFiles/CMakeTmp/testCCompiler.c
    Linking C executable cmTC_613bf
    /home/travis/deps/cmake-install/bin/cmake -E cmake_link_script CMakeFiles/cmTC_613bf.dir/link.txt --verbose=1
    /usr/bin/gcc-9 -fsanitize=thread  CMakeFiles/cmTC_613bf.dir/testCCompiler.c.o -o cmTC_613bf
    /usr/bin/ld: cannot find libtsan_preinit.o: No such file or directory
    collect2: error: ld returned 1 exit status
    make[1]: *** [CMakeFiles/cmTC_613bf.dir/build.make:99: cmTC_613bf] Error 1
    make[1]: Leaving directory '/home/travis/build/nats-io/nats.c/build/CMakeFiles/CMakeTmp'
    make: *** [Makefile:127: cmTC_613bf/fast] Error 2
```

From some searches, it seems it is a Ubuntu bug that has not been yet fixed. So disable run for now: https://bugs.launchpad.net/ubuntu/+source/gcc-9/+bug/2029910

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>