### PR TITLE
Move flaky-tests job into nightly from on-push-release-extra

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -2,7 +2,7 @@ name: "Nightly"
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '37 4 * * *'
+    - cron: "37 4 * * *"
 
 permissions:
   contents: write # required by build-test to comment on coverage but not used here.
@@ -21,3 +21,4 @@ jobs:
     uses: ./.github/workflows/build-test.yml
     with:
       server_version: ${{ matrix.server_version }}
+      repeat: 3

--- a/.github/workflows/on-push-release-extra.yml
+++ b/.github/workflows/on-push-release-extra.yml
@@ -13,13 +13,6 @@ defaults:
     shell: bash --noprofile --norc -x -eo pipefail {0}
 
 jobs:
-  flakes:
-    name: "check for flaky tests"
-    uses: ./.github/workflows/build-test.yml
-    with:
-      server_version: main
-      repeat: 5
-
   server-versions:
     strategy:
       fail-fast: false
@@ -55,4 +48,3 @@ jobs:
       type: Debug
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-


### PR DESCRIPTION
Also reduced from 5 to 3 runs.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>