### PR TITLE
[FIXED] Default statistics handler of microservice had unnecessary check

### DIFF
--- a/src/micro_monitoring.c
+++ b/src/micro_monitoring.c
@@ -81,12 +81,8 @@ static microError *
 handle_stats_default(microRequest *req)
 {
     microError *err = NULL;
-    microService *m = microRequest_GetService(req);
     microServiceStats *stats = NULL;
     natsBuffer *buf = NULL;
-
-    if ((m == NULL) || (m == NULL))
-        return micro_ErrorInvalidArg; // Should not happen
 
     MICRO_CALL(err, microService_GetStats(&stats, req->Service));
     MICRO_CALL(err, marshal_stats(&buf, stats));


### PR DESCRIPTION
The default handler was invoked with a request that was already checked to have a service associated. The handler was extracting the service (that was not needed) and had an incorrect check such as `if ((m == NULL) || (m == NULL))`.

Resolves #833

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>