### PR TITLE
Fixed `JetStreamSubscribePullAsync` to work with latest server versions

### DIFF
--- a/.github/workflows/on-push-release-extra.yml
+++ b/.github/workflows/on-push-release-extra.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        server_version: [latest, v2.10.29]
+        server_version: [latest, v2.11.10]
     uses: ./.github/workflows/build-test.yml
     name: "Other servers"
     with:


### PR DESCRIPTION
Since v2.11.11+ and v2.12.2+, the noWait request when no expiration occurs now returns 404 (not found) instead of 408 (timeout). Adjust the test.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>