### PR TITLE
[ADDED] `natsConnection_GetName()` API to return connection name

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -4561,28 +4561,17 @@ natsConnection_GetClientIP(natsConnection *nc, char **ip)
     return s;
 }
 
-natsStatus
-natsConnection_GetName(natsConnection *nc, char **name)
+const char*
+natsConnection_GetName(natsConnection *nc)
 {
-    natsStatus  s   = NATS_OK;
-    char        *n  = NULL;
-
-    if ((nc == NULL) || (name == NULL))
-        return nats_setDefaultError(NATS_INVALID_ARG);
-
-    natsConn_Lock(nc);
-    if (!nats_IsStringEmpty(nc->opts->name))
+    const char *name = NULL;
+    if (nc != NULL)
     {
-        n = NATS_STRDUP(nc->opts->name);
-        if (n == NULL)
-            s = nats_setDefaultError(NATS_NO_MEMORY);
+        natsConn_Lock(nc);
+        name = nc->opts->name;
+        natsConn_Unlock(nc);
     }
-    natsConn_Unlock(nc);
-
-    if (s == NATS_OK)
-        *name = n;
-
-    return NATS_UPDATE_ERR_STACK(s);
+    return name;
 }
 
 natsStatus

--- a/src/nats.h
+++ b/src/nats.h
@@ -5442,16 +5442,16 @@ natsConnection_GetClientIP(natsConnection *nc, char **ip);
  * Returns the name of the connection set with the option #natsOptions_SetName,
  * or `NULL` if none were set.
  *
- * \note The user is responsible for freeing the memory allocated for the
- * returned connection name string.
+ * \warning The returned string is owned by the connection and MUST NOT be freed.
+ * The returned string should be copied if it is needed past the connection's
+ * lifetime.
  *
  * @see natsOptions_SetName
  *
  * @param nc the pointer to the #natsConnection object.
- * @param name the memory location where to store the connection's name string.
  */
-NATS_EXTERN natsStatus
-natsConnection_GetName(natsConnection *nc, char **name);
+NATS_EXTERN const char*
+natsConnection_GetName(natsConnection *nc);
 
 /** \brief Returns the round trip time between this client and the server.
  *

--- a/test/test.c
+++ b/test/test.c
@@ -19080,7 +19080,7 @@ void test_GetName(void)
     natsStatus          s;
     natsConnection      *nc       = NULL;
     natsOptions         *opts     = NULL;
-    char                *name     = NULL;
+    const char          *name     = NULL;
     natsPid             serverPid = NATS_INVALID_PID;
 
     serverPid = _startServer("nats://127.0.0.1:4222", NULL, true);
@@ -19092,17 +19092,10 @@ void test_GetName(void)
     testCond(s == NATS_OK);
 
     test("Get name (bad args): ");
-    s = natsConnection_GetName(NULL, NULL);
-    if (s == NATS_INVALID_ARG)
-        s = natsConnection_GetName(NULL, &name);
-    if (s == NATS_INVALID_ARG)
-        s = natsConnection_GetName(nc, NULL);
-    testCond((s == NATS_INVALID_ARG) && (name == NULL));
-    nats_clearLastError();
+    testCond(natsConnection_GetName(NULL) == NULL);
 
     test("Get name: ");
-    s = natsConnection_GetName(nc, &name);
-    testCond((s == NATS_OK) && (name == NULL));
+    testCond(natsConnection_GetName(nc) == NULL);
 
     natsConnection_Destroy(nc);
     nc = NULL;
@@ -19113,9 +19106,8 @@ void test_GetName(void)
     testCond(s == NATS_OK);
 
     test("Get name: ");
-    s = natsConnection_GetName(nc, &name);
-    testCond((s == NATS_OK) && (name != NULL) && (strcmp(name, "MyConnection") == 0));
-    free(name);
+    name = natsConnection_GetName(nc);
+    testCond((name != NULL) && (strcmp(name, "MyConnection") == 0));
 
     natsConnection_Destroy(nc);
     natsOptions_Destroy(opts);


### PR DESCRIPTION
This is a revisit of #946. This returns directly a reference to the connection's internal name without making a copy. The string is valid as long as the connection is valid (as mentioned in the documentation).

Resolves #945

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>