### PR TITLE
{CI only} Use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/on-pr-debug.yml
+++ b/.github/workflows/on-pr-debug.yml
@@ -1,6 +1,6 @@
 name: "Debug"
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: write # so it can comment


### PR DESCRIPTION
We are having an issue running coverage upload from forked repo PRs. This should solve it, I think.

Testing for now from my own fork.