### PR TITLE
[CHANGED] const correctness for kvStore_Watch, kvStore_WatchMulti and kvStore_WatchAll options

### DIFF
--- a/src/kv.c
+++ b/src/kv.c
@@ -1040,14 +1040,14 @@ kvWatcher_Destroy(kvWatcher *w)
 }
 
 natsStatus
-kvStore_Watch(kvWatcher **new_watcher, kvStore *kv, const char *key, kvWatchOptions *opts)
+kvStore_Watch(kvWatcher **new_watcher, kvStore *kv, const char *key, const kvWatchOptions *opts)
 {
     const char *subjects = { key };
     return kvStore_WatchMulti(new_watcher, kv, &subjects, 1, opts);
 }
 
 natsStatus
-kvStore_WatchMulti(kvWatcher **new_watcher, kvStore *kv, const char **keys, int numKeys, kvWatchOptions *opts)
+kvStore_WatchMulti(kvWatcher **new_watcher, kvStore *kv, const char **keys, int numKeys, const kvWatchOptions *opts)
 {
     natsStatus      s = NATS_OK;
     kvWatcher       *w = NULL;
@@ -1163,7 +1163,7 @@ kvStore_WatchMulti(kvWatcher **new_watcher, kvStore *kv, const char **keys, int 
 }
 
 natsStatus
-kvStore_WatchAll(kvWatcher **new_watcher, kvStore *kv, kvWatchOptions *opts)
+kvStore_WatchAll(kvWatcher **new_watcher, kvStore *kv, const kvWatchOptions *opts)
 {
     natsStatus s = kvStore_Watch(new_watcher, kv, ">", opts);
     return NATS_UPDATE_ERR_STACK(s);

--- a/src/nats.h
+++ b/src/nats.h
@@ -8150,7 +8150,7 @@ kvStore_PurgeDeletes(kvStore *kv, kvPurgeOptions *opts);
  * @param opts the watcher options, possibly `NULL`.
  */
 NATS_EXTERN natsStatus
-kvStore_Watch(kvWatcher **new_watcher, kvStore *kv, const char *keys, kvWatchOptions *opts);
+kvStore_Watch(kvWatcher **new_watcher, kvStore *kv, const char *keys, const kvWatchOptions *opts);
 
 /** \brief Returns a watcher for any updates to keys that match one of the
  * `keys` argument.
@@ -8174,7 +8174,7 @@ kvStore_Watch(kvWatcher **new_watcher, kvStore *kv, const char *keys, kvWatchOpt
  * @param opts the watcher options, possibly `NULL`.
  */
 NATS_EXTERN natsStatus
-kvStore_WatchMulti(kvWatcher **new_watcher, kvStore *kv, const char **keys, int numKeys, kvWatchOptions *opts);
+kvStore_WatchMulti(kvWatcher **new_watcher, kvStore *kv, const char **keys, int numKeys, const kvWatchOptions *opts);
 
 /** \brief Returns a watcher for any updates to any keys of the KeyValue store bucket.
  *
@@ -8191,7 +8191,7 @@ kvStore_WatchMulti(kvWatcher **new_watcher, kvStore *kv, const char **keys, int 
  * @param opts the watcher options, possibly `NULL`.
  */
 NATS_EXTERN natsStatus
-kvStore_WatchAll(kvWatcher **new_watcher, kvStore *kv, kvWatchOptions *opts);
+kvStore_WatchAll(kvWatcher **new_watcher, kvStore *kv, const kvWatchOptions *opts);
 
 /** \brief Returns all keys in the bucket.
  *


### PR DESCRIPTION
It seems reasonable that the options are read-only (const) parameters here.
Is that true more broadly?  I wonder.