### PR TITLE
[DOCS ONLY] fixed documentation changes in preparation for v3.9 release

### DIFF
--- a/doc/DoxyFile.NATS.Client
+++ b/doc/DoxyFile.NATS.Client
@@ -1340,7 +1340,7 @@ HTML_COLORSTYLE_GAMMA  = 80
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_TIMESTAMP         = NO
+# HTML_TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that
@@ -2008,7 +2008,7 @@ LATEX_BIB_STYLE        = plain
 # The default value is: NO.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_TIMESTAMP        = NO
+# LATEX_TIMESTAMP        = NO
 
 # The LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute)
 # path from which the emoji images will be read. If a relative path is entered,

--- a/src/nats.h
+++ b/src/nats.h
@@ -1227,7 +1227,7 @@ typedef struct jsFetchRequest
  *
  * @see js_PullSubscribeAsync
  */
-typedef void (*natsFetchCompleteHandler)(natsConnection *nc, natsSubscription *sub, natsStatus s, void *closure);
+typedef void (*jsFetchCompleteHandler)(natsConnection *nc, natsSubscription *sub, natsStatus s, void *closure);
 
 /** \brief Callback used to customize flow control for js_PullSubscribeAsync.
  *
@@ -1298,7 +1298,7 @@ typedef struct jsOptions
                 // Fetch complete handler that receives the exit status code,
                 // the subscription's Complete handler is also invoked, but does
                 // not have the status code.
-                natsFetchCompleteHandler CompleteHandler;
+                jsFetchCompleteHandler  CompleteHandler;
                 void                    *CompleteHandlerClosure;
 
                 // Have server sends heartbeats at this interval to help detect

--- a/src/nats.h
+++ b/src/nats.h
@@ -2275,8 +2275,9 @@ natsOptions_Create(natsOptions **newOpts);
 
 /** \brief Sets the URL to connect to.
  *
- * Sets the URL of the `NATS Server` the client should try to connect to.
- * The URL can contain optional user name and password.
+ * Sets the URL of the `NATS Server` the client should try to connect to. The
+ * URL can contain optional user name and password. %-encoding is supported for
+ * entering special characters.
  *
  * Some valid URLS:
  *
@@ -2289,8 +2290,8 @@ natsOptions_Create(natsOptions **newOpts);
  * @see natsOptions_SetToken
  *
  * @param opts the pointer to the #natsOptions object.
- * @param url the string representing the URL the connection should use
- * to connect to the server.
+ * @param url the string representing the URL the connection should use to
+ * connect to the server.
  *
  */
 /*

--- a/src/nats.h
+++ b/src/nats.h
@@ -561,48 +561,46 @@ typedef struct jsStreamConfig {
         bool                    Sealed;         ///< Seal a stream so no messages can get our or in.
         bool                    DenyDelete;     ///< Restrict the ability to delete messages.
         bool                    DenyPurge;      ///< Restrict the ability to purge messages.
-        /**
-         * Allows messages to be placed into the system and purge
-         * all older messages using a special message header.
-         */
+
+        /// @brief Allow messages to be placed into the system and purge all
+        /// older messages using a special message header.
         bool                    AllowRollup;
 
-        // Allow republish of the message after being sequenced and stored.
+        /// @brief Allow republish of the message after being sequenced and
+        /// stored.
         jsRePublish             *RePublish;
 
-        // Allow higher performance, direct access to get individual messages. E.g. KeyValue
+        /// @brief Allow higher performance, direct access to get individual
+        /// messages. E.g. KeyValue
         bool                    AllowDirect;
-        // Allow higher performance and unified direct access for mirrors as well.
+
+        /// @brief Allow higher performance and unified direct access for
+        /// mirrors as well.
         bool                    MirrorDirect;
 
-        // Allow KV like semantics to also discard new on a per subject basis
+        /// @brief Allow KV like semantics to also discard new on a per subject
+        /// basis
         bool                    DiscardNewPerSubject;
 
-        /**
-         * @brief Configuration options introduced in 2.10
-         *
-         * - Metadata is a user-provided array of key/value pairs, encoded as a
-         *   string array [n1, v1, n2, v2, ...] representing key/value pairs
-         *   {n1:v1, n2:v2, ...}.
-         *
-         * - Compression: js_StorageCompressionNone (default) or
-         *   js_StorageCompressionS2
-         *
-         * - FirstSeq: the starting sequence number for the stream.
-         *
-         * - SubjectTransformConfig is for applying a subject transform (to
-         *   matching messages) before doing anything else when a new message is
-         *   received
-         *
-         * - ConsumerLimits is for setting the limits on certain options on all
-         *   consumers of the stream.
-         */
+        /// @brief A user-provided array of key/value pairs, encoded as a string
+        /// array [n1, v1, n2, v2, ...] representing key/value pairs {n1:v1,
+        /// n2:v2, ...}.
+        natsMetadata            Metadata;
 
