### PR TITLE
[CI only] run tests once, not x3 except for main, release

### DIFF
--- a/.github/workflows/on-pr-debug.yml
+++ b/.github/workflows/on-pr-debug.yml
@@ -21,7 +21,6 @@ jobs:
       compiler: ${{ matrix.compiler }}
       server_version: main
       type: Debug
-      repeat: 3
 
   coverage:
     name: "Coverage"
@@ -63,4 +62,3 @@ jobs:
     with:
       sanitize: thread
       server_version: main
-      repeat: 3

--- a/.github/workflows/on-push-release-extra.yml
+++ b/.github/workflows/on-push-release-extra.yml
@@ -14,6 +14,13 @@ defaults:
     shell: bash --noprofile --norc -x -eo pipefail {0}
 
 jobs:
+  flakes:
+    name: "check for flaky tests"
+    uses: ./.github/workflows/build-test.yml
+    with:
+      server_version: main
+      repeat: 5
+
   server-versions:
     strategy:
       fail-fast: false

--- a/.github/workflows/on-push-release.yml
+++ b/.github/workflows/on-push-release.yml
@@ -22,4 +22,3 @@ jobs:
       server_version: main
       ubuntu_version: ${{ matrix.ubuntu_version }}
       compiler: ${{ matrix.compiler }}
-      repeat: 3


### PR DESCRIPTION
`main` and `release_**` will still run 3x, but all PR jobs will use 1x