### PR TITLE
fix: typo in clear routine

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -1500,7 +1500,7 @@ nats_JSONArrayAsStrings(nats_JSONArray *arr, char ***array, int *arraySize)
         int j;
 
         for (j=0; j<i; j++)
-            NATS_FREE(values[i]);
+            NATS_FREE(values[j]);
 
         NATS_FREE(values);
     }


### PR DESCRIPTION
I hope I catch logic of this function.

We iterate over arr->values, and If allocation fails we have `i` to know how many already allocated. 
And after goes 0..i to clear allocated strings before.

But for-cycle do not use `j` which increment, and use `i`  `i`-times