### PR TITLE
[FIXED] SSL: Protect SSL_read/SSL_write with mutex.

### DIFF
--- a/src/natsp.h
+++ b/src/natsp.h
@@ -728,6 +728,7 @@ typedef struct __natsSockCtx
     natsDeadline            writeDeadline;
 
     SSL                     *ssl;
+    natsMutex               *sslMu;
 
     // This is true when we are using an external event loop (such as libuv).
     bool                    useEventLoop;


### PR DESCRIPTION
The NATS C Client design is to have a thread reading data from the socket and a flusher thread writing data, or simply writing from the user thread if buffer is full.

For a given connection, when SSL is configured, the connection has an OpenSSL `SSL` object, and that object was shared in these threads to perform `SSL_read` and `SSL_write`, which technically is wrong. Some thread sanitizer may report that.

This PR adds a mutex that will protect the calls to SSL_read/SSL_write and SSL_get_error when returned bytes is negative (that indicate an error).

The socket has to be non-blocking, which we now make sure it is when the connection is SSL.

Local benchmark has shown no difference between the main and this PR. Even if a performance degradation would have been observed, this is apparently the proper way to do it.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>