### PR TITLE
[FIXED] Reconnecting after _processConnInit error on first connection

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -2132,8 +2132,6 @@ _connect(natsConnection *nc)
                     _close(nc, NATS_CONN_STATUS_DISCONNECTED, false, false);
 
                     natsConn_Lock(nc);
-
-                    nc->cur = NULL;
                 }
             }
             else


### PR DESCRIPTION
This could happen if TCP connection was opened but there was a TLS error or the other party just closed connection without sending data. For example when used in kubernetes with linkerd proxy and NATS server down, the linkerd will accept the connection and close it in a few seconds.

If _processConnInit returns error during first connect attempt then _doReconnect will finish prematurely and won't try to reconnect because natsSrvPool_GetNextServer will return NULL.