### PR TITLE
Removed all remaining EXPERIMENTAL (micro)services documentation references

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,8 +536,6 @@ js_DeleteStream(js, "ORDERS", NULL, &jerr);
 
 ## KeyValue
 
-**EXPERIMENTAL FEATURE! We reserve the right to change the API without necessarily bumping the major version of the library.**
-
 A KeyValue store is a materialized view based on JetStream. A bucket is a stream and keys are subjects within that stream.
 
 Some features require NATS Server `v2.6.2`, so we recommend that you use the latest NATS Server release to have a better experience.

--- a/src/nats.h
+++ b/src/nats.h
@@ -7558,10 +7558,7 @@ kvStatus_Destroy(kvStatus *sts);
 // Microservices.
 //
 
-/** \defgroup microGroup EXPERIMENTAL - Microservices
- *
- * \warning EXPERIMENTAL FEATURE! We reserve the right to change the API without
- * necessarily bumping the major version of the library.
+/** \defgroup microGroup - Microservices
  *
  * ### NATS Microservices.
  *


### PR DESCRIPTION
@Jarema please note that the `Micro` in the name is still there. LMK if it's ok to stay as is, or if we should rename to `Service`.