### PR TITLE
[CI only] Skip codecov for forks until they resolve tokenless uploads…

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -165,7 +165,7 @@ jobs:
           fi
 
       - name: Upload coverage reports to Codecov
-        if: inputs.coverage == 'ON'
+        if: inputs.coverage == 'ON' && github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -165,6 +165,8 @@ jobs:
           fi
 
       - name: Upload coverage reports to Codecov
+        # PRs from external contributors fail: https://github.com/codecov/feedback/issues/301
+        # Only upload coverage reports for PRs from the same repo (not forks)
         if: inputs.coverage == 'ON' && github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
https://github.com/nats-io/nats.c/pull/763 is currently failing to upload codecov reports, because of an [issue](https://github.com/codecov/feedback/issues/301) in codecov. Until they resolve it, disable codecov for PRs from forked repos.