### PR TITLE
[IMPROVED] JetStream: handling of publish async timeouts

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -3360,7 +3360,7 @@ _processUrlString(natsOptions *opts, const char *urls)
     serverUrls = (char**) NATS_CALLOC(count + 1, sizeof(char*));
     if (serverUrls == NULL)
         return NATS_NO_MEMORY;
-    
+
     if (s == NATS_OK)
     {
         urlsCopy = NATS_STRDUP(urls);


### PR DESCRIPTION
When publishing a JetStream message asynchronously but with a publish max wait, we would schedule an internal timeout message to our internal subscription to handle ack timeout, even if the message was actually already ack'ed. The handler for the ack would disregard that timeout message because it would not be found in the hash table but we optimize here by not scheduling if the message has already been handled in `_handleAsyncReply()`.

This was reported in #880

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>