### PR TITLE
[FIXED] Added missing `NATS_EXTERN` on some functions.

### DIFF
--- a/src/nats.h
+++ b/src/nats.h
@@ -1912,7 +1912,7 @@ typedef void (*stanConnectionLostHandler)(
  * @param config points to a natsClientConfig. A copy of the settings is made,
  * so the config can be freed after initializing the NATS client.
  */
-natsStatus
+NATS_EXTERN natsStatus
 nats_OpenWithConfig(natsClientConfig *config);
 
 /** \brief Initializes the library.
@@ -1964,7 +1964,8 @@ nats_GetVersionNumber(void);
  * @see nats_GetVersion
  * @see nats_GetVersionNumber
  */
-NATS_EXTERN bool nats_CheckCompatibility(void);
+NATS_EXTERN bool
+nats_CheckCompatibility(void);
 #else
 
 #define nats_CheckCompatibility() nats_CheckCompatibilityImpl(NATS_VERSION_REQUIRED_NUMBER, \
@@ -4216,7 +4217,7 @@ natsConnection_Connect(natsConnection **nc, natsOptions *options);
  *
  * @param nc the pointer to the #natsConnection object.
  */
-natsStatus
+NATS_EXTERN natsStatus
 natsConnection_Reconnect(natsConnection *nc);
 
 /** \brief Process a read event when using external event loop.
@@ -8377,7 +8378,8 @@ microService_Run(microService *m);
  *
  * @see #micro_AddService, #microService_Run
  */
-NATS_EXTERN microError *microService_Stop(microService *m);
+NATS_EXTERN microError *
+microService_Stop(microService *m);
 
 /** @} */ // end of microServiceFunctions
 

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -113,7 +113,7 @@ static inline bool nats_StringEquals(const char *s1, const char *s2)
     if (s2 == NULL)
         return false;
 
-    return strcmp(s1, s2);
+    return strcmp(s1, s2) == 0;
 }
 
 #define DUP_STRING(s, s1, s2) \

--- a/test/check_cpp/check_cpp.cpp
+++ b/test/check_cpp/check_cpp.cpp
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
 #include <nats.h>
 
 // Check C++ compiler compatibility of structs in
@@ -24,6 +23,6 @@ int main(int argc, char **argv)
     jsFetch fetch;
     fetch.opts.Timeout = 1;
 
-    std::cout << "OK" << std::endl;
+    printf("OK\n");
     return 0;
 }


### PR DESCRIPTION
Namely `nats_OpenWithConfig` and `natsConnection_Reconnect`.

Also normalized the `NATS_EXTERN <return type>` in one line and the function name on the next line.

Updated the C++ compile test since it was failing on my mac env, and modified `nats_StringEquals` that was triggering a warning on my Windows VM build.

Resolves #835

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>