### PR TITLE
Fix possible null deref in pub

### DIFF
--- a/src/pub.c
+++ b/src/pub.c
@@ -279,10 +279,12 @@ natsConnection_PublishString(natsConnection *nc, const char *subj,
 natsStatus
 natsConnection_PublishMsg(natsConnection *nc, natsMsg *msg)
 {
-    const char *reply = (msg != NULL ? msg->reply : NULL);
     natsStatus s;
 
-    s = _publishMsg(nc, msg, reply);
+    if (nc == NULL || msg == NULL)
+        return nats_setDefaultError(NATS_INVALID_ARG);
+
+    s = _publishMsg(nc, msg, NULL);
     return NATS_UPDATE_ERR_STACK(s);
 }
 


### PR DESCRIPTION
1. remove reply construct because it is done by natsConn_publish
https://github.com/nats-io/nats.c/blob/4f993dccf03e964279d8602234c8e4d2c1afe2cb/src/pub.c#L82

2. we have check msg != NULL and i just move it to natsConn_publish
 https://github.com/nats-io/nats.c/blob/4f993dccf03e964279d8602234c8e4d2c1afe2cb/src/pub.c#L282