### PR TITLE
[FIXED] GH-736: added extern to micro_Errors

### DIFF
--- a/src/nats.h
+++ b/src/nats.h
@@ -7421,8 +7421,8 @@ typedef struct micro_service_info_s microServiceInfo;
 typedef struct micro_service_stats_s microServiceStats;
 
 
-NATS_EXTERN microError *micro_ErrorOutOfMemory;
-NATS_EXTERN microError *micro_ErrorInvalidArg;
+extern NATS_EXTERN microError *micro_ErrorOutOfMemory;
+extern NATS_EXTERN microError *micro_ErrorInvalidArg;
 
 /** @} */ // end of microTypes
 


### PR DESCRIPTION
In https://github.com/nats-io/nats.c/pull/731 I wrongly assumed that NATS_EXTERN was a superset of `extern` and it is not.

Unfortunately, our current CI set up does not catch these, I will revive the GH actions PR that used the more recent compiler versions.

Fixes https://github.com/nats-io/nats.c/issues/736