### PR TITLE
[FIXED] ObjectStore: Wrong encoding of meta subject

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -614,7 +614,7 @@ objStoreInfo_Destroy(objStoreInfo *info)
 static natsStatus
 _encodeName(char **en, const char *name)
 {
-    natsStatus  s = nats_Base64RawURL_EncodeString((const unsigned char*) name, (int) strlen(name), en);
+    natsStatus  s = nats_Base64URL_EncodeString((const unsigned char*) name, (int) strlen(name), en);
     return NATS_UPDATE_ERR_STACK(s);
 }
 

--- a/tools/objstorefix/go.mod
+++ b/tools/objstorefix/go.mod
@@ -1,0 +1,13 @@
+module github.com/nats-io/nats.c/tools/objstorefix
+
+go 1.24.6
+
+require github.com/nats-io/nats.go v1.47.0
+
+require (
+	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/nats-io/nkeys v0.4.11 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
+	golang.org/x/crypto v0.37.0 // indirect
+	golang.org/x/sys v0.32.0 // indirect
+)

--- a/tools/objstorefix/go.sum
+++ b/tools/objstorefix/go.sum
@@ -1,0 +1,12 @@
+github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
+github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/nats-io/nats.go v1.47.0 h1:YQdADw6J/UfGUd2Oy6tn4Hq6YHxCaJrVKayxxFqYrgM=
+github.com/nats-io/nats.go v1.47.0/go.mod h1:iRWIPokVIFbVijxuMQq4y9ttaBTMe0SFdlZfMDd+33g=
+github.com/nats-io/nkeys v0.4.11 h1:q44qGV008kYd9W1b1nEBkNzvnWxtRSQ7A8BoqRrcfa0=
+github.com/nats-io/nkeys v0.4.11/go.mod h1:szDimtgmfOi9n25JpfIdGw12tZFYXqhGxjhVxsatHVE=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
+golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/tools/objstorefix/main.go
+++ b/tools/objstorefix/main.go
@@ -1,0 +1,347 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func main() {
+	var (
+		url      string
+		user     string
+		password string
+		help     bool
+	)
+
+	flag.StringVar(&url, "url", "nats://127.0.0.1:4222", "Server url")
+	flag.StringVar(&user, "user", "", "Username")
+	flag.StringVar(&password, "password", "", "Username")
+	flag.BoolVar(&help, "help", false, "Show this help")
+
+	flag.Parse()
+
+	if help {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	fmt.Println("")
+	fmt.Println("!!! WARNING !!!")
+	fmt.Println("")
+	fmt.Println("You MUST stop any application that may be accessing the object stores while")
+	fmt.Println("this tool is running. Also, it is strongly recommended to backup the object")
+	fmt.Println("store streams before proceeding. If the tool fails, it will then be possible")
+	fmt.Println("to delete the original stream(s) and restore it(them). This all can be done")
+	fmt.Println("with the `nats` CLI tool (see `stream backup` and `stream restore` commands).")
+	fmt.Println("")
+	fmt.Print("Confirm object stores are not being used and backups made? [y/N]: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	text, _ := reader.ReadString('\n')
+	text = strings.TrimSuffix(text, "\n")
+	if text != "y" && text != "Y" {
+		fmt.Println("Exiting without fixing object stores!")
+		os.Exit(1)
+	}
+
+	fmt.Println("")
+
+	var opts []nats.Option
+	if user != "" {
+		opts = append(opts, nats.UserInfo(user, password))
+	}
+	nc, err := nats.Connect(url, opts...)
+	if err != nil {
+		fmt.Printf("Unable to connect: %v\n", err)
+		os.Exit(1)
+	}
+	defer nc.Close()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		fmt.Printf("Unable to get JetStream context: %v\n", err)
+		os.Exit(1)
+	}
+
+	var (
+		fixed        int
+		ctx          = context.Background()
+		objectStores = js.ObjectStores(ctx)
+	)
+	for info := range objectStores.Status() {
+		storeName := info.Bucket()
+		fmt.Printf("Fixing object store %q\n", storeName)
+		n, err := fixStore(ctx, js, storeName)
+		if err != nil {
+			if n > 0 {
+				fmt.Printf(" => fixed %d entries, but got error: %v\n", n, err)
+			} else {
+				fmt.Printf(" => error: %v\n", err)
+			}
+			fmt.Println("")
+			os.Exit(1)
+		}
+		if n > 0 {
+			fmt.Printf(" => fixed %d entries\n", n)
+			fixed += n
+		} else {
+			fmt.Println(" => no error found!")
+		}
+		fmt.Println("")
+	}
+	fmt.Printf("\nFixed a total of %v entries!", fixed)
+}
+
+func fixStore(ctx context.Context, js jetstream.JetStream, storeName string) (int, error) {
+	streamName := fmt.Sprintf("OBJ_%s", storeName)
+	stream, err := js.Stream(ctx, streamName)
+	if err != nil {
+		return 0, fmt.Errorf("unable to get stream %q: %v", streamName, err)
+	}
+
+	badOnes, mr, err := collectMetaRecords(ctx, js, storeName)
+	if err != nil {
+		return 0, err
+	}
+	if badOnes == 0 {
+		return 0, nil
+	}
+
+	isSealed := stream.CachedInfo().Config.Sealed
+	if isSealed {
+		return fixSealedStore(ctx, js, stream, storeName, mr)
+	}
+
+	metaSubjPrexix := fmt.Sprintf("$O.%s.M.", storeName)
+
+	var fixed int
+	for _, m := range mr {
+		if !m.bad && fixed == 0 {
+			continue
+		}
+		correctSubj := metaSubjPrexix + m.enc
+		correctMsg := nats.NewMsg(correctSubj)
+		correctMsg.Header = m.msg.Headers()
+		correctMsg.Data = m.msg.Data()
+		if _, err := js.PublishMsg(ctx, correctMsg); err != nil {
+			return fixed, fmt.Errorf("unable to write into %q: %v", correctSubj, err)
+		}
+		if m.bad {
+			if err = stream.DeleteMsg(ctx, m.seq); err != nil {
+				return fixed, fmt.Errorf("unable to delete message sequence %v: %v", m.seq, err)
+			}
+			// We count as "fixed" only the ones that really had bad encoding.
+			fixed++
+		}
+	}
+	return fixed, nil
+}
+
+func fixSealedStore(ctx context.Context, js jetstream.JetStream, stream jetstream.Stream,
+	storeName string, metaRecords []*metaRec) (int, error) {
+
+	tmpStoreName := storeName + "_fix"
+	tmpStreamName := "OBJ_" + tmpStoreName
+	tmpChunksSubj := fmt.Sprintf("$O.%s.C.>", tmpStoreName)
+	tmpMetaSubj := fmt.Sprintf("$O.%s.M.>", tmpStoreName)
+
+	// Create the temporary stream. We use current config and "undo" config
+	// changes made by the server when sealing a stream.
+	cfg := stream.CachedInfo().Config
+	cfg.Sealed = false
+	cfg.DenyDelete, cfg.DenyPurge = false, false
+	cfg.AllowRollup, cfg.AllowDirect = true, true
+	cfg.Name = tmpStreamName
+	cfg.Subjects = []string{tmpChunksSubj, tmpMetaSubj}
+	_, err := js.CreateStream(ctx, cfg)
+	if err != nil {
+		return 0, fmt.Errorf("unable to create stream %q: %v", tmpStreamName, err)
+	}
+
+	// Do a first pass where we are going to transfer all chunks to the temp stream.
+	chunkPrefix := fmt.Sprintf("$O.%s.C.", storeName)
+	cons, err := stream.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{
+		FilterSubjects: []string{chunkPrefix + ">"},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("unable to create consumer for chunks: %v", err)
+	}
+	defer stream.DeleteConsumer(ctx, cons.CachedInfo().Name)
+
+	tmpChunkPrefix := fmt.Sprintf("$O.%s.C.", tmpStoreName)
+	for range cons.CachedInfo().NumPending {
+		msg, err := cons.Next()
+		if err != nil {
+			return 0, fmt.Errorf("unable to get next chunk: %v", err)
+		}
+		nuid := strings.TrimPrefix(msg.Subject(), chunkPrefix)
+		if nuid == "" {
+			return 0, fmt.Errorf("invalid original chunk subject %q", msg.Subject())
+		}
+		tmpMsg := nats.NewMsg(tmpChunkPrefix + nuid)
+		tmpMsg.Header = msg.Headers()
+		tmpMsg.Data = msg.Data()
+		if _, err := js.PublishMsg(ctx, tmpMsg); err != nil {
+			return 0, fmt.Errorf("unable to write into %q: %v", tmpMsg.Subject, err)
+		}
+	}
+
+	tmpMetaPrefix := fmt.Sprintf("$O.%s.M.", tmpStoreName)
+	var fixed int
+	for _, m := range metaRecords {
+		if !m.bad && fixed == 0 {
+			continue
+		}
+		correctSubj := tmpMetaPrefix + m.enc
+		correctMsg := nats.NewMsg(correctSubj)
+		correctMsg.Header = m.msg.Headers()
+		correctMsg.Data = m.msg.Data()
+		if _, err := js.PublishMsg(ctx, correctMsg); err != nil {
+			return 0, fmt.Errorf("unable to write into %q: %v", correctSubj, err)
+		}
+		if m.bad {
+			// We count as "fixed" only the ones that really had bad encoding.
+			fixed++
+		}
+	}
+	stream.DeleteConsumer(ctx, cons.CachedInfo().Name)
+
+	// Now we will delete the original stream
+	streamName := "OBJ_" + storeName
+	if err := js.DeleteStream(ctx, streamName); err != nil {
+		return 0, fmt.Errorf("unable to delete original stream %q: %v", streamName, err)
+	}
+	metaPrefix := fmt.Sprintf("$O.%s.M.", storeName)
+	// Recreate the original stream
+	cfg.Name = streamName
+	cfg.Subjects = []string{chunkPrefix + ">", metaPrefix + ">"}
+	if _, err := js.CreateStream(ctx, cfg); err != nil {
+		return 0, fmt.Errorf("unable to recreate stream %q: %v", streamName, err)
+	}
+	stream = nil
+	// Get a stream reference for our temporary stream
+	tmpStream, err := js.Stream(ctx, tmpStreamName)
+	if err != nil {
+		return 0, fmt.Errorf("unable to get reference for stream %q: %v", streamName, err)
+	}
+	// Copy things over
+	cons, err = tmpStream.OrderedConsumer(ctx, jetstream.OrderedConsumerConfig{
+		FilterSubjects: []string{">"},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("unable to create consumer: %v", err)
+	}
+	defer tmpStream.DeleteConsumer(ctx, cons.CachedInfo().Name)
+
+	for range cons.CachedInfo().NumPending {
+		msg, err := cons.Next()
+		if err != nil {
+			return 0, fmt.Errorf("unable to get next chunk: %v", err)
+		}
+		var subject string
+		// Start with chunk prefix
+		nuid := strings.TrimPrefix(msg.Subject(), tmpChunkPrefix)
+		if nuid != msg.Subject() {
+			subject = chunkPrefix + nuid
+		} else {
+			nuid = strings.TrimPrefix(msg.Subject(), tmpMetaPrefix)
+			if nuid != msg.Subject() {
+				subject = metaPrefix + nuid
+			} else {
+				return 0, fmt.Errorf("invalid subject %q", msg.Subject())
+			}
+		}
+		tmpMsg := nats.NewMsg(subject)
+		tmpMsg.Header = msg.Headers()
+		tmpMsg.Data = msg.Data()
+		if _, err := js.PublishMsg(ctx, tmpMsg); err != nil {
+			return 0, fmt.Errorf("unable to write into %q: %v", tmpMsg.Subject, err)
+		}
+	}
+	// Now seal the stream
+	cfg.Sealed = true
+	if _, err := js.UpdateStream(ctx, cfg); err != nil {
+		return fixed, fmt.Errorf("unable to seal stream %q: %v", streamName, err)
+	}
+	// Now delete the temporary stream.
+	if err := js.DeleteStream(ctx, tmpStreamName); err != nil {
+		return fixed, fmt.Errorf("unable to delete temporary stream %q: %v", tmpStreamName, err)
+	}
+	return fixed, nil
+}
+
+type metaRec struct {
+	msg jetstream.Msg
+	enc string
+	bad bool
+	seq uint64
+}
+
+func collectMetaRecords(ctx context.Context, js jetstream.JetStream, storeName string) (int, []*metaRec, error) {
+	streamName := fmt.Sprintf("OBJ_%s", storeName)
+	metaSubjPrexix := fmt.Sprintf("$O.%s.M.", storeName)
+	metaSubj := metaSubjPrexix + ">"
+
+	cons, err := js.OrderedConsumer(ctx, streamName, jetstream.OrderedConsumerConfig{
+		FilterSubjects: []string{metaSubj},
+	})
+	if err != nil {
+		return 0, nil, fmt.Errorf("unable to create subscription on %q: %v", metaSubj, err)
+	}
+	defer js.DeleteConsumer(ctx, streamName, cons.CachedInfo().Name)
+	ci, err := cons.Info(ctx)
+	if err != nil {
+		return 0, nil, fmt.Errorf("unable to get consumer info for %q: %v", metaSubj, err)
+	}
+
+	var metaRecords []*metaRec
+	var badOnes int
+
+	for range ci.NumPending {
+		msg, err := cons.Next()
+		if err != nil {
+			return badOnes, nil, fmt.Errorf("unable to get next message: %v", err)
+		}
+		data := map[string]any{}
+		err = json.Unmarshal(msg.Data(), &data)
+		if err != nil {
+			return badOnes, nil, fmt.Errorf("unable to parse %q: %v", msg.Data(), err)
+		}
+		namei, ok := data["name"]
+		if !ok {
+			return badOnes, nil, fmt.Errorf("field %q missing", "name")
+		}
+		if _, ok := namei.(string); !ok {
+			return badOnes, nil, fmt.Errorf("field %q is of wrong type %T", "name", namei)
+		}
+		name := namei.(string)
+		goodEncoding := base64.URLEncoding.EncodeToString([]byte(name))
+		encoding := strings.TrimPrefix(msg.Subject(), metaSubjPrexix)
+		bad := encoding != goodEncoding
+
+		r := &metaRec{
+			msg: msg,
+			enc: goodEncoding,
+			bad: bad,
+		}
+		if bad {
+			md, err := msg.Metadata()
+			if err != nil {
+				return badOnes, nil, fmt.Errorf("unable to get message metadata: %v", err)
+			}
+			r.seq = md.Sequence.Stream
+			badOnes++
+		}
+		metaRecords = append(metaRecords, r)
+	}
+	return badOnes, metaRecords, nil
+}


### PR DESCRIPTION
The library was incorrectly using base64 raw URL encoding instead
of URL encoding, missing padding. For some object names, this will
cause other client libraries to be unable to read objects written
by the C library, or the C library not being able to get meta data
from objects written by other libraries (or nats CLI).

The fix here is to use the proper encoding.

However, existing C applications may no longer be able to retrieve
objects that they previously stored.

A tool written in Golang has been added to `tools/objstorefix`.
Running this against a NATS Server will list all object stores
and check the meta data records for all of them, fixing the ones
with bad encoding, which means rewrite them with correct encoding
and delete the old ones. After the first bad meta subject is found
all others are written again to preserve the meta history order.

For sealed object stores, a temporary stream is used to copy over
all data with proper meta subjects, when that is done, the original
object store is deleted and recreated with the content of the
temporary store. Once that is done, the object store is sealed again.

Note that if the tool does not detect any bad encoding for a given
store, no change is happening (for regular or sealed stores).

```
cd tools/objstorefix
go run main.go -url "nats://<nats server host>:<port>" -user "<user>" -password "<password>"
```
(this assumes that you have Golang installed on your system).

Resolves #933

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>