### PR TITLE
[CHANGED] JetStream and core requests now share same replies sub.

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -2798,10 +2798,13 @@ _close(natsConnection *nc, natsConnStatus status, bool fromPublicClose, bool doC
     // to ensure that server has received all pending data.
     // Note that _flushTimeout will release the lock and wait
     // for PONG so this is why we do this early in that function.
+    // Note: Do not check for `nc->bw` length, because even if 0,
+    // it could be that we just wrote data into the socket and the
+    // buffer is currently empty, but we should still send the PING
+    // out to ensure data is fully flushed.
     if (fromPublicClose
             && (nc->status == NATS_CONN_STATUS_CONNECTED)
-            && nc->sockCtx.fdActive
-            && (natsBuf_Len(nc->bw) > 0))
+            && nc->sockCtx.fdActive)
     {
         _flushTimeout(nc, 500);
     }

--- a/src/conn.c
+++ b/src/conn.c
@@ -1501,7 +1501,7 @@ repliesMuxer_dispose(repliesMuxer *mux, replyInfo *reply, bool needsLock)
 //
 // No connection/JS lock should be held on entry. This function will acquire
 // the muxer lock, but if the muxer has not yet been initialized, it will
-// release that lock, and then invoke `_repliexMuxerInit` (which will acquire
+// release that lock, and then invoke `_repliesMuxerInit` (which will acquire
 // the connection and muxer lock), then reacquire the muxer lock.
 natsStatus
 repliesMuxer_add(replyInfo **newReply, repliesMuxer *mux, jsCtx *js)
@@ -2886,7 +2886,7 @@ _close(natsConnection *nc, natsConnStatus status, bool fromPublicClose, bool doC
     if (doCBs && !nc->rle && postDisconnectedCb && sockWasActive)
         natsAsyncCb_PostConnHandler(nc, ASYNC_DISCONNECTED);
 
-    // The `nc->repliesMuxer.sub` is set in `_repliexMuxerInit` under the
+    // The `nc->repliesMuxer.sub` is set in `_repliesMuxerInit` under the
     // connection's lock. We don't need the muxer lock to grab the reference
     // to the sub. Do not set the sub to `NULL` to avoid "races" between JS that
     // may be in trying to add a `replyInfo` and would then init the muxer again.

--- a/src/conn.c
+++ b/src/conn.c
@@ -1,4 +1,4 @@
-// Copyright 2015-2025 The NATS Authors
+// Copyright 2015-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -178,6 +178,37 @@ _clearServerInfo(natsServerInfo *si)
 }
 
 static void
+_replyInfoFree(replyInfo *reply)
+{
+    natsMsg_Destroy(reply->msg);
+    NATS_FREE(reply->inbox);
+    NATS_FREE(reply);
+}
+
+static void
+_repliesMuxerDestroy(repliesMuxer *mux)
+{
+    if (mux->pool != NULL)
+    {
+        int         i;
+        replyInfo   *reply;
+
+        for (i = 0; i < mux->poolSize; i++)
+        {
+            reply = mux->pool[i];
+            _replyInfoFree(reply);
+        }
+        NATS_FREE(mux->pool);
+    }
+    NATS_FREE(mux->subj);
+    natsStrHash_Destroy(mux->map);
+    natsCondition_Destroy(mux->cond);
+    natsMutex_Destroy(mux->mu);
+    // Note that `mux` points to an embedded structure of the connection.
+    // So do not free this "pointer".
+}
+
+static void
 _freeConn(natsConnection *nc)
 {
     if (nc == NULL)
@@ -200,9 +231,7 @@ _freeConn(natsConnection *nc)
         SSL_free(nc->sockCtx.ssl);
     natsMutex_Destroy(nc->sockCtx.sslMu);
     NATS_FREE(nc->el.buffer);
-    natsConn_destroyRespPool(nc);
-    natsInbox_Destroy(nc->respSub);
-    natsStrHash_Destroy(nc->respMap);
+    _repliesMuxerDestroy(&nc->repliesMux);
     natsCondition_Destroy(nc->reconnectCond);
     natsCondition_Destroy(nc->drainCond);
     natsMutex_Destroy(nc->subsMu);
@@ -226,6 +255,15 @@ natsConn_retain(natsConnection *nc)
     nc->refs++;
 
     natsConn_Unlock(nc);
+}
+
+void
+natsConn_retainLocked(natsConnection *nc)
+{
+    if (nc == NULL)
+        return;
+
+    _retain(nc);
 }
 
 void
@@ -1298,148 +1336,387 @@ _clearPendingFlushRequests(natsConnection *nc)
     nc->pongs.outgoingPings = 0;
 }
 
