### PR TITLE
[ADDED] GitHub action to update docs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -26,6 +26,7 @@ jobs:
         id: update
         run: |
           cd doc
+          rm -rf ./html/*
           doxygen DoxyFile.NATS.Client
           git diff --quiet || echo "CHANGES=true" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,52 @@
+name: Update Docs
+
+on:
+  push:
+    branches:
+        - main
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # to push branches
+      pull-requests: write # to create pull requests
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Cache Doxygen
+        id: cache-doxygen
+        uses: actions/cache@v4
+        with:
+          path: /usr/bin/doxygen
+          key: doxygen
+
+      - name: Set up Doxygen
+        if: steps.cache-doxygen.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen
+
+      - name: Generate Documentation
+        id: update
+        run: |
+          cd doc
+          doxygen DoxyFile.NATS.Client
+          git diff --quiet || echo "CHANGES=true" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        if: steps.update.outputs.CHANGES == 'true'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update documentation
+          branch: update-docs
+          title: Auto-generated documentation update
+          body: Documentation changes were detected. Please review and merge.
+          labels: documentation
+          base: main
+          branch-suffix: timestamp
+          delete-branch: true

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -17,15 +17,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Cache Doxygen
-        id: cache-doxygen
-        uses: actions/cache@v4
-        with:
-          path: /usr/bin/doxygen
-          key: doxygen
-
       - name: Set up Doxygen
-        if: steps.cache-doxygen.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y doxygen


### PR DESCRIPTION
@kozlovic @Jarema this is part of retiring `dev` and switching to releases from release branches. I am editing the release instructions now, will send the PR shortly for that. This GH action eliminates the need to re-generate the docs upon release.

This PR automatically updates the docs in `main` when needed (via a new PR). See https://github.com/levb/nats.c/pull/69 as an example, contains numerous changes caused by using a newer doxygen version.

Note that it will only fire when pushed to `main`, I debugged in my fork without the branch filter.



Example:

<img width="1459" alt="image" src="https://github.com/nats-io/nats.c/assets/1187448/f6709279-b494-429a-8f15-c4bb008cfef3">
