### PR TITLE
Fixed JetStreamBackOffRedeliveries test

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -31106,7 +31106,7 @@ void test_JetStreamBackOffRedeliveries(void)
     so.Config.AckPolicy = js_AckExplicit;
     so.Config.DeliverPolicy = js_DeliverAll;
     so.Config.DeliverSubject = inbox;
-    so.Config.MaxDeliver = 2;
+    so.Config.MaxDeliver = 1;
     so.Config.BackOff = (int64_t[]){NATS_MILLIS_TO_NANOS(50), NATS_MILLIS_TO_NANOS(250)};
     so.Config.BackOffLen = 2;
     s = js_SubscribeSync(&sub, js, "foo", NULL, &so, &jerr);


### PR DESCRIPTION
Since this server PR: https://github.com/nats-io/nats-server/pull/6154 the error occurs only if MaxDeliver is specified, but it is strictly lower than BackOff length. So fix the test by lowering it to 1.

Signed-off-by: Ivan Kozlovic ivan@synadia.com