-// Dispose of the respInfo object.
-// The boolean `needsLock` indicates if connection lock is required or not.
-void
-natsConn_disposeRespInfo(natsConnection *nc, respInfo *resp, bool needsLock)
+// The subscription callback that receives the replies. Requests that are
+// waiting on the reply will be notified. For a JetStream reply, it will
+// be submitted to the JS context's pub ack handler thread.
+static void
+_repliesMuxerHandler(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void *closure)
 {
-    if (resp == NULL)
-        return;
+    char            *id     = NULL;
+    const char      *subj   = NULL;
+    replyInfo       *reply  = NULL;
+    bool            dmsg    = true;
+    repliesMuxer    *mux    = &nc->repliesMux;
 
-    // Destroy the message if present in the respInfo object. If it has
-    // been returned to the RequestX() calls, resp->msg will be NULL here.
-    if (resp->msg != NULL)
-    {
-        natsMsg_Destroy(resp->msg);
-        resp->msg = NULL;
-    }
-    if (!resp->pooled)
-    {
-        natsCondition_Destroy(resp->cond);
-        natsMutex_Destroy(resp->mu);
-        NATS_FREE(resp);
-    }
-    else
-    {
-        if (needsLock)
-            natsConn_Lock(nc);
+    natsMutex_Lock(mux->mu);
 
-        resp->closed = false;
-        resp->closedSts = NATS_OK;
-        resp->removed = false;
-        nc->respPool[nc->respPoolIdx++] = resp;
-
-        if (needsLock)
-            natsConn_Unlock(nc);
+    subj = natsMsg_GetSubject(msg);
+    // We look for the reply token by first checking that the message subject
+    // prefix matches the subscription's subject (without the last '*').
+    // It is possible that it does not due to subject rewrite (JetStream).
+    if (((int) strlen(subj) > mux->idOffset)
+        && (memcmp((const void*) sub->subject, (const void*) subj, strlen(sub->subject) - 1) == 0))
+    {
+        id = (char*) (subj + mux->idOffset);
+        reply = (replyInfo*) natsStrHash_Remove(mux->map, id);
     }
+    else if (natsStrHash_Count(mux->map) == 1)
+    {
+        // Only if the subject is completely different, we assume that it
+        // could be the server that has rewritten the subject and so if there
+        // is a single entry, use that.
+        void *value = NULL;
+        natsStrHash_RemoveSingle(mux->map, NULL, &value);
+        reply = (replyInfo*) value;
+    }
+    if (reply != NULL)
+    {
+        // Do not destroy the message since it is being used.
+        dmsg = false;
+        reply->msg = msg;
+        if (reply->js != NULL)
+            js_addReplyInfoToList(reply);
+        // We need to broadcast, not signal since many threads could be waiting
+        // on the same variable condition.
+        natsCondition_Broadcast(mux->cond);
+    }
+    natsMutex_Unlock(mux->mu);
+
+    if (dmsg)
+        natsMsg_Destroy(msg);
 }
 
-// Destroy the pool of respInfo objects.
-void
-natsConn_destroyRespPool(natsConnection *nc)
+// Initialize some of the muxer's fields used for request/reply mapping.
+//
+// No connection/JS lock should be held on entry. This function will acquire
+// the connection and muxer's locks.
+static natsStatus
+_repliesMuxerInit(repliesMuxer *mux)
 {
-    int      i;
-    respInfo *info;
+    natsStatus          s       = NATS_OK;
+    natsCondition       *cond   = NULL;
+    char                *subj   = NULL;
+    natsSubscription    *sub    = NULL;
+    natsStrHash         *map    = NULL;
+    replyInfo           **pool  = NULL;
 
-    for (i=0; i<nc->respPoolSize; i++)
+    natsConn_Lock(mux->nc);
+    // Now that we are under the connection lock, to resolve possible "races"
+    // between several threads calling `natsConn_addreplyInfo()` that lead here,
+    // we need to check if the initialization was already done. We do that by
+    // checking if the `sub` pointer is set or not.
+    if (mux->sub != NULL)
     {
-        info = nc->respPool[i];
-        info->pooled = false;
-        natsConn_disposeRespInfo(nc, info, false);
+        natsConn_Unlock(mux->nc);
+        return NATS_OK;
     }
-    NATS_FREE(nc->respPool);
-}
-
-// Creates a new respInfo object, binds it to the request's specific
-// subject (that is set in respInbox). The respInfo object is returned.
-// Connection's lock is held on entry.
-natsStatus
-natsConn_addRespInfo(respInfo **newResp, natsConnection *nc, char *respInbox)
-{
-    respInfo    *resp  = NULL;
-    natsStatus  s      = NATS_OK;
-
-    if (nc->respPoolIdx > 0)
+    pool = NATS_CALLOC(REPLIES_INFO_POOL_MAX_SIZE, sizeof(replyInfo*));
+    if (pool == NULL)
+        s = nats_setDefaultError(NATS_NO_MEMORY);
+    if (s == NATS_OK)
+        s = natsStrHash_Create(&map, 4);
+    if (s == NATS_OK)
+        s = natsConn_newInbox(mux->nc, (natsInbox**) &subj);
+    if (s == NATS_OK)
+        s = natsCondition_Create(&cond);
+    if (s == NATS_OK)
     {
-        resp = nc->respPool[--nc->respPoolIdx];
-    }
-    else
-    {
-        resp = (respInfo *) NATS_CALLOC(1, sizeof(respInfo));
-        if (resp == NULL)
+        char *inbox = NULL;
+
+        if (nats_asprintf(&inbox, "%s.*", subj) < 0)
             s = nats_setDefaultError(NATS_NO_MEMORY);
-        if (s == NATS_OK)
-            s = natsMutex_Create(&(resp->mu));
-        if (s == NATS_OK)
-            s = natsCondition_Create(&(resp->cond));
-        if ((s == NATS_OK) && (nc->respPoolSize < RESP_INFO_POOL_MAX_SIZE))
+        else
         {
-            resp->pooled = true;
-            nc->respPoolSize++;
+            s = natsConn_subscribeNoPoolNoLock(&sub, mux->nc, inbox, _repliesMuxerHandler, NULL);
+            if (s == NATS_OK)
+                natsSubscription_SetPendingLimits(sub, -1, -1);
         }
+
+        NATS_FREE(inbox);
     }
 
     if (s == NATS_OK)
     {
-        nc->respId[nc->respIdPos] = '0' + nc->respIdVal;
-        nc->respId[nc->respIdPos + 1] = '\0';
-
-        // Build the response inbox
-        memcpy(respInbox, nc->respSub, nc->reqIdOffset);
-        respInbox[nc->reqIdOffset-1] = '.';
-        memcpy(respInbox+nc->reqIdOffset, nc->respId, nc->respIdPos + 2); // copy the '\0' of respId
-
-        nc->respIdVal++;
-        if (nc->respIdVal == 10)
-        {
-            nc->respIdVal = 0;
-            if (nc->respIdPos > 0)
-            {
-                bool shift = true;
-                int  i, j;
-
-                for (i=nc->respIdPos-1; i>=0; i--)
-                {
-                    if (nc->respId[i] != '9')
-                    {
-                        nc->respId[i]++;
-
-                        for (j=i+1; j<=nc->respIdPos-1; j++)
-                            nc->respId[j] = '0';
-
-                        shift = false;
-                        break;
-                    }
-                }
-                if (shift)
-                {
-                    nc->respId[0] = '1';
-
-                    for (i=1; i<=nc->respIdPos; i++)
-                        nc->respId[i] = '0';
-
-                    nc->respIdPos++;
-                }
-            }
-            else
-            {
-                nc->respId[0] = '1';
-                nc->respIdPos++;
-            }
-            if (nc->respIdPos == NATS_MAX_REQ_ID_LEN)
-                nc->respIdPos = 0;
-        }
-
-        s = natsStrHash_Set(nc->respMap, respInbox+nc->reqIdOffset, true,
-                            (void*) resp, NULL);
+        natsMutex_Lock(mux->mu);
+        mux->cond   = cond;
+        mux->subj   = subj;
+        mux->sub    = sub;
+        mux->map    = map;
+        mux->pool   = pool;
+        natsMutex_Unlock(mux->mu);
     }
-
-    if (s == NATS_OK)
-        *newResp = resp;
     else
-        natsConn_disposeRespInfo(nc, resp, false);
+    {
+        NATS_FREE(subj);
+        natsStrHash_Destroy(map);
+        NATS_FREE(pool);
+    }
+    natsConn_Unlock(mux->nc);
 
     return NATS_UPDATE_ERR_STACK(s);
+}
+
+// Dispose of the replyInfo object. Should not be invoked directly if the
+// `reply` is still in the muxer's map.
+//
+// The boolean `needsLock` indicates if muxer lock is required or not.
+void
+repliesMuxer_dispose(repliesMuxer *mux, replyInfo *reply, bool needsLock)
+{
+    if (reply == NULL)
+        return;
+
+    if (needsLock)
+        natsMutex_Lock(mux->mu);
+
+    if (!reply->pooled)
+    {
+        _replyInfoFree(reply);
+        if (needsLock)
+            natsMutex_Unlock(mux->mu);
+        return;
+    }
+    // Destroy the message if present in the replyInfo object. If it has
+    // been returned to the RequestX() calls, reply->msg will be NULL here.
+    if (reply->msg != NULL)
+    {
+        natsMsg_Destroy(reply->msg);
+        reply->msg = NULL;
+    }
+    NATS_FREE(reply->inbox);
+
+    reply->next = NULL;
+    reply->inbox= NULL;
+    reply->js   = NULL;
+    reply->err  = NATS_OK;
+
+    mux->pool[mux->poolIdx++] = reply;
+
+    if (needsLock)
+        natsMutex_Unlock(mux->mu);
+}
+
+// Creates a new `replyInfo` object, binds it to the request's specific
+// subject (that is set in inbox). On success, the `replyInfo` object is returned.
+//
+// No connection/JS lock should be held on entry. This function will acquire
+// the muxer lock, but if the muxer has not yet been initialized, it will
+// release that lock, and then invoke `_repliexMuxerInit` (which will acquire
+// the connection and muxer lock), then reacquire the muxer lock.
+natsStatus
+repliesMuxer_add(replyInfo **newReply, repliesMuxer *mux, jsCtx *js)
+{
+    natsStatus  s       = NATS_OK;
+    replyInfo   *reply  = NULL;
+
+    natsMutex_Lock(mux->mu);
+    // Use `sub` to see if we need to initialize the muxer or not.
+    if (mux->sub == NULL)
+    {
+        // We need to release the muxer lock because the initialization will
+        // involve creating a subscription which will need connection's lock.
+        // Check `mux->mu` description regarding its purpose and lock ordering.
+        natsMutex_Unlock(mux->mu);
+        s = _repliesMuxerInit(mux);
+        if (s != NATS_OK)
+            return NATS_UPDATE_ERR_STACK(s);
+        natsMutex_Lock(mux->mu);
+    }
+    if (mux->poolIdx > 0)
+    {
+        reply = mux->pool[--mux->poolIdx];
+    }
+    else
+    {
+        reply = (replyInfo *) NATS_CALLOC(1, sizeof(replyInfo));
+        if (reply == NULL)
+            s = nats_setDefaultError(NATS_NO_MEMORY);
+        if ((s == NATS_OK) && (mux->poolSize < REPLIES_INFO_POOL_MAX_SIZE))
+        {
+            reply->pooled = true;
+            mux->poolSize++;
+        }
+    }
+    if (s == NATS_OK)
+    {
+        reply->inbox = (char*) NATS_MALLOC(mux->nc->inboxPfxLen+NATS_MAX_REQ_SUFFIX_LEN);
+        if (reply->inbox == NULL)
+            s = nats_setDefaultError(NATS_NO_MEMORY);
+    }
+    if (s == NATS_OK)
+    {
+        // Build the response inbox
+        memcpy(reply->inbox, mux->subj, mux->idOffset);
+        reply->inbox[mux->idOffset-1] = '.';
+        snprintf(reply->inbox+mux->idOffset, NATS_MAX_REQ_ID_LEN+1, "%" PRIX64, mux->idVal++);
+
+        s = natsStrHash_Set(mux->map, reply->inbox+mux->idOffset, false, (void*) reply, NULL);
+    }
+    if (s == NATS_OK)
+        reply->js = js;
+
+    if (s == NATS_OK)
+        *newReply = reply;
+    else
+    {
+        // Ok here because it was never added to the map.
+        repliesMuxer_dispose(mux, reply, false);
+    }
+
+    natsMutex_Unlock(mux->mu);
+
+    return NATS_UPDATE_ERR_STACK(s);
+}
+
+// This will remove from the muxer's map the `replyInfo` for the given `id`.
+// A returned value of `NULL` indicates that the object was not found.
+replyInfo*
+repliesMuxer_remove(repliesMuxer *mux, char *id)
+{
+    void *p = NULL;
+
+    natsMutex_Lock(mux->mu);
+    p = natsStrHash_Remove(mux->map, id);
+    natsMutex_Unlock(mux->mu);
+    return (replyInfo*) p;
+}
+
+// This will remove from the muxer's map the `reply` if present and dispose it.
+// Should be invoked if `reply` may still be in the map.
+void
+repliesMuxer_removeAndDispose(repliesMuxer *mux, replyInfo *reply)
+{
+    natsMutex_Lock(mux->mu);
+    natsStrHash_Remove(mux->map, reply->inbox+mux->idOffset);
+    repliesMuxer_dispose(mux, reply, false);
+    natsMutex_Unlock(mux->mu);
+}
+
+// This will cause all pending requests (or JS wait for publish ack)
+// to error out with the given reason.
+//
+// If a `js` is specified, this will be limited to this specific context.
+//
+// The boolean `needsLock` indicates if muxer lock is required or not.
+void
+repliesMuxer_errorAll(repliesMuxer *mux, jsCtx *js, natsStatus reason, bool needsLock)
+{
+    if (needsLock)
+        natsMutex_Lock(mux->mu);
+
+    // This can be invoked even when a muxer has not been initialized (if
+    // there were no requests or no JS publish async). So make sure we
+    // proceed only if fully initialized (mux->sub != NULL).
+    if (mux->sub != NULL)
+    {
+        if (natsStrHash_Count(mux->map) > 0)
+        {
+            natsStrHashIter iter;
+            void            *p  = NULL;
+
+            natsStrHashIter_Init(&iter, mux->map);
+            while (natsStrHashIter_Next(&iter, NULL, &p))
+            {
+                replyInfo *reply = (replyInfo*) p;
+                if ((js == NULL) || (js == reply->js))
+                {
+                    reply->err = reason;
+                    natsStrHashIter_RemoveCurrent(&iter);
+                    if (reply->js != NULL)
+                        js_addReplyInfoToList(reply);
+                }
+            }
+            natsStrHashIter_Done(&iter);
+        }
+        // Broadcast to all threads waiting on this variable condition.
+        // Do this unconditionally (even if nothing was in the map) because
+        // in some cases we want threads waiting on this condition to wake up.
+        natsCondition_Broadcast(mux->cond);
+    }
+
+    if (needsLock)
+        natsMutex_Unlock(mux->mu);
+}
+
+void
+repliesMuxer_error(repliesMuxer *mux, char *id, natsStatus reason)
+{
+    void *p = NULL;
+
+    natsMutex_Lock(mux->mu);
+    if ((p = natsStrHash_Remove(mux->map, id)) != NULL)
+    {
+        replyInfo *reply = (replyInfo*) p;
+        reply->err = reason;
+        if (reply->js != NULL)
+            js_addReplyInfoToList(reply);
+        natsCondition_Broadcast(mux->cond);
+    }
+    natsMutex_Unlock(mux->mu);
+}
+
+natsStatus
+repliesMuxer_waitReplyReceived(natsMsg **replyMsg, repliesMuxer *mux, replyInfo *reply,
+                               natsStatus pubSts, int64_t timeout)
+{
+    natsStatus  s       = pubSts;
+    bool        remove  = true;
+
+    natsMutex_Lock(mux->mu);
+    if (s == NATS_OK)
+    {
+        int64_t target = nats_setTargetTime(timeout);
+
+        while ((s != NATS_TIMEOUT) && (reply->msg == NULL) && (reply->err == NATS_OK))
+            s = natsCondition_AbsoluteTimedWait(mux->cond, mux->mu, target);
+
+        // There could be a "race" where we get `NATS_TIMEOUT` but by the
+        // time the lock is reacquired, the notification did happen. If
+        // that is the case, consider a success and reset `s` to `NATS_OK`.
+        if ((reply->msg != NULL) || (reply->err != NATS_OK))
+            s = NATS_OK;
+
+        if (s == NATS_OK)
+        {
+            // The object `reply` has already been removed by the code that
+            // did notify us, so no need to do it again.
+            remove = false;
+
+            // We either got a message or a `err` indicating a problem
+            // (such as disconnected or connection closed).
+            if (reply->msg != NULL)
+            {
+                // For servers that support it, we may receive an empty message
+                // with a 503 status header. If that is the case, return NULL
+                // message and NATS_NO_RESPONDERS error.
+                if (natsMsg_IsNoResponders(reply->msg))
+                {
+                    s = NATS_NO_RESPONDERS;
+                }
+                else
+                {
+                    *replyMsg = reply->msg;
+                    // Clear this so that we don't destroy it when disposing.
+                    reply->msg = NULL;
+                }
+            }
+            else if (reply->err != NATS_OK)
+            {
+                // Use the closed status that we got from `resp`.
+                s = reply->err;
+            }
+        }
+    }
+    if (remove)
+    {
+        // We are here if we failed to publish, or timed-out waiting
+        // for `reply` to be ready, so remove it from the map.
+        natsStrHash_Remove(mux->map, reply->inbox+mux->idOffset);
+    }
+    // Dispose will destroy `reply->msg` if still set.
+    repliesMuxer_dispose(mux, reply, false);
+    natsMutex_Unlock(mux->mu);
+    return s;
 }
 
 natsStatus
@@ -1486,70 +1763,6 @@ natsConn_newInbox(natsConnection *nc, natsInbox **newInbox)
     if (s != NATS_OK)
         NATS_FREE(inbox);
     return s;
-}
-
-// Initialize some of the connection's fields used for request/reply mapping.
-// Connection's lock is held on entry.
-natsStatus
-natsConn_initResp(natsConnection *nc, natsMsgHandler cb)
-{
-    natsStatus s = NATS_OK;
-
-    nc->respPool = NATS_CALLOC(RESP_INFO_POOL_MAX_SIZE, sizeof(respInfo*));
-    if (nc->respPool == NULL)
-        s = nats_setDefaultError(NATS_NO_MEMORY);
-    if (s == NATS_OK)
-        s = natsStrHash_Create(&nc->respMap, 4);
-    if (s == NATS_OK)
-        s = natsConn_newInbox(nc, (natsInbox**) &nc->respSub);
-    if (s == NATS_OK)
-    {
-        char *inbox = NULL;
-
-        if (nats_asprintf(&inbox, "%s.*", nc->respSub) < 0)
-            s = nats_setDefaultError(NATS_NO_MEMORY);
-        else
-            s = natsConn_subscribeNoPoolNoLock(&(nc->respMux), nc, inbox, cb, (void*) nc);
-
-        NATS_FREE(inbox);
-    }
-    if (s != NATS_OK)
-    {
-        natsInbox_Destroy(nc->respSub);
-        nc->respSub = NULL;
-        natsStrHash_Destroy(nc->respMap);
-        nc->respMap = NULL;
-        NATS_FREE(nc->respPool);
-        nc->respPool = NULL;
-    }
-
-    return NATS_UPDATE_ERR_STACK(s);
-}
-
-// This will clear any pending Request calls.
-// Lock is assumed to be held by the caller.
-static void
-_clearPendingRequestCalls(natsConnection *nc, natsStatus reason)
-{
-    natsStrHashIter iter;
-    void            *p = NULL;
-
-    if (nc->respMap == NULL)
-        return;
-
-    natsStrHashIter_Init(&iter, nc->respMap);
-    while (natsStrHashIter_Next(&iter, NULL, &p))
-    {
-        respInfo *val = (respInfo*) p;
-        natsMutex_Lock(val->mu);
-        val->closed = true;
-        val->closedSts = reason;
-        val->removed = true;
-        natsCondition_Signal(val->cond);
-        natsMutex_Unlock(val->mu);
-        natsStrHashIter_RemoveCurrent(&iter);
-    }
-    natsStrHashIter_Done(&iter);
 }
 
 static void
