### PR TITLE
fix: double free and deref after free in js.c

### DIFF
--- a/src/js.c
+++ b/src/js.c
@@ -3535,6 +3535,8 @@ jsSub_resetOrderedConsumer(natsSubscription *sub, uint64_t sseq)
         if (s != NATS_OK)
         {
             NATS_FREE(oci);
+            NATS_FREE(oci->ndlv);
+            oci = NULL;
             natsSub_release(sub);
         }
     }

--- a/src/js.c
+++ b/src/js.c
@@ -3533,13 +3533,12 @@ jsSub_resetOrderedConsumer(natsSubscription *sub, uint64_t sseq)
 
         s = natsThread_Create(&oci->thread, _recreateOrderedCons, (void*) oci);
         if (s != NATS_OK)
-        {
-            NATS_FREE(oci->ndlv);
             natsSub_release(sub);
-        }
     }
-    if ((s != NATS_OK) && (oci != NULL))
+    if (s != NATS_OK)
     {
+        if (oci != NULL)
+            NATS_FREE(oci->ndlv);
         NATS_FREE(oci);
     }
     return s;

--- a/src/js.c
+++ b/src/js.c
@@ -3534,15 +3534,12 @@ jsSub_resetOrderedConsumer(natsSubscription *sub, uint64_t sseq)
         s = natsThread_Create(&oci->thread, _recreateOrderedCons, (void*) oci);
         if (s != NATS_OK)
         {
-            NATS_FREE(oci);
             NATS_FREE(oci->ndlv);
-            oci = NULL;
             natsSub_release(sub);
         }
     }
     if ((s != NATS_OK) && (oci != NULL))
     {
-        NATS_FREE(oci->ndlv);
         NATS_FREE(oci);
     }
     return s;

--- a/src/js.c
+++ b/src/js.c
@@ -3535,10 +3535,9 @@ jsSub_resetOrderedConsumer(natsSubscription *sub, uint64_t sseq)
         if (s != NATS_OK)
             natsSub_release(sub);
     }
-    if (s != NATS_OK)
+    if ((s != NATS_OK) && (oci != NULL))
     {
-        if (oci != NULL)
-            NATS_FREE(oci->ndlv);
+        NATS_FREE(oci->ndlv);
         NATS_FREE(oci);
     }
     return s;


### PR DESCRIPTION
If we failed in natsThread_Create now we do double free for oci.

I added free on oci part for this and assigns NULL to avoid it.