### PR TITLE
Testing: add custom inbox prefix that is very long

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -1328,7 +1328,7 @@ natsConn_destroyRespPool(natsConnection *nc)
 // subject (that is set in respInbox). The respInfo object is returned.
 // Connection's lock is held on entry.
 natsStatus
-natsConn_addRespInfo(respInfo **newResp, natsConnection *nc, char *respInbox, int respInboxSize)
+natsConn_addRespInfo(respInfo **newResp, natsConnection *nc, char *respInbox)
 {
     respInfo    *resp  = NULL;
     natsStatus  s      = NATS_OK;
@@ -3360,7 +3360,7 @@ _processUrlString(natsOptions *opts, const char *urls)
     serverUrls = (char**) NATS_CALLOC(count + 1, sizeof(char*));
     if (serverUrls == NULL)
         return NATS_NO_MEMORY;
-    
+
     if (s == NATS_OK)
     {
         urlsCopy = NATS_STRDUP(urls);

--- a/src/conn.h
+++ b/src/conn.h
@@ -111,7 +111,7 @@ void
 natsConn_processAsyncINFO(natsConnection *nc, char *buf, int len);
 
 natsStatus
-natsConn_addRespInfo(respInfo **newResp, natsConnection *nc, char *respInbox, int respInboxSize);
+natsConn_addRespInfo(respInfo **newResp, natsConnection *nc, char *respInbox);
 
 void
 natsConn_disposeRespInfo(natsConnection *nc, respInfo *resp, bool needsLock);

--- a/src/pub.c
+++ b/src/pub.c
@@ -474,7 +474,7 @@ natsConnection_RequestMsg(natsMsg **replyMsg, natsConnection *nc,
     if (nc->respMux == NULL)
         s = natsConn_initResp(nc, _respHandler);
     if (s == NATS_OK)
-        s = natsConn_addRespInfo(&resp, nc, respInbox, sizeof(respInbox));
+        s = natsConn_addRespInfo(&resp, nc, respInbox);
 
     natsConn_Unlock(nc);
 

--- a/test/test.c
+++ b/test/test.c
@@ -12287,23 +12287,45 @@ void test_CustomInbox(void)
         nats_clearLastError();
     }
 
-    test("Good prefix: ");
-    s = natsOptions_SetCustomInboxPrefix(opts, "my.prefix");
-    testCond((s == NATS_OK) && (opts->inboxPfx != NULL)
-                && (strcmp(opts->inboxPfx, "my.prefix.") == 0));
-
     arg.string = "I will help you";
     arg.control= 4;
 
-    for (mode=0; mode<2; mode++)
+    for (mode=0; mode<4; mode++)
     {
-        test("Set old request style: ");
-        s = natsOptions_UseOldRequestStyle(opts, true);
-        testCond(s == NATS_OK);
+        const char  *smallPrefix = "prefix.small";
+        const char  *bigPrefix   = "prefix.that.is.very.very.very.very.very.very.big.to.make.sure.that.we.do.proper.memory.allocation";
+        const char  *prefix      = (mode < 2 ? smallPrefix : bigPrefix);
+
+        if (mode < 2)
+        {
+            test("Set small prefix: ");
+        }
+        else
+        {
+            test("Set big prefix: ");
+        }
+        s = natsOptions_SetCustomInboxPrefix(opts, prefix);
+        testCond((s == NATS_OK) && (opts->inboxPfx != NULL)
+                    && (strstr(opts->inboxPfx, prefix) == opts->inboxPfx)
+                    && (strlen(opts->inboxPfx) == strlen(prefix) + 1)
+                    && (opts->inboxPfx[strlen(opts->inboxPfx)-1] == '.'));
+
+        if (mode % 2 == 0)
+        {
+            test("Set old request style: ");
+            s = natsOptions_UseOldRequestStyle(opts, true);
+            testCond(s == NATS_OK);
+        }
+        else
+        {
+            test("Use new request style: ");
+            s = natsOptions_UseOldRequestStyle(opts, false);
+            testCond(s == NATS_OK);
+        }
 
         test("Connect and setup sub: ");
         s = natsConnection_Connect(&nc, opts);
-        IFOK(s, natsConnection_SubscribeSync(&sub1, nc, "my.prefix.>"));
+        IFOK(s, natsConnection_SubscribeSync(&sub1, nc, "prefix.>"));
         IFOK(s, natsConnection_Subscribe(&sub2, nc, "foo", _recvTestString, (void*) &arg));
         testCond(s == NATS_OK);
 
@@ -12316,7 +12338,7 @@ void test_CustomInbox(void)
         test("Check custom inbox: ");
         s = natsSubscription_NextMsg(&msg, sub1, 500);
         testCond((s == NATS_OK) && (msg != NULL)
-                    && (strstr(natsMsg_GetSubject(msg), "my.prefix.") == natsMsg_GetSubject(msg)));
+                    && (strstr(natsMsg_GetSubject(msg), prefix) == natsMsg_GetSubject(msg)));
         natsMsg_Destroy(msg);
         msg = NULL;
 


### PR DESCRIPTION
This is to make sure that we properly allocate the inbox with a very long prefix that is larger than the stack variable.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

Resolves #884