### PR TITLE
[IMPROVED] Timer insertion

### DIFF
--- a/src/glib/glibp.h
+++ b/src/glib/glibp.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2024 The NATS Authors
+// Copyright 2015-2025 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -46,7 +46,8 @@ typedef struct __natsLibTimers
     natsMutex *lock;
     natsCondition *cond;
     natsThread *thread;
-    natsTimer *timers;
+    natsTimer *head;
+    natsTimer *tail;
     int count;
     bool changed;
     bool shutdown;


### PR DESCRIPTION
We use a linked list to hold timers. They are ordered by absolute time. Inserting a timer was always looking for the spot starting at the beginning. We now check first if it should be added directly at the end of the list, which in most cases - say creating new connections that creates a timer for sending PINGs, they will likely be sequential.

Added a test that shows that for 100,000 timers, the time spent is now very small.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>