### PR TITLE
fix: some nulls checks

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -3352,9 +3352,8 @@ _processUrlString(natsOptions *opts, const char *urls)
 
     serverUrls = (char**) NATS_CALLOC(count + 1, sizeof(char*));
     if (serverUrls == NULL)
-    {
         return NATS_NO_MEMORY;
-    }
+    
     if (s == NATS_OK)
     {
         urlsCopy = NATS_STRDUP(urls);

--- a/src/conn.c
+++ b/src/conn.c
@@ -580,7 +580,7 @@ _processInfo(natsConnection *nc, char *info, int len)
             tlsName = (const char*) nc->cur->url->host;
 
         s = natsSrvPool_addNewURLs(nc->srvPool,
-                                   nc->cur->url,
+                                   nc->cur ? nc->cur->url : NULL,
                                    nc->info.connectURLs,
                                    nc->info.connectURLsCount,
                                    tlsName,
@@ -3352,7 +3352,9 @@ _processUrlString(natsOptions *opts, const char *urls)
 
     serverUrls = (char**) NATS_CALLOC(count + 1, sizeof(char*));
     if (serverUrls == NULL)
-        s = NATS_NO_MEMORY;
+    {
+        return NATS_NO_MEMORY;
+    }
     if (s == NATS_OK)
     {
         urlsCopy = NATS_STRDUP(urls);

--- a/src/js.c
+++ b/src/js.c
@@ -3454,8 +3454,10 @@ _recreateOrderedCons(void *closure)
 
     NATS_FREE(oci->ndlv);
     NATS_FREE(oci);
-    natsThread_Detach(t);
-    natsThread_Destroy(t);
+    if (t != NULL) {
+        natsThread_Detach(t);
+        natsThread_Destroy(t);
+    }
     natsSub_release(sub);
 }
 

--- a/src/sub.c
+++ b/src/sub.c
@@ -656,12 +656,15 @@ natsSub_nextMsg(natsMsg **nextMsg, natsSubscription *sub, int64_t timeout, bool 
     if (s == NATS_OK)
     {
         msg = sub->ownDispatcher.queue.head;
-        if ((msg == NULL) && sub->draining)
+        if (msg == NULL)
         {
-            removeSub = true;
-            s = NATS_TIMEOUT;
+            if (sub->draining)
+            {
+                removeSub = true;
+                s = NATS_TIMEOUT;
+            }
         }
-        else if (msg != NULL)
+        else
         {
             sub->ownDispatcher.queue.head = msg->next;
 

--- a/src/sub.c
+++ b/src/sub.c
@@ -661,7 +661,7 @@ natsSub_nextMsg(natsMsg **nextMsg, natsSubscription *sub, int64_t timeout, bool 
             removeSub = true;
             s = NATS_TIMEOUT;
         }
-        else
+        else if (msg != NULL)
         {
             sub->ownDispatcher.queue.head = msg->next;
 


### PR DESCRIPTION
3 locations:
1. nc->cur checked for NULL, but after use it without check
2. serverUrls can be null and dereferenced in do-while cycle
3. msg can be null, if sub->draining false. I just added check, maybe someone advice how to fix it better