### PR TITLE
[FIXED] MicroServices: Wrong marshaling of `average_processing_time`

### DIFF
--- a/src/micro.c
+++ b/src/micro.c
@@ -933,8 +933,12 @@ microService_GetStats(microServiceStats **new_stats, microService *m)
                 MICRO_CALL(err, micro_strdup((char **)&stats->Endpoints[len].QueueGroup, micro_queue_group_for_endpoint(ep)));
                 if (err == NULL)
                 {
-                    avg = (long double)ep->stats.ProcessingTimeSeconds * 1000000000.0 + (long double)ep->stats.ProcessingTimeNanoseconds;
-                    avg = avg / (long double)ep->stats.NumRequests;
+                    avg = 0.0;
+                    if (ep->stats.NumRequests >= 1)
+                    {
+                        avg = (long double)ep->stats.ProcessingTimeSeconds * 1000000000.0 + (long double)ep->stats.ProcessingTimeNanoseconds;
+                        avg = avg / (long double)ep->stats.NumRequests;
+                    }
                     stats->Endpoints[len].AverageProcessingTimeNanoseconds = (int64_t)avg;
                     len++;
                     stats->EndpointsLen = len;

--- a/src/micro_monitoring.c
+++ b/src/micro_monitoring.c
@@ -325,7 +325,7 @@ marshal_stats(natsBuffer **new_buf, microServiceStats *stats)
                 IFOK_attr("queue_group", ep->QueueGroup, ",");
             IFOK(s, nats_marshalLong(buf, false, "num_requests", ep->NumRequests));
             IFOK(s, nats_marshalLong(buf, true, "num_errors", ep->NumErrors));
-            IFOK(s, nats_marshalDuration(buf, true, "average_processing_time", ep->AverageProcessingTimeNanoseconds));
+            IFOK(s, nats_marshalLong(buf, true, "average_processing_time", ep->AverageProcessingTimeNanoseconds));
             IFOK(s, natsBuf_AppendByte(buf, ','));
             IFOK_attr("last_error", ep->LastErrorString, "");
             IFOK(s, natsBuf_AppendByte(buf, '}'));


### PR DESCRIPTION
The field was incorrectly marshaled as a string duration instead of a number (nano seconds). Also, the computation of the average time would not take into account the possibility of having zero number of requests, which would produced a NaN and an invalid number during marshal.

Added test to check statistics before any request and that the field is a proper number (not a string). Also verified that it now works well with the NATS CLI.

Resolves #890

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>