### PR TITLE
[FIXED] EventLoop: Handling of possible failure on initial attach

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -4367,6 +4367,12 @@ natsConnection_ProcessCloseEvent(natsSock *socket)
     *socket = NATS_SOCK_INVALID;
 }
 
+void
+natsConnection_ProcessDetachedEvent(natsConnection *nc)
+{
+    natsConn_release(nc);
+}
+
 natsStatus
 natsConnection_GetClientID(natsConnection *nc, uint64_t *cid)
 {

--- a/src/nats.h
+++ b/src/nats.h
@@ -5085,6 +5085,19 @@ natsConnection_ProcessCloseEvent(natsSock *socket);
 NATS_EXTERN void
 natsConnection_ProcessWriteEvent(natsConnection *nc);
 
+/** \brief Process a detach event when using external event loop.
+ *
+ * When a connection is closed, the library will invoke the adapter's
+ * #natsEvLoop_Detach callback. But the code in the adapter may run
+ * asynchronously. The adapter will invoke this function when the
+ * adapter has fully detached the NATS connection from the event loop,
+ * so that resources held by the library for this connection can be released.
+ *
+ * @param nc the pointer to the #natsConnection object.
+ */
+NATS_EXTERN void
+natsConnection_ProcessDetachedEvent(natsConnection *nc);
+
 /** \brief Connects to a `NATS Server` using any of the URL from the given list.
  *
  * Attempts to connect to a `NATS Server`.


### PR DESCRIPTION
On initial attach, the internals needs to be freed, but we can't call the "detach" function neither on initial nor successive attach failures.

Introduced `natsConnection_ProcessDetachedEvent` function that is invoked by the adapters when fully detached. This allows the library to release resources associated with the connection after it has been detached.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>