### PR TITLE
[CHANGED] TLS: Changed `SSL_verify_cb` to `natsSSLVerifyCb`

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -729,14 +729,10 @@ _makeTLSConn(natsConnection *nc)
             }
             if (s == NATS_OK)
             {
-#ifdef NATS_WITH_EXPERIMENTAL
-                SSL_verify_cb cb = _collectSSLErr;
                 if (nc->opts->sslCtx->callback != NULL)
-                    cb = nc->opts->sslCtx->callback;
-                SSL_set_verify(ssl, SSL_VERIFY_PEER, cb);
-#else
-                SSL_set_verify(ssl, SSL_VERIFY_PEER, _collectSSLErr);
-#endif // NATS_WITH_EXPERIMENTAL
+                    SSL_set_verify(ssl, SSL_VERIFY_PEER, (SSL_verify_cb) nc->opts->sslCtx->callback);
+                else
+                    SSL_set_verify(ssl, SSL_VERIFY_PEER, _collectSSLErr);
             }
         }
     }

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -206,10 +206,7 @@ typedef struct __natsSSLCtx
     bool            skipVerify;
     char            *certFileName;
     char            *keyFileName;
-
-#ifdef NATS_WITH_EXPERIMENTAL
-    SSL_verify_cb   callback;
-#endif // NATS_WITH_EXPERIMENTAL
+    natsSSLVerifyCb callback;
 
 } natsSSLCtx;
 

--- a/src/opts.c
+++ b/src/opts.c
@@ -766,10 +766,8 @@ natsOptions_SkipServerVerification(natsOptions *opts, bool skip)
     if (s == NATS_OK)
     {
         opts->sslCtx->skipVerify = skip;
-#ifdef NATS_WITH_EXPERIMENTAL
         if (skip)
             opts->sslCtx->callback = NULL;
-#endif // NATS_WITH_EXPERIMENTAL
     }
 
     UNLOCK_OPTS(opts);
@@ -777,10 +775,8 @@ natsOptions_SkipServerVerification(natsOptions *opts, bool skip)
     return s;
 }
 
-#ifdef NATS_WITH_EXPERIMENTAL
-
 natsStatus
-natsOptions_SetSSLVerificationCallback(natsOptions *opts, SSL_verify_cb callback)
+natsOptions_SetSSLVerificationCallback(natsOptions *opts, natsSSLVerifyCb callback)
 {
     natsStatus s = NATS_OK;
 
@@ -800,8 +796,6 @@ natsOptions_SetSSLVerificationCallback(natsOptions *opts, SSL_verify_cb callback
 
     return s;
 }
-
-#endif // NATS_WITH_EXPERIMENTAL
 
 #else
 
@@ -861,16 +855,11 @@ natsOptions_SkipServerVerification(natsOptions *opts, bool skip)
     return nats_setError(NATS_ILLEGAL_STATE, "%s", NO_SSL_ERR);
 }
 
-
-#ifdef NATS_WITH_EXPERIMENTAL
-
 natsStatus
-natsOptions_SetSSLVerificationCallback(natsOptions *opts, SSL_verify_cb callback)
+natsOptions_SetSSLVerificationCallback(natsOptions *opts, natsSSLVerifyCb callback)
 {
     return nats_setError(NATS_ILLEGAL_STATE, "%s", NO_SSL_ERR);
 }
-
-#endif // NATS_WITH_EXPERIMENTAL
 
 #endif
 

--- a/test/test.c
+++ b/test/test.c
@@ -21631,8 +21631,9 @@ _logChain(STACK_OF(X509) *chain)
 }
 
 static int
-_sslVerifyCallback(int preverify_ok, X509_STORE_CTX *ctx)
+_sslVerifyCallback(int preverify_ok, void *pctx)
 {
+    X509_STORE_CTX      *ctx                = (X509_STORE_CTX*) pctx;
     X509                *cert               = X509_STORE_CTX_get_current_cert(ctx);
     SSL                 *ssl                = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
     STACK_OF(X509)      *chain              = SSL_get_peer_cert_chain(ssl);
@@ -21694,7 +21695,6 @@ _sslVerifyCallback(int preverify_ok, X509_STORE_CTX *ctx)
 
 void test_SSLVerificationCallback(void)
 {
-#ifdef NATS_WITH_EXPERIMENTAL
 #ifdef NATS_HAS_TLS
     natsStatus          s;
     natsConnection      *nc         = NULL;
@@ -21729,7 +21729,6 @@ void test_SSLVerificationCallback(void)
     test("Skipped when built with no SSL support: ");
     testCond(true);
 #endif // NATS_HAS_TLS
-#endif // NATS_WITH_EXPERIMENTAL
 }
 
 void test_SSLCiphers(void)


### PR DESCRIPTION
The callback uses a `void*` that the user should cast to a `X509_STORE_CTX*`.

This removes the `nats.h` dependency on `NATS_HAS_TLS` and openssl headers.

Programs that have a verification callback would have to modify it to change to a `void*` and do a cast, as described in the doc for the `natsSSLVerifyCb` verification callback.

I have tested that an application compiled dynamically (with 3.10.1) and code that directly uses the `X509_STORE_CTX*` would work without problems if linked to a library build with this code.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
