### PR TITLE
[FIXED] Missing NATS_EXTERN in nats.h for some functions.

### DIFF
--- a/src/nats.h
+++ b/src/nats.h
@@ -4074,7 +4074,7 @@ natsConnection_IsReconnecting(natsConnection *nc);
  *
  * @param nc the pointer to the #natsConnection object.
  */
-bool
+NATS_EXTERN bool
 natsConnection_IsDraining(natsConnection *nc);
 
 /** \brief Returns the current state of the connection.
@@ -4381,7 +4381,7 @@ natsConnection_HasHeaderSupport(natsConnection *nc);
  * @return #NATS_SYS_ERROR if a system error getting the IP and port occurred.
  * @return #NATS_NO_MEMORY if the library was unable to allocate memory for the returned IP string.
  */
-natsStatus
+NATS_EXTERN natsStatus
 natsConnection_GetLocalIPAndPort(natsConnection *nc, char **ip, int *port);
 
 /** \brief Closes the connection.
@@ -7200,15 +7200,15 @@ kvStatus_Destroy(kvStatus *sts);
  *
  * \warning EXPERIMENTAL FEATURE! We reserve the right to change the API without
  * necessarily bumping the major version of the library.
- * 
+ *
  * ### NATS Microservices.
  *
  * Microservices can expose one or more request-response endpoints that process
- * incoming NATS messages. 
+ * incoming NATS messages.
  *
  * Microservices are created by calling micro_AddService, and configured by
  * passing a microServiceConfig to it. Many microservices can share a single
- * connection to a NATS server. 
+ * connection to a NATS server.
  *
  * Once created, a microservice will subscribe to all endpoints' subjects and
  * associate them with the configured handlers. It will also subscribe to and
@@ -7295,7 +7295,7 @@ typedef struct micro_endpoint_stats_s microEndpointStats;
  * This error type is returned by most microservice functions. You can create
  * your own custom errors by using #micro_Errorf and wrap existing errors using
  * #microError_Wrapf. Errors are heap-allocated and must be freed with either
- * #microError_Destroy or by passing it into #microRequest_Respond. 
+ * #microError_Destroy or by passing it into #microRequest_Respond.
  *
  * There are no public fields in this struct, use #microError_Code,
  * #microError_Status, and #microError_String to get more information about the
@@ -7306,7 +7306,7 @@ typedef struct micro_error_s microError;
 /**
  * @brief a collection of endpoints and other groups, with a
  * common prefix to their subjects and names.
- * 
+ *
  * It has no other purpose than
  * convenience, for organizing endpoint subject space.
  */
@@ -7319,7 +7319,7 @@ typedef struct micro_group_s microGroup;
  */
 typedef struct micro_request_s microRequest;
 
-/** 
+/**
  * @brief the main object for a configured microservice.
  *
  * It can be created with #micro_AddService, and configured by passing a
@@ -7355,7 +7355,7 @@ typedef struct micro_service_config_s microServiceConfig;
 typedef struct micro_service_info_s microServiceInfo;
 
 /**
- * @brief The Microservice service-level stats struct. 
+ * @brief The Microservice service-level stats struct.
  *
  * @see micro_service_stats_s for descriptions of the fields,
  * microService_GetStats
@@ -7426,7 +7426,7 @@ typedef void (*microDoneHandler)(microService *m);
 /** \defgroup microStructs Public structs
  *
  *  Microservice public structs.
- * 
+ *
  *  @{
  */
 
