### PR TITLE
[CI only]: Nightly test server main, latest release

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -1,0 +1,23 @@
+name: "Nightly"
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '37 4 * * *'
+
+permissions:
+  contents: write # required by build-test to comment on coverage but not used here.
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -x -eo pipefail {0}
+
+jobs:
+  quick:
+    name: "DefaultR"
+    strategy:
+      fail-fast: false
+      matrix:
+        server_version: [main, latest]
+    uses: ./.github/workflows/build-test.yml
+    with:
+      server_version: ${{ matrix.server_version }}


### PR DESCRIPTION
https://github.com/nats-io/nats-server/pull/5366 broke test_KeyValueMirrorCrossDomains and I only noticed because there was an active PR.

Now test against `main`, `latest` nightly