### PR TITLE
Fixed Claude Code review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,11 @@
 name: Claude Code
 
-# GITHUB_TOKEN is neutered — all GitHub API access uses the App token instead.
-permissions: {}
+# GITHUB_TOKEN needs contents:read and actions:read — required by
+# claude-code-action for restoring trusted config files from the base branch.
+# All other GitHub API access uses the App token.
+permissions:
+  contents: read
+  actions: read
 
 on:
   issue_comment:
@@ -13,7 +17,12 @@ on:
 
 jobs:
   claude:
+    name: Claude Review
     uses: synadia-io/ai-workflows/.github/workflows/claude.yml@v2
+    if: contains(
+      fromJson('["OWNER","MEMBER","COLLABORATOR"]'),
+      github.event.comment.author_association || github.event.pull_request.author_association
+      )
     with:
       gh_app_id: ${{ vars.CLAUDE_GH_APP_ID }}
       checkout_mode: 'base'


### PR DESCRIPTION
Was getting error:
```
The workflow is not valid. .github/workflows/claude.yml (Line: 15, Col: 3):
Error calling workflow 'synadia-io/ai-workflows/.github/workflows/claude.yml@v2'.
The workflow is requesting 'actions: read, contents: read', but is only allowed
```

Updated claude.yml based on the NATS Server's one that I know works.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>