### PR TITLE
[FIXED] Build: failure with Android NDK

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -37025,12 +37025,22 @@ void test_StanSubTimeout(void)
 
 #ifndef _WIN32
 static void _sigsegv_handler(int sig) {
+
+// Android doesn't support backtrace before API Level 33.
+// Because this is for tests it's good enough to check
+// for Android only, until there is need for a better solution.
+#ifndef ANDROID
   void *array[20];
   int size = backtrace(array, 20);
+#endif // ANDROID
 
   // print out all the frames to stderr
   fprintf(stderr, "Error: signal %d:\n", sig);
+
+#ifndef ANDROID
   backtrace_symbols_fd(array, size, STDERR_FILENO);
+#endif // ANDROID
+
   exit(1);
 }
 #endif // _WIN32


### PR DESCRIPTION
When building against Android NDK testsuit compilation fails due to missing execinfo.h/backtrace implementation in platforms with id less than 33. Because this is only in tests just checking for Android should be enough to keep things simple.

reproduced on ubuntu:
```
wget https://dl.google.com/android/repository/android-ndk-r27c-linux.zip
unzip android-ndk-r27c-linux.zip -d /path/to/ndk
export ANDROID_NDK=/path/to/ndk/android-ndk-r27c
cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake -DNATS_BUILD_STREAMING=NO -DNATS_BUILD_WITH_TLS=NO
cmake --build build

[ 97%] Building C object test/CMakeFiles/testsuite.dir/test.c.o
/home/mtmk/src/nats.c/test/test.c:37029:14: error: call to undeclared function 'backtrace'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  int size = backtrace(array, 20);
             ^
/home/mtmk/src/nats.c/test/test.c:37033:3: error: call to undeclared function 'backtrace_symbols_fd'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  backtrace_symbols_fd(array, size, STDERR_FILENO);
  ^
2 errors generated.
gmake[2]: *** [test/CMakeFiles/testsuite.dir/build.make:76: test/CMakeFiles/testsuite.dir/test.c.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1592: test/CMakeFiles/testsuite.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

**Note about API Levels**
Function is actually supported on Android but only on the more recent builds i.e. API Level >= 33:
https://android.googlesource.com/platform/bionic/+/refs/tags/ndk-r27c/libc/include/execinfo.h#48

