### PR TITLE
[FIXED] Build: Unknown type name SSL_verify_cb

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -737,12 +737,14 @@ _makeTLSConn(natsConnection *nc)
             }
             if (s == NATS_OK)
             {
-                SSL_verify_cb cb = _collectSSLErr;
 #ifdef NATS_WITH_EXPERIMENTAL
+                SSL_verify_cb cb = _collectSSLErr;
                 if (nc->opts->sslCtx->callback != NULL)
                     cb = nc->opts->sslCtx->callback;
-#endif // NATS_WITH_EXPERIMENTAL
                 SSL_set_verify(ssl, SSL_VERIFY_PEER, cb);
+#else
+                SSL_set_verify(ssl, SSL_VERIFY_PEER, _collectSSLErr);
+#endif // NATS_WITH_EXPERIMENTAL
             }
         }
     }
@@ -3360,7 +3362,7 @@ _processUrlString(natsOptions *opts, const char *urls)
     serverUrls = (char**) NATS_CALLOC(count + 1, sizeof(char*));
     if (serverUrls == NULL)
         return NATS_NO_MEMORY;
-    
+
     if (s == NATS_OK)
     {
         urlsCopy = NATS_STRDUP(urls);


### PR DESCRIPTION
We had several issues around the introducing of a verification callback. We reverted to use a `NATS_WITH_EXPERIMENTAL` build flag, but still, as part of the rewrite, there was something of the like:
```
SSL_verify_cb cb = _collectSSLErr;
```
Prior to 3.10, we would have called `SSL_set_verify(ssl, SSL_VERIFY_PEER, _collectSSLErr);` which was not causing an issue. The above would when building with OpenSSL prior to 1.1.1.

So move the `cb` initialization as a `SSL_verify_cb` only when under the experimental flag, otherwise, invoke the same code we had prior to 3.10.

Resolves #877

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>