### PR TITLE
[FIXED] `natsConnection_Close` was not always properly flushing

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -2585,10 +2585,13 @@ _close(natsConnection *nc, natsConnStatus status, bool fromPublicClose, bool doC
     // to ensure that server has received all pending data.
     // Note that _flushTimeout will release the lock and wait
     // for PONG so this is why we do this early in that function.
+    // Note: Do not check for `nc->bw` length, because even if 0,
+    // it could be that we just wrote data into the socket and the
+    // buffer is currently empty, but we should still send the PING
+    // out to ensure data is fully flushed.
     if (fromPublicClose
             && (nc->status == NATS_CONN_STATUS_CONNECTED)
-            && nc->sockCtx.fdActive
-            && (natsBuf_Len(nc->bw) > 0))
+            && nc->sockCtx.fdActive)
     {
         _flushTimeout(nc, 500);
     }


### PR DESCRIPTION
In PR #189, we improved the behavior of a close to perform a flush (with a timeout of 2 seconds), and added the test `ConnCloseDoesFlush`. That was 8 years ago. Then, with the addition of write deadline, in PR #268 7 years ago, the code was changed a bit and the timeout was reduced to 500ms but more importantly, we added the check of the write buffer not being empty as the condition to trigger the flush.

But recently, the `ConnCloseDoesFlush` test started to flap and it was determined that the reason was that the buffer was empty, but the lack of PING/PONG caused data to be dropped in some cases. I am not sure why it started to show up recently though.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>