### PR TITLE
[FIXED] GH-738, do not prefix endpoint name with the group prefix

### DIFF
--- a/src/micro.c
+++ b/src/micro.c
@@ -95,7 +95,7 @@ micro_add_endpoint(microEndpoint **new_ep, microService *m, const char *prefix, 
 
     if (m->first_ep != NULL)
     {
-        if (strcmp(m->first_ep->name, ep->name) == 0)
+        if (strcmp(m->first_ep->subject, ep->subject) == 0)
         {
             ep->next = m->first_ep->next;
             prev_ep = m->first_ep;
@@ -106,7 +106,7 @@ micro_add_endpoint(microEndpoint **new_ep, microService *m, const char *prefix, 
             prev_ptr = m->first_ep;
             for (ptr = m->first_ep->next; ptr != NULL; prev_ptr = ptr, ptr = ptr->next)
             {
-                if (strcmp(ptr->name, ep->name) == 0)
+                if (strcmp(ptr->subject, ep->subject) == 0)
                 {
                     ep->next = ptr->next;
                     prev_ptr->next = ep;

--- a/src/micro_endpoint.c
+++ b/src/micro_endpoint.c
@@ -50,7 +50,7 @@ micro_new_endpoint(microEndpoint **new_ep, microService *m, const char *prefix, 
 
     MICRO_CALL(err, micro_ErrorFromStatus(natsMutex_Create(&ep->endpoint_mu)));
     MICRO_CALL(err, micro_clone_endpoint_config(&ep->config, cfg));
-    MICRO_CALL(err, _dup_with_prefix(&ep->name, prefix, cfg->Name));
+    MICRO_CALL(err, micro_strdup(&ep->name, cfg->Name));
     MICRO_CALL(err, _dup_with_prefix(&ep->subject, prefix, subj));
     if (err != NULL)
     {


### PR DESCRIPTION
Fixes #738 

The Go client [does not](https://github.com/nats-io/nats.go/blob/10381e1f115d3904df20bbefab2645e21bc2ac6c/micro/service.go#L786) prefix the name, it was a mistake. Now identify the EPs by subject, like the [Go client](https://github.com/nats-io/nats.go/blob/10381e1f115d3904df20bbefab2645e21bc2ac6c/micro/service.go#L835)