-        natsMetadata Metadata;
-        jsStorageCompression Compression;
-        uint64_t FirstSeq;
+        /// @brief js_StorageCompressionNone (default) or
+        /// js_StorageCompressionS2.
+        jsStorageCompression    Compression;
+
+        /// @brief  the starting sequence number for the stream.
+        uint64_t                FirstSeq;
+
+        /// @brief Applies a subject transform (to matching messages) before
+        /// doing anything else when a new message is received.
         jsSubjectTransformConfig SubjectTransform;
-        jsStreamConsumerLimits ConsumerLimits;
+
+        /// @brief Sets the limits on certain options on all consumers of the
+        /// stream.
+        jsStreamConsumerLimits  ConsumerLimits;
 } jsStreamConfig;
 
 /**
@@ -4169,12 +4167,11 @@ stanMsg_Destroy(stanMsg *msg);
 NATS_EXTERN natsStatus
 natsConnection_Connect(natsConnection **nc, natsOptions *options);
 
-/** \brief Drop the connection to the current server and perform the standard
- * reconnection process, including re-subscribing.
+/** \brief Drops the current connection, reconnects including re-subscribing.
  *
- * Causes the client to drop the connection to the current server and perform
- * the standard reconnection process. This means that all subscriptions and
- * consumers will be resubscribed and their work resumed after successful
+ * Causes the client to drop the connection to the current server and to
+ * initiate the standard reconnection process. This means that all subscriptions
+ * and consumers will be resubscribed and their work resumed after successful
  * reconnect where all reconnect options are respected.
  *
  * @param nc the pointer to the #natsConnection object.

--- a/src/nats.h
+++ b/src/nats.h
@@ -1234,12 +1234,12 @@ typedef void (*natsFetchCompleteHandler)(natsConnection *nc, natsSubscription *s
  * The library will invoke this callback when it may be time to request more
  * messages from the server.
  *
- * @return true to fetch more, false to skip. If true, @messages and @maxBytes
- * should be set to the number of messages and max bytes to fetch.
+ * @return true to fetch more, false to skip. If true, \p messages and \p
+ * maxBytes should be set to the number of messages and max bytes to fetch.
  *
  * @see js_PullSubscribeAsync
  */
-typedef bool (*natsFetchNextHandler)(int *messages, int64_t *bytes, natsSubscription *sub, void *closure);
+typedef bool (*natsFetchNextHandler)(int *messages, int64_t *maxBytes, natsSubscription *sub, void *closure);
 
 /**
  * JetStream context options.
@@ -6493,7 +6493,8 @@ js_Subscribe(natsSubscription **sub, jsCtx *js, const char *subject,
  * @param sub the location where to store the pointer to the newly created
  * #natsSubscription object.
  * @param js the pointer to the #jsCtx object.
- * @param subject the subject this subscription is created for.
+ * @param subjects the subject this subscription is created for.
+ * @param numSubjects the number of subjects for the subscription.
  * @param cb the #natsMsgHandler callback.
  * @param cbClosure a pointer to an user defined object (can be `NULL`). See
  * the #natsMsgHandler prototype.
@@ -6541,7 +6542,7 @@ js_SubscribeSync(natsSubscription **sub, jsCtx *js, const char *subject,
  */
 NATS_EXTERN natsStatus
 js_SubscribeSyncMulti(natsSubscription **sub, jsCtx *js, const char **subjects, int numSubjects,
-                      jsOptions *jsOpts, jsSubOptions *opts, jsErrCode *errCode);
+                      jsOptions *opts, jsSubOptions *subOpts, jsErrCode *errCode);
 
 /** \brief Create a pull subscriber.
  *
@@ -7840,7 +7841,7 @@ struct micro_endpoint_info_s
     const char *QueueGroup;
 
     /**
-     * @briefMetadata for the endpoint, a JSON-encoded user-provided object,
+     * @brief Metadata for the endpoint, a JSON-encoded user-provided object,
      * e.g. `{"key":"value"}`
      */
     natsMetadata Metadata;
@@ -7893,7 +7894,7 @@ struct micro_endpoint_stats_s
 };
 
 /**
- * #brief The Microservice endpoint *group* configuration object.
+ * @brief The Microservice endpoint *group* configuration object.
  */
 struct micro_group_config_s
 {

--- a/src/nats.h
+++ b/src/nats.h
@@ -4169,12 +4169,13 @@ stanMsg_Destroy(stanMsg *msg);
 NATS_EXTERN natsStatus
 natsConnection_Connect(natsConnection **nc, natsOptions *options);
 
-/** \brief Causes the client to drop the connection to the current server and
- * perform standard reconnection process.
+/** \brief Drop the connection to the current server and perform the standard
+ * reconnection process, including re-subscribing.
  *
- * This means that all subscriptions and consumers should be resubscribed and
- * their work resumed after successful reconnect where all reconnect options are
- * respected.
+ * Causes the client to drop the connection to the current server and perform
+ * the standard reconnection process. This means that all subscriptions and
+ * consumers will be resubscribed and their work resumed after successful
+ * reconnect where all reconnect options are respected.
  *
  * @param nc the pointer to the #natsConnection object.
  */


### PR DESCRIPTION
Mostly doxygen changes, renames 2 (new) callback types that were inappropriately named `nats...`, should've been `js_`.

The only way I know to see the HTML changes is to run Doxygen locally, in this branch.