### PR TITLE
[BUILD ONLY] removed the older compilers jobs, n/a on Ubuntu 22.04

### DIFF
--- a/.github/workflows/on-push-release-extra.yml
+++ b/.github/workflows/on-push-release-extra.yml
@@ -40,17 +40,6 @@ jobs:
     with:
       tls: OFF
 
-  older-cc:
-    strategy:
-      fail-fast: false
-      matrix:
-        compiler: [gcc-7, gcc-8, clang-8]
-    uses: ./.github/workflows/build-test.yml
-    name: "Older compilers"
-    with:
-      ubuntu_version: 22.04
-      compiler: ${{ matrix.compiler }}
-
   no-streaming:
     uses: ./.github/workflows/build-test.yml
     name: "No Streaming"


### PR DESCRIPTION
This job now fails since these older compilers do not appear available on Ubuntu 22.04 (after https://github.com/nats-io/nats.c/pull/864)

I scanned the README and the docs and we do not appear to make any claims as to the specific compiler version support.