### PR TITLE
[BUILD ONLY] Fix Windows build to use server main

### DIFF
--- a/.github/workflows/on-pr-debug.yml
+++ b/.github/workflows/on-pr-debug.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           cd build
           # Download latest nats-server
-          rel="latest" # TODO: parameterize
+          rel="main" # TODO: parameterize
           if [ "$rel" = "latest" ]; then
             rel=$(curl -s https://api.github.com/repos/nats-io/nats-server/releases/latest | jq -r '.tag_name')
           fi


### PR DESCRIPTION
This is caused by binary only tag no being able to processed by the nats-server download system