### PR TITLE
[FIXED] MicroServices: statistics error always incremented

### DIFF
--- a/src/micro_endpoint.c
+++ b/src/micro_endpoint.c
@@ -203,7 +203,8 @@ _handle_request(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void *c
     full_s = stats->ProcessingTimeNanoseconds / 1000000000;
     stats->ProcessingTimeSeconds += full_s;
     stats->ProcessingTimeNanoseconds -= full_s * 1000000000;
-    _update_last_error(ep, err);
+    if (err != NULL)
+        _update_last_error(ep, err);
     micro_unlock_endpoint(ep);
 
     microError_Destroy(err);


### PR DESCRIPTION
Handling a request that did not return an error would still lead to the number of errors to be incremented and the last error to be cleared.

Resolves #893

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>