### PR TITLE
fix: add missing statusText string

### DIFF
--- a/src/status.c
+++ b/src/status.c
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <assert.h>
+
 #include "natsp.h"
 
 static const char *statusText[] = {
@@ -75,6 +77,8 @@ static const char *statusText[] = {
 
     "Jetstream Consumer PinID Mismatch",
 };
+
+static_assert(NATS_MAX_STATUS_VALUE_ == sizeof(statusText)/sizeof(statusText[0]), "Incorrect array size");
 
 const char*
 natsStatus_GetText(natsStatus s) {

--- a/src/status.c
+++ b/src/status.c
@@ -72,6 +72,8 @@ static const char *statusText[] = {
     "Mismatch",
     "Missed Server Heartbeat",
     "Limit reached",
+
+    "Jetstream Consumer PinID Mismatch",
 };
 
 const char*

--- a/src/status.h
+++ b/src/status.h
@@ -136,6 +136,8 @@ typedef enum
     NATS_PIN_ID_MISMATCH,               ///< Pin ID sent in the request does not match the currently pinned
                                         ///  consumer subscriber ID on the server.
 
+    NATS_MAX_STATUS_VALUE_,             ///< Maximum status value, this element MUST be the last one
+
 } natsStatus;
 
 typedef enum {


### PR DESCRIPTION
For status **NATS_PIN_ID_MISMATCH** in array **statusText** its description was missing. 
Therefore, calling the function **natsStatus_GetText(NATS_PIN_ID_MISMATCH)** would result in accessing an invalid address.