### PR TITLE
[FIXED] microService_AddEndpoint() could crash if subject is invalid

### DIFF
--- a/src/micro.c
+++ b/src/micro.c
@@ -149,8 +149,9 @@ micro_add_endpoint(microEndpoint **new_ep, microService *m, microGroup *g, micro
         return microError_Wrapf(err, "failed to create full subject for endpoint '%s'", cfg->Name);
     if (!micro_is_valid_subject(fullSubject))
     {
+        err = microError_Wrapf(micro_ErrorInvalidArg, "invalid subject '%s' for endpoint '%s'", fullSubject, cfg->Name);
         NATS_FREE(fullSubject);
-        return microError_Wrapf(micro_ErrorInvalidArg, "invalid subject '%s' for endpoint '%s'", fullSubject, cfg->Name);
+        return err;
     }
 
     _lock_service(m);

--- a/test/test.c
+++ b/test/test.c
@@ -33940,6 +33940,7 @@ void test_MicroGroups(void)
     microGroup *g2 = NULL;
     microServiceInfo *info = NULL;
     int i;
+    char buf[1024];
 
     microEndpointConfig ep2_cfg = {
         .Name = "ep2",
@@ -33976,6 +33977,13 @@ void test_MicroGroups(void)
     testCond(NATS_OK == natsConnection_Connect(&nc, opts));
 
     _startMicroservice(&m, nc, &cfg, NULL, 0, &arg);
+
+    test("AddEnpoint with invalid subject: ");
+    microEndpointConfig invalid_subject_ep_cfg = { .Name = "invalidsubject", .Handler = _microHandleRequest42, .Subject = "foo bar" };
+    err = microService_AddEndpoint(m, &invalid_subject_ep_cfg);
+    testCond((err != NULL) && (strstr(microError_String(err, buf, sizeof(buf)), "invalid subject 'foo bar'") != NULL));
+    microError_Destroy(err);
+    err = NULL;
 
     test("AddEndpoint 1 to service: ");
     microEndpointConfig ep1_cfg = { .Name = "ep1", .Handler = _microHandleRequest42 };


### PR DESCRIPTION
Saw that looking at the build log in GitHub actions:
```
/home/runner/work/nats.c/nats.c/src/micro.c: In function ‘micro_add_endpoint’:
/home/runner/work/nats.c/nats.c/src/micro.c:153:16: warning: pointer used after ‘free’ [-Wuse-after-free]
  153 |         return microError_Wrapf(micro_ErrorInvalidArg, "invalid subject '%s' for endpoint '%s'", fullSubject, cfg->Name);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/runner/work/nats.c/nats.c/src/microp.h:18,
                 from /home/runner/work/nats.c/nats.c/src/micro.c:16:
/home/runner/work/nats.c/nats.c/src/mem.h:28:29: note: call to ‘free’ here
   28 | #define NATS_FREE(p)        free((p))
      |                             ^~~~~~~~~
/home/runner/work/nats.c/nats.c/src/micro.c:152:9: note: in expansion of macro ‘NATS_FREE’
  152 |         NATS_FREE(fullSubject);
      |         ^~~~~~~~~
```

Added an invalid subject endpoint config in one of the test to verify the issue and the fix.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>