### PR TITLE
nats.c is available on conan.io/center

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This NATS Client implementation is heavily based on the [NATS GO Client](https:/
 
 There are several package managers with NATS C client library available. If you know one that is not in this list, please submit a PR to add it!
 
+- [conan](https://conan.io/center) The "cnats" recipe is [here](https://github.com/conan-io/conan-center-index/tree/master/recipes/cnats)
 - [Homebrew](https://github.com/Homebrew/homebrew-core) The "cnats" formula is [here](https://github.com/Homebrew/homebrew-core/blob/master/Formula/c/cnats.rb)
 - [vcpkg](https://vcpkg.io) The "cnats" port is [here](https://github.com/microsoft/vcpkg/tree/master/ports/cnats)
 


### PR DESCRIPTION
Hi, 
I just found that nats.c is also available [here](https://conan.io/center/recipes/cnats?version=3.8.0), so I added it to the README.

Best,
 Matthias