### PR TITLE
Use monotonic timer for RTT

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -4446,12 +4446,9 @@ natsConnection_GetRTT(natsConnection *nc, int64_t *rtt)
     {
 
         start = nats_NowMonotonicInNanoSeconds();
-        // start = nats_NowInNanoSeconds();
         s = _flushTimeout(nc, DEFAULT_FLUSH_TIMEOUT);
-        if (s == NATS_OK) {
+        if (s == NATS_OK)
             *rtt = nats_NowMonotonicInNanoSeconds()-start;
-            // *rtt = nats_NowInNanoSeconds()-start;
-        }
     }
     natsConn_Unlock(nc);
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -4444,10 +4444,14 @@ natsConnection_GetRTT(natsConnection *nc, int64_t *rtt)
         s = nats_setDefaultError(NATS_CONNECTION_DISCONNECTED);
     else
     {
-        start = nats_NowInNanoSeconds();
+
+        start = nats_NowMonotonicInNanoSeconds();
+        // start = nats_NowInNanoSeconds();
         s = _flushTimeout(nc, DEFAULT_FLUSH_TIMEOUT);
-        if (s == NATS_OK)
-            *rtt = nats_NowInNanoSeconds()-start;
+        if (s == NATS_OK) {
+            *rtt = nats_NowMonotonicInNanoSeconds()-start;
+            // *rtt = nats_NowInNanoSeconds()-start;
+        }
     }
     natsConn_Unlock(nc);
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -4444,7 +4444,6 @@ natsConnection_GetRTT(natsConnection *nc, int64_t *rtt)
         s = nats_setDefaultError(NATS_CONNECTION_DISCONNECTED);
     else
     {
-
         start = nats_NowMonotonicInNanoSeconds();
         s = _flushTimeout(nc, DEFAULT_FLUSH_TIMEOUT);
         if (s == NATS_OK)

--- a/src/nats.h
+++ b/src/nats.h
@@ -1992,6 +1992,18 @@ nats_Now(void);
 NATS_EXTERN int64_t
 nats_NowInNanoSeconds(void);
 
+/** \brief Gives the current time in nanoseconds using monotonic timer.
+ *
+ * Gives the current time in nanoseconds. When such granularity is not
+ * available, the time returned is still expressed in nanoseconds.
+ * Using monotonic timer is more reliable than using the real time
+ * when measuring time intervals.
+ *
+ * \note On Windows platforms, this function uses the QueryPerformanceCounter.
+ */
+NATS_EXTERN int64_t
+nats_NowMonotonicInNanoSeconds(void);
+
 /** \brief Sleeps for a given number of milliseconds.
  *
  * Causes the current thread to be suspended for at least the number of

--- a/src/natstime.c
+++ b/src/natstime.c
@@ -61,20 +61,18 @@ nats_NowInNanoSeconds(void)
 int64_t
 nats_NowMonotonicInNanoSeconds(void)
 {
+    int64_t now = 0;
 #ifdef _WIN32
     LARGE_INTEGER frequency;
     LARGE_INTEGER counter;
     if (QueryPerformanceFrequency(&frequency) && QueryPerformanceCounter(&counter))
-        return (int64_t)(counter.QuadPart * 1000000000ULL / frequency.QuadPart);
-    return nats_NowInNanoSeconds();
+        now = (int64_t)(counter.QuadPart * 1000000000ULL / frequency.QuadPart);
 #elif defined CLOCK_MONOTONIC
     struct timespec ts;
     if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
-        return ((int64_t) ts.tv_sec) * 1000000000L + ((int64_t) ts.tv_nsec);
-    return nats_NowInNanoSeconds();
-#else
-    return nats_NowInNanoSeconds();
+        now = ((int64_t) ts.tv_sec) * 1000000000L + ((int64_t) ts.tv_nsec);
 #endif
+    return now != 0 ? now : nats_NowInNanoSeconds();
 }
 
 void

--- a/src/natstime.c
+++ b/src/natstime.c
@@ -64,24 +64,16 @@ nats_NowMonotonicInNanoSeconds(void)
 #ifdef _WIN32
     LARGE_INTEGER frequency;
     LARGE_INTEGER counter;
-    if (!QueryPerformanceFrequency(&frequency) || !QueryPerformanceCounter(&counter))
-        abort();
-    return (int64_t)(counter.QuadPart * 1000000000ULL / frequency.QuadPart);
+    if (QueryPerformanceFrequency(&frequency) && QueryPerformanceCounter(&counter))
+        return (int64_t)(counter.QuadPart * 1000000000ULL / frequency.QuadPart);
+    return nats_NowInNanoSeconds();
 #elif defined CLOCK_MONOTONIC
     struct timespec ts;
-    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
-        abort();
-    return ((int64_t) ts.tv_sec) * 1000000000L + ((int64_t) ts.tv_nsec);
-#elif defined CLOCK_REALTIME
-    struct timespec ts;
-    if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
-        abort();
-    return ((int64_t)ts.tv_sec) * 1000000000L + ((int64_t)ts.tv_nsec);
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
+        return ((int64_t) ts.tv_sec) * 1000000000L + ((int64_t) ts.tv_nsec);
+    return nats_NowInNanoSeconds();
 #else
-    struct timeval tv;
-    if (gettimeofday(&tv, NULL) != 0)
-        abort();
-    return ((int64_t)tv.tv_sec) * 1000000000L + (((int64_t)tv.tv_usec) * 1000);
+    return nats_NowInNanoSeconds();
 #endif
 }
 

--- a/src/natstime.c
+++ b/src/natstime.c
@@ -58,6 +58,33 @@ nats_NowInNanoSeconds(void)
 #endif
 }
 
+int64_t
+nats_NowMonotonicInNanoSeconds(void)
+{
+#ifdef _WIN32
+    LARGE_INTEGER frequency;
+    LARGE_INTEGER counter;
+    if (!QueryPerformanceFrequency(&frequency) || !QueryPerformanceCounter(&counter))
+        abort();
+    return (int64_t)(counter.QuadPart * 1000000000ULL / frequency.QuadPart);
+#elif defined CLOCK_MONOTONIC
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
+        abort();
+    return ((int64_t) ts.tv_sec) * 1000000000L + ((int64_t) ts.tv_nsec);
+#elif defined CLOCK_REALTIME
+    struct timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
+        abort();
+    return ((int64_t)ts.tv_sec) * 1000000000L + ((int64_t)ts.tv_nsec);
+#else
+    struct timeval tv;
+    if (gettimeofday(&tv, NULL) != 0)
+        abort();
+    return ((int64_t)tv.tv_sec) * 1000000000L + (((int64_t)tv.tv_usec) * 1000);
+#endif
+}
+
 void
 natsDeadline_Init(natsDeadline *deadline, int64_t timeout)
 {


### PR DESCRIPTION
Currently, on Windows, the RTT (round-trip time) resolution is too low because it doesn’t support sub-millisecond precision. To address this, I propose we use the `QueryPerformanceCounter` API, which offers higher resolution. Additionally, monotonic timers are preferable for time interval measurements. Unlike the real-time clock, which isn’t guaranteed to be incremental and can even move backward, monotonic timers ensure consistent and reliable results.