@@ -7500,7 +7500,7 @@ struct micro_endpoint_stats_s
 {
     const char *Name;
     const char *Subject;
-    
+
     /**
      * @brief The number of requests received by the endpoint.
      */
@@ -7564,7 +7564,7 @@ struct micro_service_config_s
     natsMetadata Metadata;
 
     /**
-     * @brief The "main" (aka default) endpoint configuration. 
+     * @brief The "main" (aka default) endpoint configuration.
      *
      * It is the default in that it does not require calling
      * microService_AddEndpoint, it is added automatically when creating the
@@ -7621,7 +7621,7 @@ struct micro_service_info_s
      * @brief Response type. Always `"io.nats.micro.v1.info_response"`.
      */
     const char *Type;
-    
+
     /**
      * @brief The name of the service.
      */
@@ -7636,7 +7636,7 @@ struct micro_service_info_s
      * @brief The description of the service.
      */
     const char *Description;
-    
+
     /**
      * @brief The ID of the service instance responding to the request.
      */
@@ -7692,7 +7692,7 @@ struct micro_service_stats_s
      * @brief The stats for each endpoint of the service.
      */
     microEndpointStats *Endpoints;
-    
+
     /**
      * @brief The number of endpoints in the `endpoints` array.
      */
@@ -7709,7 +7709,7 @@ struct micro_service_stats_s
 
 /**
  * @brief The prefix for all microservice monitoring subjects.
- * 
+ *
  * For example, `"$SRV.PING"`.
  */
 #define MICRO_API_PREFIX "$SRV"
@@ -7834,7 +7834,7 @@ microService_AddGroup(microGroup **new_group, microService *m, const char *prefi
  *
  * @note This function may fail while stopping the service, do not assume
  * unconditional success if clean up is important.
- * 
+ *
  * @param m the #microService to stop and destroy.
  *
  * @return a #microError if an error occurred.
@@ -8018,7 +8018,7 @@ microRequest_AddHeader(microRequest *req, const char *key, const char *value);
 NATS_EXTERN microError *
 microRequest_DeleteHeader(microRequest *req, const char *key);
 
-/** @brief Returns the connection associated with the request. 
+/** @brief Returns the connection associated with the request.
  *
  * @param req the request.
  *
@@ -8029,7 +8029,7 @@ microRequest_DeleteHeader(microRequest *req, const char *key);
 NATS_EXTERN natsConnection *
 microRequest_GetConnection(microRequest *req);
 
-/** @brief Returns the data in the the request, as a byte array. 
+/** @brief Returns the data in the the request, as a byte array.
  *
  * @note The request owns the data, so it should not be freed other than with
  * `microRequest_Destroy`.
@@ -8039,25 +8039,25 @@ microRequest_GetConnection(microRequest *req);
  * @param req the request.
  *
  * @return a pointer to the request's data.
- * 
+ *
  * @see #natsMsg_GetData, #microRequest_GetDataLength
  */
 NATS_EXTERN const char *
 microRequest_GetData(microRequest *req);
 
-/** @brief Returns the number of data bytes in the the request. 
+/** @brief Returns the number of data bytes in the the request.
  *
  * @param req the request.
  *
  * @return the number of data bytes in the request.
- * 
+ *
  * @see #natsMsg_GetDataLength, #microRequest_GetData
  */
 NATS_EXTERN int
 microRequest_GetDataLength(microRequest *req);
 
 /** \brief Returns the pointer to the user-provided endpoint state, if
- * the request is associated with an endpoint. 
+ * the request is associated with an endpoint.
  *
  * @param req the request.
  *
@@ -8093,7 +8093,7 @@ microRequest_GetHeaderKeys(microRequest *req, const char ***keys, int *count);
  * @param key the key for which the value is requested.
  * @param value the memory location where the library will store the pointer to the first
  * value (if more than one is found) associated with the `key`.
- * 
+ *
  * @return a #microError if an error occurred.
  *
  * @see #natsMsgHeader_Get, #microRequest_GetHeaderValue, #microRequest_GetHeaderValues
@@ -8140,7 +8140,7 @@ microRequest_GetMsg(microRequest *req);
 NATS_EXTERN const char *
 microRequest_GetReply(microRequest *req);
 
-/** @brief Returns the pointer to the microservice associated with the request. 
+/** @brief Returns the pointer to the microservice associated with the request.
  *
  * @param req the request.
  *
@@ -8177,7 +8177,7 @@ microRequest_GetSubject(microRequest *req);
  * @param data the response data.
  * @param len the length of the response data.
  *
- * @return an error, if any. 
+ * @return an error, if any.
  */
 NATS_EXTERN microError *
 microRequest_Respond(microRequest *req, const char *data, size_t len);
@@ -8186,7 +8186,7 @@ microRequest_Respond(microRequest *req, const char *data, size_t len);
  * @brief Respond to a request with a simple error.
  *
  * If err is NULL, `RespondError` does nothing.
- * 
+ *
  * @note microRequest_RespondError is called automatially if the handler returns
  * an error. Usually, there is no need for a handler to use this function
  * directly. If the request
@@ -8194,7 +8194,7 @@ microRequest_Respond(microRequest *req, const char *data, size_t len);
  * @param req the request.
  * @param err the error to include in the response header. If `NULL`, no error.
  *
- * @return an error, if any. 
+ * @return an error, if any.
  */
 NATS_EXTERN microError *
 microRequest_RespondError(microRequest *req, microError *err);
@@ -8204,7 +8204,7 @@ microRequest_RespondError(microRequest *req, microError *err);
  *
  * If err is NULL, `RespondErrorWithData` is equivalent to `Respond`. If err is
  * not NULL, the response will include the error in the response header, and err
- * will be freed. 
+ * will be freed.
  *
  * The following example illustrates idiomatic usage in a request handler. Since
  * this handler handles its own error responses, the only error it might return
@@ -8219,7 +8219,7 @@ microRequest_RespondError(microRequest *req, microError *err);
  * \endcode
  *
  * Or, if the request handler has its own cleanup logic:
- * 
+ *
  * \code{.c}
  * if (err = somefunc(), err != NULL)
  *     goto CLEANUP;
@@ -8237,10 +8237,10 @@ microRequest_RespondError(microRequest *req, microError *err);
  * @param data the response data.
  * @param len the length of the response data.
  *
- * @note 
+ * @note
  *
  *
- * @return an error, if any. 
+ * @return an error, if any.
  */
 NATS_EXTERN microError *
 microRequest_RespondCustom(microRequest *req, microError *err, const char *data, size_t len);
@@ -8324,10 +8324,10 @@ microError_Destroy(microError *err);
 
 /**
  * @brief Returns the NATS status associated with the error.
- * 
- * @param err 
- * 
- * @return the status 
+ *
+ * @param err
+ *
+ * @return the status
  */
 NATS_EXTERN natsStatus
 microError_Status(microError *err);
@@ -8341,7 +8341,7 @@ microError_Status(microError *err);
  * @param err the error.
  * @param buf the output buffer.
  * @param len the capacity of the output buffer.
- * @return `buf` 
+ * @return `buf`
  */
 NATS_EXTERN const char *
 microError_String(microError *err, char *buf, size_t len);
@@ -8355,7 +8355,7 @@ microError_String(microError *err, char *buf, size_t len);
  *
  * @param err the original error
  * @param format the new message to prepend to the original error message.
- * @param ... 
+ * @param ...
  *
  * @return a new, wrapped, error.
  */
@@ -8371,19 +8371,19 @@ microError_Wrapf(microError *err, const char *format, ...);
 
 /**
  * @brief Creates a new microservice client.
- * 
+ *
  * @param new_client received the pointer to the new client.
  * @param nc a NATS connection.
  * @param cfg for future use, use NULL for now.
- * 
- * @return a #microError if an error occurred. 
+ *
+ * @return a #microError if an error occurred.
  */
 NATS_EXTERN microError *
 micro_NewClient(microClient **new_client, natsConnection *nc, microClientConfig *cfg);
 
 /**
  * @brief Destroys a microservice client.
- * 
+ *
  * @param client the client to destroy.
  */
 NATS_EXTERN void
@@ -8398,7 +8398,7 @@ microClient_Destroy(microClient *client);
  * @param subject the subject to send the request on.
  * @param data the request data.
  * @param data_len the request data length.
- * 
+ *
  * @return a #microError if an error occurred.
  */
 NATS_EXTERN microError *
@@ -8414,7 +8414,7 @@ microClient_DoRequest(natsMsg **reply, microClient *client, const char *subject,
 
 /**
  * @brief Destroys a #microServiceInfo object.
- * 
+ *
  * @param info the object to destroy.
  */
 NATS_EXTERN void
@@ -8422,7 +8422,7 @@ microServiceInfo_Destroy(microServiceInfo *info);
 
 /**
  * @brief Destroys a #microServiceStats object.
- * 
+ *
  * @param stats the object to destroy.
  */
 NATS_EXTERN void

--- a/src/util.c
+++ b/src/util.c
@@ -2551,7 +2551,7 @@ nats_freeMetadata(natsMetadata *md)
     {
         NATS_FREE((char *)md->List[i]);
     }
-    NATS_FREE(md->List);
+    NATS_FREE((char*) md->List);
     md->List = NULL;
     md->Count = 0;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT NATS_BUILD_LIB_STATIC)
    MESSAGE(FATAL_ERROR
      "Building tests require static library, or run CMake with -DBUILD_TESTING=OFF")
   return()
-endif()  
+endif()
 
 # We need this to build the test program
 include_directories(${PROJECT_SOURCE_DIR}/src)


### PR DESCRIPTION
This is important for Windows platform.

I also fixed a cast issue in util.c (that was reported on Windows build). Some changes are also related to spaces at end of lines that were removed by my editor.

Resolves #714

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>