### PR TITLE
Fixed KeyValue test following changes in the server

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -34982,7 +34982,9 @@ void test_KeyValueKeysWithFilters(void)
     kvKeysList_Destroy(&l);
 
     test("filter: multiple overlapping filters");
-    const char **filter6 = (const char *[]){"*.a","a.*","*.a.*"};
+    // Original test with values {"*.a","a.*","*.a.*"} would fail since
+    // server PR #7810, so updating the list to this:
+    const char **filter6 = (const char *[]){"a.>","a.*","*.a.*"};
     s = kvStore_KeysWithFilters(&l, kv, filter6, 3, NULL);
     // consumer subject filters cannot overlap
     testCond((s == NATS_ERR) && (l.Keys == NULL) && (l.Count == 0));


### PR DESCRIPTION
Changes in the handling of overlapping subjects required this test to be modified.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>