### PR TITLE
Modify JetStream examples (Add comments to SubjectsLen)

### DIFF
--- a/examples/js-pub.c
+++ b/examples/js-pub.c
@@ -88,6 +88,7 @@ int main(int argc, char **argv)
             cfg.Name = stream;
             // Set the subject
             cfg.Subjects = (const char*[1]){subj};
+            // Set the subject count
             cfg.SubjectsLen = 1;
             // Make it a memory stream.
             cfg.Storage = js_MemoryStorage;

--- a/examples/js-sub.c
+++ b/examples/js-sub.c
@@ -111,6 +111,7 @@ int main(int argc, char **argv)
             cfg.Name = stream;
             // Set the subject
             cfg.Subjects = (const char*[1]){subj};
+            // Set the subject count
             cfg.SubjectsLen = 1;
             // Make it a memory stream.
             cfg.Storage = js_MemoryStorage;


### PR DESCRIPTION
'SubjectsLen' is named in a way that suggests it can invoke the 'strlen' function, so I clarified in the comments that it represents the number of elements.