### PR TITLE
Fixed `SSLHandshakeTimeout` test to prevent flapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ At times we may introduce APIs that are not stable yet. To build with them, defi
 ```
 # cd ./build
 rm CMakeCache.txt
-cmake .. <build options that you may already use> -DNATS_WITH_EXPERIMENTALON
+cmake .. <build options that you may already use> -DNATS_WITH_EXPERIMENTAL=ON
 make
 ```
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -764,8 +764,9 @@ DO_HANDSHAKE:
                 if (s != NATS_SSL_ERROR)
                 {
                     s = nats_setError(NATS_SSL_ERROR,
-                                    "SSL handshake error: %s",
-                                    (nc->errStr[0] != '\0' ? nc->errStr : NATS_SSL_ERR_REASON_STRING));
+                                    "SSL handshake error: %s (ssl err=%d - errno=%d (%s))",
+                                    (nc->errStr[0] != '\0' ? nc->errStr : NATS_SSL_ERR_REASON_STRING),
+                                    sslErr, errno, strerror(errno));
                 }
             }
         }


### PR DESCRIPTION
Strengthen the test added in PR #907. Also improved the error returned during a SSL handshake failure.

Relates to #907

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>