### PR TITLE
[FIXED] Examples: Add missing 'stream' and 'durable' params in usage

### DIFF
--- a/examples/js-pub.c
+++ b/examples/js-pub.c
@@ -14,7 +14,7 @@
 #include "examples.h"
 
 static const char *usage = ""\
-"-stream        stream name (default is 'foo')\n" \
+"-stream        stream name (required)\n" \
 "-txt           text to send (default is 'hello')\n" \
 "-count         number of messages to send\n" \
 "-sync          publish synchronously (default is async)\n";

--- a/examples/js-sub.c
+++ b/examples/js-sub.c
@@ -15,6 +15,8 @@
 
 static const char *usage = ""\
 "-gd            use global message delivery thread pool\n" \
+"-stream        stream name (required)\n" \
+"-durable       durable name (default is to create an ephemeral consumer)\n"
 "-sync          receive synchronously (default is asynchronous)\n" \
 "-pull          use pull subscription\n" \
 "-pull-async    use an async pull subscription\n" \


### PR DESCRIPTION
Also clarify that `stream` parameter is actually needed.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>