### PR TITLE
fix: better cleanup if js clone config fails

### DIFF
--- a/src/jsm.c
+++ b/src/jsm.c
@@ -4019,8 +4019,9 @@ js_cloneConsumerConfig(jsConsumerConfig *org, jsConsumerConfig **clone)
         for (int i = 0; (s == NATS_OK) && (i < org->FilterSubjectsLen); i++)
         {
             IF_OK_DUP_STRING(s, c->FilterSubjects[i], org->FilterSubjects[i]);
+            if (s == NATS_OK)
+                c->FilterSubjectsLen++;
         }
-        c->FilterSubjectsLen = org->FilterSubjectsLen;
     }
     IFOK(s, nats_cloneMetadata(&(c->Metadata), org->Metadata));
     if (s == NATS_OK)


### PR DESCRIPTION
I see some problem around this code fragment.

What if this calloc returns NULL?
https://github.com/nats-io/nats.c/blob/07df538b422a8bb3377173d26db238f9b12e73ec/src/jsm.c#L4015
- we set `s = nats_setDefaultError(NATS_NO_MEMORY);` - ok
- we skip cycle because s raised - ok
- we assign len for clone - bad 
https://github.com/nats-io/nats.c/blob/07df538b422a8bb3377173d26db238f9b12e73ec/src/jsm.c#L4023
- go here:
https://github.com/nats-io/nats.c/blob/07df538b422a8bb3377173d26db238f9b12e73ec/src/jsm.c#L4029
- Free NULL - ok
https://github.com/nats-io/nats.c/blob/07df538b422a8bb3377173d26db238f9b12e73ec/src/jsm.c#L3027
- Free NULL->`*some offset*` - bad
https://github.com/nats-io/nats.c/blob/07df538b422a8bb3377173d26db238f9b12e73ec/src/jsm.c#L3025

Counter examples (why my patch looks like this):
https://github.com/nats-io/nats.c/blob/07df538b422a8bb3377173d26db238f9b12e73ec/src/jsm.c#L1119
https://github.com/nats-io/nats.c/blob/07df538b422a8bb3377173d26db238f9b12e73ec/src/jsm.c#L1206
https://github.com/nats-io/nats.c/blob/07df538b422a8bb3377173d26db238f9b12e73ec/src/jsm.c#L2536




