### PR TITLE
Add support for loading CA trusted certificates from directory

### DIFF
--- a/src/nats.h
+++ b/src/nats.h
@@ -2528,7 +2528,7 @@ natsOptions_LoadCATrustedCertificates(natsOptions *opts, const char *fileName);
  * You can get extra information by calling #nats_GetLastError.
  *
  * @param opts the pointer to the #natsOptions object.
- * @param path the file containing the CA certificates.
+ * @param path the path containing the CA certificates.
  *
  */
 NATS_EXTERN natsStatus

--- a/src/nats.h
+++ b/src/nats.h
@@ -2528,7 +2528,7 @@ natsOptions_LoadCATrustedCertificates(natsOptions *opts, const char *fileName);
  * You can get extra information by calling #nats_GetLastError.
  *
  * @param opts the pointer to the #natsOptions object.
- * @param fileName the file containing the CA certificates.
+ * @param path the file containing the CA certificates.
  *
  */
 NATS_EXTERN natsStatus

--- a/src/nats.h
+++ b/src/nats.h
@@ -2518,6 +2518,22 @@ natsOptions_TLSHandshakeFirst(natsOptions *opts);
 NATS_EXTERN natsStatus
 natsOptions_LoadCATrustedCertificates(natsOptions *opts, const char *fileName);
 
+/** \brief Loads the trusted CA certificates from a directory.
+ *
+ * Loads the trusted CA certificates from a directory.
+ *
+ * Note that the certificates are added to a SSL context for this #natsOptions
+ * object at the time of this call, so possible errors while loading the
+ * certificates will be reported now instead of when a connection is created.
+ * You can get extra information by calling #nats_GetLastError.
+ *
+ * @param opts the pointer to the #natsOptions object.
+ * @param fileName the file containing the CA certificates.
+ *
+ */
+NATS_EXTERN natsStatus
+natsOptions_LoadCATrustedCertificatesPath(natsOptions *opts, const char *path);
+
 /** \brief Sets the trusted CA certificates from memory.
  *
  * Similar to #natsOptions_LoadCATrustedCertificates expect that instead

--- a/src/opts.c
+++ b/src/opts.c
@@ -409,6 +409,32 @@ natsOptions_LoadCATrustedCertificates(natsOptions *opts, const char *fileName)
 }
 
 natsStatus
+natsOptions_LoadCATrustedCertificatesPath(natsOptions *opts, const char *path)
+{
+    natsStatus s = NATS_OK;
+
+    LOCK_AND_CHECK_OPTIONS(opts, ((path == NULL) || (path[0] == '\0')));
+
+    s = _getSSLCtx(opts);
+    if (s == NATS_OK)
+    {
+        nats_sslRegisterThreadForCleanup();
+
+        if (SSL_CTX_load_verify_locations(opts->sslCtx->ctx, NULL, path) != 1)
+        {
+            s = nats_setError(NATS_SSL_ERROR,
+                              "Error loading trusted certificates in path '%s': %s",
+                              path,
+                              NATS_SSL_ERR_REASON_STRING);
+        }
+    }
+
+    UNLOCK_OPTS(opts);
+
+    return s;
+}
+
+natsStatus
 natsOptions_SetCATrustedCertificates(natsOptions *opts, const char *certs)
 {
     natsStatus s = NATS_OK;


### PR DESCRIPTION
This adds support for loading certificates from a directory. For now, I'm patching the library during the build of our container, but it would be nice if a dedicated function were available instead.