### PR TITLE
fix(pkg-config): handle absolute install paths in libnats.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,20 @@ endif(NATS_UPDATE_VERSION OR NATS_UPDATE_DOC)
 #------------
 # pkg-config
 if(UNIX)
+  # Handle absolute vs relative install dirs for pkg-config.
+  # GNUInstallDirs may produce absolute paths (e.g. on NixOS), in which case
+  # we must not prepend ${prefix}/.
+  if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+    set(PKGCONFIG_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+  else()
+    set(PKGCONFIG_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+  endif()
+  if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+    set(PKGCONFIG_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+  else()
+    set(PKGCONFIG_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+  endif()
+
   configure_file(
     ${PROJECT_SOURCE_DIR}/src/libnats.pc.in
     ${PROJECT_BINARY_DIR}/libnats.pc

--- a/src/libnats.pc.in
+++ b/src/libnats.pc.in
@@ -1,7 +1,7 @@
 prefix="@CMAKE_INSTALL_PREFIX@"
 exec_prefix="${prefix}"
-libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
-includedir="${prefix}/include"
+libdir="@PKGCONFIG_LIBDIR@"
+includedir="@PKGCONFIG_INCLUDEDIR@"
 
 Name: NATS & NATS Streaming - C Client library
 Description: A C client library for the NATS messaging system.


### PR DESCRIPTION
GNUInstallDirs may set CMAKE_INSTALL_LIBDIR and CMAKE_INSTALL_INCLUDEDIR to absolute paths (e.g. on NixOS), causing libnats.pc to produce broken paths like /usr/local//nix/store/.../lib. Use IS_ABSOLUTE to check whether to prepend / or use the path directly.