@@ -2263,7 +2476,7 @@ _processOpError(natsConnection *nc, natsStatus s, bool initialConnect)
             _clearPendingFlushRequests(nc);
         // If option set, also fail pending requests.
         if ((ls == NATS_OK) && nc->opts->failRequestsOnDisconnect)
-            _clearPendingRequestCalls(nc, NATS_CONNECTION_DISCONNECTED);
+            repliesMuxer_errorAll(&nc->repliesMux, NULL, NATS_CONNECTION_DISCONNECTED, true);
 
         // Create the pending buffer to hold all write requests while we try
         // to reconnect.
@@ -2617,7 +2830,7 @@ _close(natsConnection *nc, natsConnStatus status, bool fromPublicClose, bool doC
     _clearPendingFlushRequests(nc);
 
     // Kick out any queued and blocking requests.
-    _clearPendingRequestCalls(nc, NATS_CONNECTION_CLOSED);
+    repliesMuxer_errorAll(&nc->repliesMux, NULL, NATS_CONNECTION_CLOSED, true);
 
     if (nc->ptmr != NULL)
         natsTimer_Stop(nc->ptmr);
@@ -2670,8 +2883,11 @@ _close(natsConnection *nc, natsConnStatus status, bool fromPublicClose, bool doC
     if (doCBs && !nc->rle && postDisconnectedCb && sockWasActive)
         natsAsyncCb_PostConnHandler(nc, ASYNC_DISCONNECTED);
 
-    sub = nc->respMux;
-    nc->respMux = NULL;
+    // The `nc->repliesMuxer.sub` is set in `_repliexMuxerInit` under the
+    // connection's lock. We don't need the muxer lock to grab the reference
+    // to the sub. Do not set the sub to `NULL` to avoid "races" between JS that
+    // may be in trying to add a `replyInfo` and would then init the muxer again.
+    sub = nc->repliesMux.sub;
 
     natsConn_Unlock(nc);
 
@@ -3123,6 +3339,7 @@ natsConn_subscribeImpl(natsSubscription **newSub,
         return nats_setDefaultError(NATS_DRAINING);
     }
 
+    _retain(nc);
     s = natsSub_create(&sub, nc, subj, queue, timeout, cb, cbClosure, preventUseOfLibDlvPool, jsi);
     if (s == NATS_OK)
     {
@@ -3156,16 +3373,21 @@ natsConn_subscribeImpl(natsSubscription **newSub,
     {
         *newSub = sub;
     }
-    else if (sub != NULL)
+    else
     {
-        // A delivery thread may have been started, but the subscription not
-        // added to the connection's subscription map. So this is necessary
-        // for the delivery thread to unroll.
-        natsSub_close(sub, false);
+        if (sub != NULL)
+        {
+            // A delivery thread may have been started, but the subscription not
+            // added to the connection's subscription map. So this is necessary
+            // for the delivery thread to unroll.
+            natsSub_close(sub, false);
 
-        natsConn_removeSubscription(nc, sub);
+            natsConn_removeSubscription(nc, sub);
 
-        natsSub_release(sub);
+            natsSub_release(sub);
+        }
+        // Compensate for the `_retain()` done before calling `natsSub_create`.
+        _release(nc);
     }
 
     if (lock)
@@ -3343,8 +3565,15 @@ natsConn_create(natsConnection **newConn, natsOptions *options)
         else
             nc->inboxPfx = NATS_DEFAULT_INBOX_PRE;
 
+        // nc->inboxPfx includes the separator `.` (such as `_INBOX.`) even
+        // for the user defined one.
         nc->inboxPfxLen = (int) strlen(nc->inboxPfx);
-        nc->reqIdOffset = nc->inboxPfxLen+NUID_BUFFER_LEN+1;
+    }
+    if (s == NATS_OK)
+    {
+        nc->repliesMux.idOffset = nc->inboxPfxLen+NUID_BUFFER_LEN+1;
+        nc->repliesMux.nc       = nc;
+        s = natsMutex_Create(&(nc->repliesMux.mu));
     }
 
     if (s == NATS_OK)
@@ -3713,7 +3942,7 @@ _iterateSubsAndInvokeFunc(natsStatus callerSts, natsConnection *nc, subIterFunc 
     while (natsHashIter_Next(&iter, NULL, &p))
     {
         sub = (natsSubscription*) p;
-        if (nc->drainExcludeRespMux && (sub == nc->respMux))
+        if (nc->drainExcludeRespMux && (sub == nc->repliesMux.sub))
             continue;
         ls = (f)(callerSts, nc, sub);
         s = (s == NATS_OK ? ls : s);
@@ -3862,14 +4091,14 @@ _flushAndDrain(void *closure)
                 // Now that we are under the lock, make sure that nc->respMux
                 // has not been removed by the time we get here.
                 natsMutex_Lock(nc->subsMu);
-                if (nc->respMux != NULL)
+                if (nc->repliesMux.sub != NULL)
                 {
                     subsDone = false;
                     nc->drainExcludeRespMux = false;
                     nc->drainSubCountTarget = 0;
-                    s = _enqueUnsubProto(NATS_OK, nc, nc->respMux);
+                    s = _enqueUnsubProto(NATS_OK, nc, nc->repliesMux.sub);
                     if (s == NATS_OK)
-                        s = _initSubDrain(NATS_OK, nc, nc->respMux);
+                        s = _initSubDrain(NATS_OK, nc, nc->repliesMux.sub);
                 }
                 // If respMux is NULL, `subsDone` is true, so we will exit the loop.
                 natsMutex_Unlock(nc->subsMu);
@@ -3954,7 +4183,7 @@ _drain(natsConnection *nc, int64_t timeout)
             nc->drainSubSignalOnRemove = true;
             // Exclude respMux if it exists and there are more than 1
             // subscriptions present in the list at this time.
-            nc->drainExcludeRespMux = ((nc->respMux != NULL) && (subs > 1) ? true : false);
+            nc->drainExcludeRespMux = ((nc->repliesMux.sub != NULL) && (subs > 1) ? true : false);
             // If we exclude respMux, then we will wait for the number of subscriptions
             // to fall down to 1, otherwise to 0.
             nc->drainSubCountTarget = (nc->drainExcludeRespMux ? 1 : 0);

--- a/src/conn.c
+++ b/src/conn.c
@@ -1402,7 +1402,7 @@ _repliesMuxerInit(repliesMuxer *mux)
 
     natsConn_Lock(mux->nc);
     // Now that we are under the connection lock, to resolve possible "races"
-    // between several threads calling `natsConn_addreplyInfo()` that lead here,
+    // between several threads calling `repliesMuxer_add()` that lead here,
     // we need to check if the initialization was already done. We do that by
     // checking if the `sub` pointer is set or not.
     if (mux->sub != NULL)
@@ -1448,8 +1448,9 @@ _repliesMuxerInit(repliesMuxer *mux)
     else
     {
         NATS_FREE(subj);
-        natsStrHash_Destroy(map);
         NATS_FREE(pool);
+        natsStrHash_Destroy(map);
+        natsCondition_Destroy(cond);
     }
     natsConn_Unlock(mux->nc);
 

--- a/src/conn.h
+++ b/src/conn.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The NATS Authors
+// Copyright 2015-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,7 +16,7 @@
 
 #include "natsp.h"
 
-#define RESP_INFO_POOL_MAX_SIZE (10)
+#define REPLIES_INFO_POOL_MAX_SIZE (64)
 
 #ifdef DEV_MODE
 // For type safety
@@ -39,6 +39,11 @@ natsConn_create(natsConnection **newConn, natsOptions *options);
 
 void
 natsConn_retain(natsConnection *nc);
+
+// This is to be invoked from outside conn.c but if already under the
+// connection's lock.
+void
+natsConn_retainLocked(natsConnection *nc);
 
 void
 natsConn_release(natsConnection *nc);
@@ -111,16 +116,26 @@ void
 natsConn_processAsyncINFO(natsConnection *nc, char *buf, int len);
 
 natsStatus
-natsConn_addRespInfo(respInfo **newResp, natsConnection *nc, char *respInbox);
+repliesMuxer_add(replyInfo **newReply, repliesMuxer *mux, jsCtx *js);
+
+replyInfo*
+repliesMuxer_remove(repliesMuxer *mux, char *id);
 
 void
-natsConn_disposeRespInfo(natsConnection *nc, respInfo *resp, bool needsLock);
+repliesMuxer_removeAndDispose(repliesMuxer *mux, replyInfo *reply);
+
+void
+repliesMuxer_dispose(repliesMuxer *mux, replyInfo *reply, bool needsLock);
+
+void
+repliesMuxer_errorAll(repliesMuxer *mux, jsCtx *js, natsStatus reason, bool needsLock);
+
+void
+repliesMuxer_error(repliesMuxer *mux, char *id, natsStatus reason);
 
 natsStatus
-natsConn_initResp(natsConnection *nc, natsMsgHandler cb);
-
-void
-natsConn_destroyRespPool(natsConnection *nc);
+repliesMuxer_waitReplyReceived(natsMsg **replyMsg, repliesMuxer *mux, replyInfo *reply,
+                               natsStatus pubSts, int64_t timeout);
 
 natsStatus
 natsConn_publish(natsConnection *nc, natsMsg *msg, const char *reply, bool directFlush);

--- a/src/js.c
+++ b/src/js.c
@@ -18,10 +18,8 @@
 #include "mem.h"
 #include "conn.h"
 #include "util.h"
-#include "opts.h"
 #include "sub.h"
 #include "dispatch.h"
-#include "glib/glib.h"
 
 #ifdef DEV_MODE
 // For type safety
@@ -30,12 +28,12 @@ void js_lock(jsCtx *js)   { natsMutex_Lock(js->mu);   }
 void js_unlock(jsCtx *js) { natsMutex_Unlock(js->mu); }
 
 static void _retain(jsCtx *js)  { js->refs++; }
-static void _release(jsCtx *js) { js->refs--; }
+static int  _release(jsCtx *js) { return --(js->refs); }
 
 #else
 
 #define _retain(js)         ((js)->refs++)
-#define _release(js)        ((js)->refs--)
+#define _release(js)        (--((js)->refs))
 
 #endif // DEV_MODE
 
@@ -43,11 +41,8 @@ static void _release(jsCtx *js) { js->refs--; }
 const char*      jsDefaultAPIPrefix      = "$JS.API";
 const int64_t    jsDefaultRequestWait    = 5000;
 const int64_t    jsDefaultStallWait      = 200;
-const char       *jsDigits               = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-const int        jsBase                  = 62;
 const int64_t    jsOrderedHBInterval     = NATS_SECONDS_TO_NANOS(5);
 
-#define jsReplyTokenSize    (8)
 #define jsDefaultMaxMsgs    (512 * 1024)
 
 #define jsLastConsumerSeqHdr    "Nats-Last-Consumer"
@@ -85,9 +80,7 @@ _freeContext(jsCtx *js)
     js_onReleaseCb  cb      = NULL;
 
     natsStrHash_Destroy(js->pm);
-    natsSubscription_Destroy(js->rsub);
     _destroyOptions(&(js->opts));
-    NATS_FREE(js->rpre);
     natsCondition_Destroy(js->cond);
     natsMutex_Destroy(js->mu);
     natsTimer_Destroy(js->pmtmr);
@@ -106,35 +99,33 @@ void
 js_retain(jsCtx *js)
 {
     js_lock(js);
-    js->refs++;
+    _retain(js);
     js_unlock(js);
 }
 
 void
 js_release(jsCtx *js)
 {
-    bool doFree;
+    int refs;
 
     if (js == NULL)
         return;
 
     js_lock(js);
-    doFree = (--(js->refs) == 0);
+    refs = _release(js);
     js_unlock(js);
 
-    if (doFree)
+    if (refs == 0)
         _freeContext(js);
 }
 
 static void
 js_unlockAndRelease(jsCtx *js)
 {
-    bool doFree;
-
-    doFree = (--(js->refs) == 0);
+    int refs = _release(js);
     js_unlock(js);
 
-    if (doFree)
+    if (refs == 0)
         _freeContext(js);
 }
 
@@ -151,7 +142,8 @@ _destroyPMInfo(pmInfo *pmi)
 void
 jsCtx_Destroy(jsCtx *js)
 {
-    pmInfo *pm;
+    pmInfo          *pm;
+    repliesMuxer    *mux;
 
     if (js == NULL)
         return;
@@ -163,24 +155,13 @@ jsCtx_Destroy(jsCtx *js)
         return;
     }
     js->closed = true;
-    if (js->rsub != NULL)
-    {
-        natsSubscription_Destroy(js->rsub);
-        js->rsub = NULL;
-    }
-    if ((js->pm != NULL) && natsStrHash_Count(js->pm) > 0)
-    {
-        natsStrHashIter iter;
-        void            *v = NULL;
 
-        natsStrHashIter_Init(&iter, js->pm);
-        while (natsStrHashIter_Next(&iter, NULL, &v))
-        {
-            natsMsg *msg = (natsMsg*) v;
-            natsStrHashIter_RemoveCurrent(&iter);
-            natsMsg_Destroy(msg);
-        }
-    }
+    mux = &js->nc->repliesMux;
+    natsMutex_Lock(mux->mu);
+    js->rClosed = true;
+    repliesMuxer_errorAll(mux, js, NATS_CONNECTION_CLOSED, false);
+    natsMutex_Unlock(mux->mu);
+
     while ((pm = js->pmHead) != NULL)
     {
         js->pmHead = pm->next;
@@ -300,9 +281,6 @@ natsConnection_JetStream(jsCtx **new_js, natsConnection *nc, jsOptions *opts)
     // we properly release the NATS connection.
     natsConn_retain(nc);
     js->nc = nc;
-    // This will be immutable and is computed based on the possible custom
-    // inbox prefix length (or the default "_INBOX.")
-    js->rpreLen = nc->inboxPfxLen+jsReplyTokenSize+1;
 
     s = natsMutex_Create(&(js->mu));
     if (s == NATS_OK)
@@ -615,26 +593,21 @@ _freePubAck(jsPubAck *pa)
 }
 
 static natsStatus
-_parsePubAck(natsMsg *msg, jsPubAck *pa, jsPubAckErr *pae, char *errTxt, size_t errTxtSize)
+_parsePubAck(replyInfo *reply, jsPubAck *pa, jsPubAckErr *pae, char *errTxt, size_t errTxtSize)
 {
     natsStatus  s       = NATS_OK;
     jsErrCode   jerr    = 0;
 
-    if (natsMsg_isTimeout(msg))
-    {
-        s = NATS_TIMEOUT;
-    }
-    else if (natsMsg_IsNoResponders(msg))
-    {
+    s = reply->err;
+    if ((s == NATS_OK) && natsMsg_IsNoResponders(reply->msg))
         s = NATS_NO_RESPONDERS;
-    }
-    else
+    if (s == NATS_OK)
     {
         nats_JSON           *json = NULL;
         jsApiResponse       ar;
 
         // Now unmarshal the API response and check if there was an error.
-        s = js_unmarshalResponse(&ar, &json, msg);
+        s = js_unmarshalResponse(&ar, &json, reply->msg);
         if (s == NATS_OK)
         {
             if (js_apiResponseIsErr(&ar))
@@ -679,24 +652,13 @@ _parsePubAck(natsMsg *msg, jsPubAck *pa, jsPubAckErr *pae, char *errTxt, size_t 
 }
 
 static void
-_handleAsyncReply(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void *closure)
+_handleReplyInfo(jsCtx *js, char *id, replyInfo *reply)
 {
-    const char      *subject    = natsMsg_GetSubject(msg);
-    char            *id         = NULL;
-    jsCtx           *js         = (jsCtx*) closure;
     natsMsg         *pmsg       = NULL;
     char            errTxt[256] = {'\0'};
     jsPubAckErr     pae;
     jsPubAck        pa;
     struct jsOptionsPublishAsync *opa = NULL;
-
-    if ((subject == NULL) || (int) strlen(subject) <= js->rpreLen)
-    {
-        natsMsg_Destroy(msg);
-        return;
-    }
-
-    id = (char*) (subject+js->rpreLen);
 
     js_lock(js);
 
@@ -704,7 +666,7 @@ _handleAsyncReply(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void 
     if (pmsg == NULL)
     {
         js_unlock(js);
-        natsMsg_Destroy(msg);
+        natsMsg_Destroy(reply->msg);
         return;
     }
 
@@ -717,7 +679,7 @@ _handleAsyncReply(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void 
         // If _parsePubAck returns an error, we will set the pointer ppae to
         // our stack variable 'pae', otherwise, set the pointer ppa to the
         // stack variable 'pa', which is the jsPubAck (positive ack).
-        if (_parsePubAck(msg, &pa, &pae, errTxt, sizeof(errTxt)) != NATS_OK)
+        if (_parsePubAck(reply, &pa, &pae, errTxt, sizeof(errTxt)) != NATS_OK)
             ppae = &pae;
         else
             ppa = &pa;
@@ -733,7 +695,7 @@ _handleAsyncReply(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void 
         // Set pmsg to NULL because user was responsible for destroying the message.
         pmsg = NULL;
     }
-    else if ((opa->ErrHandler != NULL) && (_parsePubAck(msg, NULL, &pae, errTxt, sizeof(errTxt)) != NATS_OK))
+    else if ((opa->ErrHandler != NULL) && (_parsePubAck(reply, NULL, &pae, errTxt, sizeof(errTxt)) != NATS_OK))
     {
         // We will invoke CB only if there is any kind of error.
         // Associate the message with the pubAckErr object.
@@ -765,99 +727,67 @@ _handleAsyncReply(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void 
     js_unlock(js);
 
     natsMsg_Destroy(pmsg);
-    natsMsg_Destroy(msg);
+    natsMsg_Destroy(reply->msg);
 }
 
 static void
-_subComplete(void *closure)
+_repliesHandler(void *closure)
 {
-    js_release((jsCtx*) closure);
-}
+    // We are guaranteed to have a valid (retained) "js" and "js->nc" for
+    // the duration of this thread.
+    jsCtx           *js    = (jsCtx*) closure;
+    repliesMuxer    *mux   = &js->nc->repliesMux;
+    replyInfo       *reply = NULL;
+    replyInfo       *list  = NULL;
+    int             offset = mux->idOffset;
 
-static natsStatus
-_newAsyncReply(char *reply, jsCtx *js)
-{
-    natsStatus  s           = NATS_OK;
-
-    // Create the internal objects if it is the first time that we are doing
-    // an async publish.
-    if (js->rsub == NULL)
+    natsMutex_Lock(mux->mu);
+    while (true)
     {
-        s = natsCondition_Create(&(js->cond));
-        IFOK(s, natsStrHash_Create(&(js->pm), 64));
-        if (s == NATS_OK)
-        {
-            js->rpre = NATS_MALLOC(js->rpreLen+1);
-            if (js->rpre == NULL)
-                s = nats_setDefaultError(NATS_NO_MEMORY);
-            else
-            {
-                char nuid[NUID_BUFFER_LEN+1];
+        while ((js->rHead == NULL) && !js->rClosed)
+            natsCondition_Wait(mux->cond, mux->mu);
 
-                s = natsNUID_Next(nuid, sizeof(nuid));
-                if (s == NATS_OK)
-                {
-                    memcpy(js->rpre, js->nc->inboxPfx, js->nc->inboxPfxLen);
-                    memcpy(js->rpre+js->nc->inboxPfxLen, nuid+((int)strlen(nuid)-jsReplyTokenSize), jsReplyTokenSize);
-                    js->rpre[js->rpreLen-1] = '.';
-                    js->rpre[js->rpreLen]   = '\0';
-                }
-            }
-        }
-        if (s == NATS_OK)
-        {
-            char *subj = NULL;
+        // End the loop only when we have drained all replies.
+        if ((js->rHead == NULL) && js->closed)
+            break;
 
-            if (nats_asprintf(&subj, "%s*", js->rpre) < 0)
-                s = nats_setDefaultError(NATS_NO_MEMORY);
-            else
-                s = natsConn_subscribeNoPool(&(js->rsub), js->nc, subj, _handleAsyncReply, (void*) js);
-            if (s == NATS_OK)
-            {
-                _retain(js);
-                natsSubscription_SetPendingLimits(js->rsub, -1, -1);
-                natsSubscription_SetOnCompleteCB(js->rsub, _subComplete, (void*) js);
-            }
-            NATS_FREE(subj);
-        }
-        if (s != NATS_OK)
+        list = js->rHead;
+        js->rHead = NULL;
+        js->rTail = NULL;
+        natsMutex_Unlock(mux->mu);
+
+        reply = list;
+        while (reply != NULL)
         {
-            // Undo the things we created so we retry again next time.
-            // It is either that or we have to always check individual
-            // objects to know if we have to create them.
-            NATS_FREE(js->rpre);
-            js->rpre = NULL;
-            natsStrHash_Destroy(js->pm);
-            js->pm = NULL;
-            natsCondition_Destroy(js->cond);
-            js->cond = NULL;
+            _handleReplyInfo(js, reply->inbox+offset, reply);
+            reply = reply->next;
+        }
+
+        natsMutex_Lock(mux->mu);
+        while (list != NULL)
+        {
+            reply = list;
+            list = list->next;
+            reply->msg = NULL;
+            repliesMuxer_dispose(mux, reply, false);
         }
     }
-    if (s == NATS_OK)
-    {
-        int64_t l;
-        int     i;
+    natsMutex_Unlock(mux->mu);
 
-        memcpy(reply, js->rpre, js->rpreLen);
-        l = nats_Rand64();
-        for (i=0; i < jsReplyTokenSize; i++)
-        {
-            reply[js->rpreLen+i] = jsDigits[l%jsBase];
-            l /= jsBase;
-        }
-        reply[js->rpreLen+jsReplyTokenSize] = '\0';
-    }
-
-    return NATS_UPDATE_ERR_STACK(s);
+    js_lock(js);
+    natsThread_Detach(js->rht);
+    natsThread_Destroy(js->rht);
+    js_unlockAndRelease(js);
 }
 
 static void
 _timeoutPubAsync(natsTimer *t, void *closure)
 {
-    jsCtx   *js = (jsCtx*) closure;
-    pmInfo  *pm = NULL;
-    int64_t now = nats_Now();
-    int64_t next= 0;
+    jsCtx           *js = (jsCtx*) closure;
+    pmInfo          *pm = NULL;
+    int64_t         now = nats_Now();
+    int64_t         next= 0;
+    repliesMuxer    *mux= &js->nc->repliesMux;
 
     js_lock(js);
     if (js->closed)
@@ -868,22 +798,8 @@ _timeoutPubAsync(natsTimer *t, void *closure)
 
     while (((pm = js->pmHead) != NULL) && (pm->deadline <= now))
     {
-        // Check if the corresponding message is still in the hashtable.
-        char *id = (pm->subject+js->rpreLen);
-        if (natsStrHash_Get(js->pm, id) != NULL)
-        {
-            natsMsg *m = NULL;
-
-            if (natsMsg_Create(&m, pm->subject, NULL, NULL, 0) == NATS_OK)
-            {
-                natsMsg_setTimeout(m);
-
-                // Best attempt, ignore NATS_SLOW_CONSUMER errors which may be returned here.
-                nats_lockSubAndDispatcher(js->rsub);
-                natsSub_enqueueUserMessage(js->rsub, m);
-                nats_unlockSubAndDispatcher(js->rsub);
-            }
-        }
+        char *id = (pm->subject+mux->idOffset);
+        repliesMuxer_error(mux, id, NATS_TIMEOUT);
         // Remove from the list.
         js->pmHead = pm->next;
         _destroyPMInfo(pm);
@@ -976,24 +892,56 @@ _trackPublishAsyncTimeout(jsCtx *js, char *subject, int64_t mw)
 }
 
 static natsStatus
-_registerPubMsg(natsConnection **nc, char *reply, jsCtx *js, natsMsg *msg, int64_t mw)
+_initRepliesHandler(jsCtx *js)
 {
-    natsStatus  s       = NATS_OK;
-    char        *id     = NULL;
-    bool        release = false;
-    int64_t     maxp    = 0;
+    natsStatus s = NATS_OK;
+
+    // Initialize fields that need to be.
+
+    if (js->cond == NULL)
+        s = natsCondition_Create(&(js->cond));
+    if ((s == NATS_OK) && (js->pm == NULL))
+        s = natsStrHash_Create(&(js->pm), 64);
+
+    // Do this one last.
+    if ((s == NATS_OK) && (js->rht == NULL))
+    {
+        _retain(js);
+        s = natsThread_Create(&(js->rht), _repliesHandler, (void*) js);
+        if (s != NATS_OK)
+            _release(js);
+    }
+    return NATS_UPDATE_ERR_STACK(s);
+}
+
+static natsStatus
+_registerPubMsg(replyInfo **newReply, jsCtx *js, natsMsg *msg, int64_t mw)
+{
+    natsStatus      s       = NATS_OK;
+    bool            release = false;
+    int64_t         maxp    = 0;
+    repliesMuxer    *mux    = &js->nc->repliesMux;
+    replyInfo       *reply  = NULL;
+
+    *newReply = NULL;
+
+    // Invoke this outside of the JS lock because it could result in the
+    // need to initialize the muxer that will then need the connection lock
+    // to create the replies wildcard subscription.
+    s = repliesMuxer_add(&reply, mux, js);
+    if (s != NATS_OK)
+        return NATS_UPDATE_ERR_STACK(s);
 
     js_lock(js);
 
     maxp = js->opts.PublishAsync.MaxPending;
-
     js->pmcount++;
-    s = _newAsyncReply(reply, js);
-    if (s == NATS_OK)
-        id = reply+js->rpreLen;
-    if ((s == NATS_OK)
-            && (maxp > 0)
-            && (js->pmcount > maxp))
+
+    // If we did not yet initialize the state, do it now.
+    if (js->rht == NULL)
+        s = _initRepliesHandler(js);
+
+    if ((s == NATS_OK) && (maxp > 0) && (js->pmcount > maxp))
     {
         int64_t target = nats_setTargetTime(js->opts.PublishAsync.StallWait);
 
@@ -1010,19 +958,39 @@ _registerPubMsg(natsConnection **nc, char *reply, jsCtx *js, natsMsg *msg, int64
         release = true;
     }
     if ((s == NATS_OK) && (mw > 0))
-        s = _trackPublishAsyncTimeout(js, reply, mw);
+        s = _trackPublishAsyncTimeout(js, reply->inbox, mw);
     if (s == NATS_OK)
-        s = natsStrHash_Set(js->pm, id, true, msg, NULL);
+        s = natsStrHash_Set(js->pm, reply->inbox+mux->idOffset, true, msg, NULL);
+
     if (s == NATS_OK)
-        *nc = js->nc;
+    {
+        *newReply = reply;
+    }
     else
+    {
         js->pmcount--;
+        repliesMuxer_removeAndDispose(mux, reply);
+    }
     if (release)
         js_unlockAndRelease(js);
     else
         js_unlock(js);
 
     return NATS_UPDATE_ERR_STACK(s);
+}
+
+// This will add the `reply` to the list.
+// The JS's connection's muxer lock is held on entry.
+void
+js_addReplyInfoToList(replyInfo *reply)
+{
+    jsCtx *js = reply->js;
+
+    if (js->rTail != NULL)
+        js->rTail->next = reply;
+    js->rTail = reply;
+    if (js->rHead == NULL)
+        js->rHead = reply;
 }
 
 natsStatus
@@ -1044,21 +1012,12 @@ js_PublishAsync(jsCtx *js, const char *subj, const void *data, int dataLen,
 natsStatus
 js_PublishMsgAsync(jsCtx *js, natsMsg **msg, jsPubOptions *opts)
 {
-    natsStatus      s   = NATS_OK;
-    natsConnection  *nc = NULL;
-    char            replyBuf[32 + jsReplyTokenSize + 1];
-    char            *reply = replyBuf;
-    int64_t         mw = 0;
+    natsStatus  s       = NATS_OK;
+    replyInfo   *reply  = NULL;
+    int64_t     mw      = 0;
 
     if ((js == NULL) || (msg == NULL) || (*msg == NULL))
         return nats_setDefaultError(NATS_INVALID_ARG);
-
-    if (js->rpreLen > 32)
-    {
-        reply = NATS_MALLOC(js->rpreLen + jsReplyTokenSize + 1);
-        if (reply == NULL)
-            return nats_setDefaultError(NATS_NO_MEMORY);
-    }
 
     if (opts != NULL)
     {
@@ -1066,14 +1025,15 @@ js_PublishMsgAsync(jsCtx *js, natsMsg **msg, jsPubOptions *opts)
         s = _setHeadersFromOptions(*msg, opts);
     }
 
-    // On success, the context will be retained.
-    IFOK(s, _registerPubMsg(&nc, reply, js, *msg, mw));
+    IFOK(s, _registerPubMsg(&reply, js, *msg, mw));
     if (s == NATS_OK)
     {
-        s = natsConn_publish(nc, *msg, (const char*) reply, false);
+        s = natsConn_publish(js->nc, *msg, reply->inbox, false);
         if (s != NATS_OK)
         {
-            char *id = reply+js->rpreLen;
+            repliesMuxer    *mux = &js->nc->repliesMux;
+            char            *id  = reply->inbox+mux->idOffset;
+            bool            rm   = false;
 
             // The message may or may not have been sent, we don't know for sure.
             // We are going to attempt to remove from the map. If we can, then
@@ -1081,12 +1041,20 @@ js_PublishMsgAsync(jsCtx *js, natsMsg **msg, jsPubOptions *opts)
             // it means that its ack has already been processed, so we consider
             // this call a success. If there was a pub ack failure, it is handled
             // with the error callback, but regardless, the library owns the message.
+            rm = (repliesMuxer_remove(mux, id) != NULL ? true : false);
             js_lock(js);
-            // If msg no longer in map, Remove() will return NULL.
-            if (natsStrHash_Remove(js->pm, id) == NULL)
-                s = NATS_OK;
-            else
+            if (rm)
+            {
+                natsStrHash_Remove(js->pm, id);
+                repliesMuxer_dispose(mux, reply, true);
                 js->pmcount--;
+            }
+            else
+            {
+                // Was not removed, so consider that the pubAck is being (or has
+                // been) delivered, so consider a success.
+                s = NATS_OK;
+            }
             js_unlock(js);
         }
     }
@@ -1096,9 +1064,6 @@ js_PublishMsgAsync(jsCtx *js, natsMsg **msg, jsPubOptions *opts)
     // they would call with natsMsg_Destroy(NULL), which is a no-op.
     if (s == NATS_OK)
         *msg = NULL;
-
-    if (reply != replyBuf)
-        NATS_FREE(reply);
 
     return NATS_UPDATE_ERR_STACK(s);
 }

--- a/src/js.c
+++ b/src/js.c
@@ -748,7 +748,7 @@ _repliesHandler(void *closure)
             natsCondition_Wait(mux->cond, mux->mu);
 
         // End the loop only when we have drained all replies.
-        if ((js->rHead == NULL) && js->closed)
+        if ((js->rHead == NULL) && js->rClosed)
             break;
 
         list = js->rHead;

--- a/src/js.c
+++ b/src/js.c
@@ -28,12 +28,12 @@ void js_lock(jsCtx *js)   { natsMutex_Lock(js->mu);   }
 void js_unlock(jsCtx *js) { natsMutex_Unlock(js->mu); }
 
 static void _retain(jsCtx *js)  { js->refs++; }
-static int  _release(jsCtx *js) { return --(js->refs); }
+static void _release(jsCtx *js) { js->refs--; }
 
 #else
 
 #define _retain(js)         ((js)->refs++)
-#define _release(js)        (--((js)->refs))
+#define _release(js)        ((js)->refs--)
 
 #endif // DEV_MODE
 
@@ -99,33 +99,35 @@ void
 js_retain(jsCtx *js)
 {
     js_lock(js);
-    _retain(js);
+    js->refs++;
     js_unlock(js);
 }
 
 void
 js_release(jsCtx *js)
 {
-    int refs;
+    bool doFree;
 
     if (js == NULL)
         return;
 
     js_lock(js);
-    refs = _release(js);
+    doFree = (--(js->refs) == 0);
     js_unlock(js);
 
-    if (refs == 0)
+    if (doFree)
         _freeContext(js);
 }
 
 static void
 js_unlockAndRelease(jsCtx *js)
 {
-    int refs = _release(js);
+    bool doFree;
+
+    doFree = (--(js->refs) == 0);
     js_unlock(js);
 
-    if (refs == 0)
+    if (doFree)
         _freeContext(js);
 }
 

--- a/src/js.h
+++ b/src/js.h
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef JS_H_
+#define JS_H_
+
 #include "natsp.h"
 #include "util.h"
 
@@ -302,3 +305,8 @@ js_maybeFetchMore(natsSubscription *sub, jsFetch *fetch);
 
 void
 js_setOnReleasedCb(jsCtx *js, js_onReleaseCb cb, void *arg);
+
+void
+js_addReplyInfoToList(replyInfo *reply);
+
+#endif /* JS_H_ */

--- a/src/msg.h
+++ b/src/msg.h
@@ -45,10 +45,6 @@
 #define natsMsg_clearNoDestroy(m)   ((m)->flags  &= ~(1 << 2))
 #define natsMsg_noDestroyFlag       (1 << 2)
 
-#define natsMsg_setTimeout(m)       ((m)->flags  |=  (1 << 3))
-#define natsMsg_isTimeout(m)        (((m)->flags &   (1 << 3)) != 0)
-#define natsMsg_clearTimeout(m)     ((m)->flags  &= ~(1 << 3))
-
 #define natsMsg_dataAndHdrLen(m)    ((m)->dataLen + (m)->hdrLen)
 
 struct __natsMsg

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2025 The NATS Authors
+// Copyright 2015-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -94,7 +94,8 @@
 #define NATS_DEFAULT_INBOX_PRE      "_INBOX."
 #define NATS_DEFAULT_INBOX_PRE_LEN  (7)
 
-#define NATS_MAX_REQ_ID_LEN (19) // to display 2^63-1 number
+#define NATS_MAX_REQ_ID_LEN     (16) // to display FFFFFFFFFFFFFFFF number
+#define NATS_MAX_REQ_SUFFIX_LEN (NUID_BUFFER_LEN + 1 + NATS_MAX_REQ_ID_LEN + 1) // for '<nuid>.<max req_id>\0'
 
 #define WAIT_FOR_READ       (0)
 #define WAIT_FOR_WRITE      (1)
@@ -371,6 +372,7 @@ struct __natsOptions
     // (regardless of reconnect policy).
     bool ignoreAuthErrAbort;
 };
+
 typedef struct __pmInfo
 {
     char                *subject;
@@ -392,15 +394,17 @@ struct __jsCtx
     natsTimer           *pmtmr;
     pmInfo              *pmHead;
     pmInfo              *pmTail;
-    natsSubscription    *rsub;
-    char                *rpre;
-    int                 rpreLen;
     int                 pacw;
     int64_t             pmcount;
     int                 stalled;
     bool                closed;
     js_onReleaseCb      onReleaseCb;
     void                *onReleaseCbArg;
+    natsThread          *rht;       // replies handler thread.
+    // Those will be protected by the connection's muxer's lock.
+    struct __replyInfo  *rHead;     // replies list head.
+    struct __replyInfo  *rTail;     // replies list tail.
+    bool                rClosed;    // context is destroyed, end processing of replies.
 };
 
 struct __jsAtomicBatchCtx
@@ -757,17 +761,42 @@ typedef struct __natsSockCtx
 
 } natsSockCtx;
 
-typedef struct __respInfo
+typedef struct __replyInfo
 {
-    natsMutex           *mu;
-    natsCondition       *cond;
+    struct __replyInfo  *next;
+    char                *inbox;
     natsMsg             *msg;
-    bool                closed;
-    natsStatus          closedSts;
-    bool                removed;
+    jsCtx               *js;
+    natsStatus          err;
     bool                pooled;
 
-} respInfo;
+} replyInfo;
+
+typedef struct __repliesMuxer
+{
+    // This lock protects access to the other fields and manipulation of the
+    // `replyInfo` object by the thread that gets notification that the response
+    // was received (or request is being failed, such as disconnect/closed).
+    // Note that `cond`, `subj`, `sub`, `map` and `pool` are set under both
+    // the connection and muxer lock, so it is safe for code to access/check
+    // them under any of those.
+    // Code invoked under this lock should not acquire the connection or JS locks.
+    natsMutex           *mu;
+    // Back-reference to the connection this muxer belongs to. This is just
+    // so that "muxer" APIs (that need internally the connection) don't require
+    // the connection pointer as parameter.
+    natsConnection      *nc;
+    natsCondition       *cond;
+    char                *subj;
+    natsSubscription    *sub;
+    natsStrHash         *map;
+    uint64_t            idVal;
+    replyInfo           **pool;
+    int                 poolSize;
+    int                 poolIdx;
+    int                 idOffset;
+
+} repliesMuxer;
 
 // Used internally for testing and allow to alter/suppress an incoming message
 typedef void (*natsMsgFilter)(natsConnection *nc, natsMsg **msg, void* closure);
@@ -841,22 +870,13 @@ struct __natsConnection
     // which will prevent user from calling Close and/or Destroy.
     bool                stanOwned;
 
-    // New Request style
-    char                respId[NATS_MAX_REQ_ID_LEN+1];
-    int                 respIdPos;
-    char                respIdVal;
-    char                *respSub;   // The wildcard subject
-    natsSubscription    *respMux;   // A single response subscription
-    natsStrHash         *respMap;   // Request map for the response msg
-    respInfo            **respPool;
-    int                 respPoolSize;
-    int                 respPoolIdx;
+    // Replies handler for combined core and js subscription.
+    repliesMuxer        repliesMux;
 
     // For inboxes. We now support custom prefixes, so we can't rely
     // on constants based on hardcoded "_INBOX." prefix.
     const char          *inboxPfx;
     int                 inboxPfxLen;
-    int                 reqIdOffset;
 
     struct
     {

--- a/src/pub.c
+++ b/src/pub.c
@@ -367,10 +367,9 @@ natsConnection_RequestMsg(natsMsg **replyMsg, natsConnection *nc,
     natsConn_retainLocked(nc);
 
     mux = &nc->repliesMux;
-    s = repliesMuxer_add(&reply, mux, NULL);
-
     natsConn_Unlock(nc);
 
+    s = repliesMuxer_add(&reply, mux, NULL);
     if (s == NATS_OK)
     {
         natsStatus ps = natsConn_publish(nc, m, (const char*) reply->inbox, true);

--- a/src/pub.c
+++ b/src/pub.c
@@ -336,71 +336,13 @@ _oldRequestMsg(natsMsg **replyMsg, natsConnection *nc,
     return NATS_UPDATE_ERR_STACK(s);
 }
 
-static void
-_respHandler(natsConnection *nc, natsSubscription *sub, natsMsg *msg, void *closure)
-{
-    char        *rt   = NULL;
-    const char  *subj = NULL;
-    respInfo    *resp = NULL;
-    bool        dmsg  = true;
-
-    natsConn_Lock(nc);
-    if (natsConn_isClosed(nc))
-    {
-        natsConn_Unlock(nc);
-        natsMsg_Destroy(msg);
-        return;
-    }
-    subj = natsMsg_GetSubject(msg);
-    // We look for the reply token by first checking that the message subject
-    // prefix matches the subscription's subject (without the last '*').
-    // It is possible that it does not due to subject rewrite (JetStream).
-    if (((int) strlen(subj) > nc->reqIdOffset)
-        && (memcmp((const void*) sub->subject, (const void*) subj, strlen(sub->subject) - 1) == 0))
-    {
-        rt = (char*) (natsMsg_GetSubject(msg) + nc->reqIdOffset);
-        resp = (respInfo*) natsStrHash_Remove(nc->respMap, rt);
-    }
-    else if (natsStrHash_Count(nc->respMap) == 1)
-    {
-        // Only if the subject is completely different, we assume that it
-        // could be the server that has rewritten the subject and so if there
-        // is a single entry, use that.
-        void *value = NULL;
-        natsStrHash_RemoveSingle(nc->respMap, NULL, &value);
-        resp = (respInfo*) value;
-    }
-    if (resp != NULL)
-    {
-        natsMutex_Lock(resp->mu);
-        // Check for the race where the requestor has already timed-out.
-        // If so, resp->removed will be true, in which case simply discard
-        // the message.
-        if (!resp->removed)
-        {
-            // Do not destroy the message since it is being used.
-            dmsg = false;
-            resp->msg = msg;
-            resp->removed = true;
-            natsCondition_Signal(resp->cond);
-        }
-        natsMutex_Unlock(resp->mu);
-    }
-    natsConn_Unlock(nc);
-
-    if (dmsg)
-        natsMsg_Destroy(msg);
-}
-
 natsStatus
 natsConnection_RequestMsg(natsMsg **replyMsg, natsConnection *nc,
                           natsMsg *m, int64_t timeout)
 {
-    natsStatus          s           = NATS_OK;
-    respInfo            *resp       = NULL;
-    bool                needsRemoval= true;
-    char                respInboxBuf[32 + NUID_BUFFER_LEN + NATS_MAX_REQ_ID_LEN + 1]; // <inbox prefix>.<nuid>.<reqId>
-    char                *respInbox = respInboxBuf;
+    natsStatus      s       = NATS_OK;
+    replyInfo       *reply  = NULL;
+    repliesMuxer    *mux    = NULL;
 
     if ((replyMsg == NULL) || (nc == NULL) || (m == NULL))
         return nats_setDefaultError(NATS_INVALID_ARG);
@@ -419,87 +361,26 @@ natsConnection_RequestMsg(natsMsg **replyMsg, natsConnection *nc,
         return _oldRequestMsg(replyMsg, nc, m, timeout);
     }
 
-    // If the custom inbox prefix is more than the reserved 32 characters
-    // in respInboxBuf, then we need to allocate...
-    if (nc->inboxPfxLen > 32)
-    {
-        respInbox = NATS_MALLOC(nc->inboxPfxLen + NUID_BUFFER_LEN + NATS_MAX_REQ_ID_LEN + 1);
-        if (respInbox == NULL)
-        {
-            natsConn_Unlock(nc);
-            return nats_setDefaultError(NATS_NO_MEMORY);
-        }
-    }
-
     // Since we are going to release the lock and connection
     // may be closed while we wait for reply, we need to retain
     // the connection object.
-    natsConn_retain(nc);
+    natsConn_retainLocked(nc);
 
-    // Setup only once (but could be more if natsConn_initResp() returns != OK)
-    if (nc->respMux == NULL)
-        s = natsConn_initResp(nc, _respHandler);
-    if (s == NATS_OK)
-        s = natsConn_addRespInfo(&resp, nc, respInbox);
+    mux = &nc->repliesMux;
+    s = repliesMuxer_add(&reply, mux, NULL);
 
     natsConn_Unlock(nc);
 
     if (s == NATS_OK)
     {
-        s = natsConn_publish(nc, m, (const char*) respInbox, true);
-        if (s == NATS_OK)
-        {
-            natsMutex_Lock(resp->mu);
-            while ((s != NATS_TIMEOUT) && (resp->msg == NULL) && !resp->closed)
-                s = natsCondition_TimedWait(resp->cond, resp->mu, timeout);
-
-            // If we have a message, deliver it.
-            if (resp->msg != NULL)
-            {
-                // In case of race where s != NATS_OK but we got the message,
-                // we need to override status and set it to OK.
-                s = NATS_OK;
-
-                // For servers that support it, we may receive an empty message
-                // with a 503 status header. If that is the case, return NULL
-                // message and NATS_NO_RESPONDERS error.
-                if (natsMsg_IsNoResponders(resp->msg))
-                {
-                    natsMsg_Destroy(resp->msg);
-                    s = NATS_NO_RESPONDERS;
-                }
-                else
-                    *replyMsg = resp->msg;
-            }
-            else
-            {
-                // Set the correct error status that we return to the user
-                if (resp->closed)
-                    s = resp->closedSts;
-                else
-                    s = NATS_TIMEOUT;
-            }
-            resp->msg = NULL;
-            needsRemoval = !resp->removed;
-            // Signal to _respHandler that we are no longer interested.
-            resp->removed = true;
-            natsMutex_Unlock(resp->mu);
-        }
+        natsStatus ps = natsConn_publish(nc, m, (const char*) reply->inbox, true);
+        // Regardless if the publish status `ps` is ok or not, invoke this
+        // function. It will take into account this status but will properly
+        // handle the `reply` in all cases.
+        s = repliesMuxer_waitReplyReceived(replyMsg, mux, reply, ps, timeout);
     }
-    // Common to success or if we failed to create the sub, send the request...
-    if (needsRemoval)
-    {
-        natsConn_Lock(nc);
-        if (nc->respMap != NULL)
-            natsStrHash_Remove(nc->respMap, respInbox+nc->reqIdOffset);
-        natsConn_Unlock(nc);
-    }
-    natsConn_disposeRespInfo(nc, resp, true);
 
     natsConn_release(nc);
-
-    if (respInbox != respInboxBuf)
-        NATS_FREE(respInbox);
 
     return NATS_UPDATE_ERR_STACK(s);
 }

--- a/src/sub.c
+++ b/src/sub.c
@@ -1,4 +1,4 @@
-// Copyright 2015-2024 The NATS Authors
+// Copyright 2015-2026 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,9 +20,7 @@
 #include "conn.h"
 #include "sub.h"
 #include "msg.h"
-#include "util.h"
 #include "js.h"
-#include "opts.h"
 #include "glib/glib.h"
 
 #ifdef DEV_MODE
@@ -359,8 +357,6 @@ natsSub_create(natsSubscription **newSub, natsConnection *nc, const char *subj,
         NATS_FREE(sub);
         return NATS_UPDATE_ERR_STACK(s);
     }
-
-    natsConn_retain(nc);
 
     sub->refs           = 1;
     sub->conn           = nc;

--- a/test/test.c
+++ b/test/test.c
@@ -8293,8 +8293,8 @@ void test_RequestPool(void)
     natsConnection      *nc = NULL;
     natsSubscription    *sub = NULL;
     natsMsg             *msg = NULL;
-    int                 numThreads = RESP_INFO_POOL_MAX_SIZE+5;
-    natsThread          *threads[RESP_INFO_POOL_MAX_SIZE+5];
+    int                 numThreads = REPLIES_INFO_POOL_MAX_SIZE+5;
+    natsThread          *threads[REPLIES_INFO_POOL_MAX_SIZE+5];
 
     pid = _startServer("nats://127.0.0.1:4222", NULL, true);
     CHECK_SERVER_STARTED(pid);
@@ -8317,11 +8317,11 @@ void test_RequestPool(void)
     // With current implementation, the pool should not
     // increase at all.
     test("Pool not growing: ");
-    for (i=0; (i<RESP_INFO_POOL_MAX_SIZE); i++)
+    for (i=0; (i<REPLIES_INFO_POOL_MAX_SIZE); i++)
         natsConnection_RequestString(&msg, nc, "foo", "test", 1);
-    natsMutex_Lock(nc->mu);
-    testCond(nc->respPoolSize == 1);
-    natsMutex_Unlock(nc->mu);
+    natsMutex_Lock(nc->repliesMux.mu);
+    testCond(nc->repliesMux.poolSize == 1);
+    natsMutex_Unlock(nc->repliesMux.mu);
 
     test("Pool max size: ");
     for (i=0; i<numThreads; i++)
@@ -8339,9 +8339,9 @@ void test_RequestPool(void)
             natsThread_Destroy(threads[i]);
         }
     }
-    natsMutex_Lock(nc->mu);
-    testCond((s == NATS_OK) && (nc->respPoolSize == RESP_INFO_POOL_MAX_SIZE));
-    natsMutex_Unlock(nc->mu);
+    natsMutex_Lock(nc->repliesMux.mu);
+    testCond((s == NATS_OK) && (nc->repliesMux.poolSize == REPLIES_INFO_POOL_MAX_SIZE));
+    natsMutex_Unlock(nc->repliesMux.mu);
 
     natsSubscription_Destroy(sub);
     natsConnection_Destroy(nc);
@@ -27536,6 +27536,10 @@ _jsPubAckErrHandler(jsCtx *js, jsPubAckErr *pae, void *closure)
         args->closed = true;
         natsCondition_Broadcast(args->c);
     }
+    else if (strcmp(natsMsg_GetData(pae->Msg), "fail4") == 0)
+    {
+        natsCondition_Broadcast(args->c);
+    }
     else if (strcmp(natsMsg_GetData(pae->Msg), "block") == 0)
     {
         while (!args->done)
@@ -27746,9 +27750,13 @@ void test_JetStreamPublishAsync(void)
 
     test("Send new failed messages which will block cb: ");
     s = js_PublishAsync(js, "foo", "fail3", 5, &opts);
-    // Send another message, which should not be delivered to CB
-    // since we will destroy context from CB on releasing CB
-    // after fail3 msg is processed.
+    // The pubAck handler will block on "fail3" and the context
+    // will be destroyed when we release it. We send another
+    // message here that will be delivered since it is likely
+    // that the library will receive it and transfer to the
+    // thread handling replies. It is possible however that
+    // we get an error "NATS_CONNECTION_CLOSED" if the context
+    // were to be destroyed before the pubAck is received.
     IFOK(s, js_PublishAsync(js, "foo", "fail4", 5, &opts));
     testCond(s == NATS_OK);
 
@@ -27768,10 +27776,11 @@ void test_JetStreamPublishAsync(void)
     natsMutex_Unlock(args.m);
     testCond(s == NATS_OK);
 
-    test("Check that last msg was not delivered to CB: ");
+    test("Check that last msg was delivered to CB: ");
     natsMutex_Lock(args.m);
-    // cb has seen: fail1, fail2 twice, fail3, so sum == 4
-    s = (args.sum == 4 ? NATS_OK: NATS_ERR);
+    // cb has seen: fail1, fail2 twice, fail3, fail4 so sum == 5
+    while ((s != NATS_TIMEOUT) && (args.sum != 5))
+        s = natsCondition_TimedWait(args.c, args.m, 2000);
     natsMutex_Unlock(args.m);
     testCond(s == NATS_OK);
 
@@ -27878,34 +27887,10 @@ void test_JetStreamPublishAsync(void)
     }
     testCond(s == NATS_OK);
 
-    test("Enqueue message with bad subject: ");
-    s = natsMsg_Create(&msg, "some.subject", NULL, "hello", 5);
-    if (s == NATS_OK)
-    {
-        natsSubscription *rsub;
-
-        js_lock(js);
-        rsub = js->rsub;
-        js_unlock(js);
-
-        _waitSubPending(rsub, 0);
-
-        natsSub_Lock(rsub);
-        rsub->ownDispatcher.queue.head = msg;
-        rsub->ownDispatcher.queue.tail = msg;
-        rsub->ownDispatcher.queue.msgs = 1;
-        rsub->ownDispatcher.queue.bytes = natsMsg_dataAndHdrLen(msg);
-        natsCondition_Signal(rsub->ownDispatcher.cond);
-        natsSub_Unlock(rsub);
-
-        // Message is owned by subscription, do not destroy it here.
-    }
-    testCond(s == NATS_OK);
-
     test("Publish async cb received non existent pid: ");
     {
         char subj[64];
-        snprintf(subj, sizeof(subj), "%sabcdefgh", js->rpre);
+        snprintf(subj, sizeof(subj), "%s.abcdefgh", js->nc->repliesMux.subj);
         s = natsConnection_Publish(nc, subj, NULL, 0);
     }
     testCond(s == NATS_OK);
@@ -40407,7 +40392,7 @@ void test_JetStreamAtomicBatchPublish(void)
     test("Publish 98 messages: ");
     for (uint64_t i = 0; (i < msg_count) && (s == NATS_OK); i++)
     {
-        char data[12];
+        char data[32];
         snprintf(data, sizeof(data), "%" PRIu64, i);
         s = natsMsg_Create(&msg, "foo", NULL, data, strlen(data));
         IFOK(s, js_BatchPublishAdd(NULL, batch_ctx, msg, NULL, NULL));
@@ -40453,7 +40438,7 @@ void test_JetStreamAtomicBatchPublish(void)
     test("Publish 98 messages: ");
     for (uint64_t i = 0; (i < msg_count) && (s == NATS_OK); i++)
     {
-        char data[12];
+        char data[32];
         snprintf(data, sizeof(data), "%" PRIu64, i);
         s = natsMsg_Create(&msg, "foo", NULL, data, strlen(data));
         IFOK(s, js_BatchPublishAdd(NULL, batch_ctx, msg, NULL, NULL));
@@ -40491,7 +40476,7 @@ void test_JetStreamAtomicBatchPublish(void)
     test("Publish 98 messages to each: ");
     for (uint64_t i = 0; (i < msg_count) && (s == NATS_OK); i++)
     {
-        char data[12];
+        char data[32];
         snprintf(data, sizeof(data), "%" PRIu64, i);
         s = natsMsg_Create(&msg, "foo", NULL, data, strlen(data));
         IFOK(s, natsMsg_Create(&msg2, "foo", NULL, data, strlen(data)));


### PR DESCRIPTION
Currently 2 muxers are created for a jetstream and nats core.
This can cause scale issues when thousands of clients are
connected to a cluster. This implements the solution brought
up while discussing https://github.com/nats-io/nats.c/pull/971

Note that the pub ack handler will now be invoked if the
connection or JS context is closed with `NATS_CONNECTION_CLOSED`
for pending pub acks, and `NATS_CONNECTION_DISCONNECTED`
if the connection breaks and the option `natsOptions_SetFailRequestsOnDisconnect()`
is set to `true`.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>
Signed-off-by: Edward Payzant <adam@synadia.com>
