### PR TITLE
[FIXED] JetStream async pull could cause a double free of a message

### DIFF
--- a/src/sub.c
+++ b/src/sub.c
@@ -110,8 +110,11 @@ _freeSub(natsSubscription *sub)
     if (sub == NULL)
         return;
 
-    _freeControlMessages(sub);
     _cleanupOwnDispatcher(sub);
+    // Make sure to do this after (and not before) destroying messages in the
+    // queue in case the control messages are in there, otherwise it would cause
+    // a double free.
+    _freeControlMessages(sub);
 
     NATS_FREE(sub->subject);
     NATS_FREE(sub->queue);


### PR DESCRIPTION
The test `JetStreamSubscribePullAsync` would sometimes report this:
```
==55144== Thread 4:
==55144== Invalid read of size 8
==55144==    at 0x28721D: nats_garbageCollectorThreadf (glib_gc.c:73)
==55144==    by 0x2894DC: _threadStart (thread.c:41)
==55144==    by 0x5ED56DA: start_thread (pthread_create.c:463)
==55144==    by 0x620E71E: clone (clone.S:95)
==55144==  Address 0x68c6cd0 is 0 bytes inside a block of size 106 free'd
==55144==    at 0x4C32D3B: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==55144==    by 0x26655D: natsMsg_free (msg.c:700)
==55144==    by 0x28723F: nats_garbageCollectorThreadf (glib_gc.c:77)
==55144==    by 0x2894DC: _threadStart (thread.c:41)
==55144==    by 0x5ED56DA: start_thread (pthread_create.c:463)
==55144==    by 0x620E71E: clone (clone.S:95)
==55144==  Block was alloc'd at
==55144==    at 0x4C31B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==55144==    by 0x266700: natsMsg_createWithPadding (msg.c:798)
==55144==    by 0x2669A5: natsMsg_create (msg.c:880)
==55144==    by 0x27A2D9: _createControlMessage (sub.c:66)
==55144==    by 0x27AB9B: nats_createControlMessages (sub.c:337)
==55144==    by 0x27AED8: natsSub_create (sub.c:393)
==55144==    by 0x238C6D: natsConn_subscribeImpl (conn.c:3129)
==55144==    by 0x24778F: _subscribeMulti (js.c:2774)
==55144==    by 0x247D8E: _subscribe (js.c:2896)
==55144==    by 0x248971: js_PullSubscribeAsync (js.c:3133)
==55144==    by 0x1D2638: test_JetStreamSubscribePullAsync (test.c:31685)
==55144==    by 0x22D941: main (test.c:42824)
```

The subscription creates "control" messages that are special messages that can be queued so that the dispatcher can act on them. Those messages are created once and marked as "no destroy" so that they are not accidentally destroyed when processed in the dispatcher.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>

At the end, when the subscription is freed, the "no destroy" flag is cleared and these messages can now be destroyed. However, destroying the messages that may still be pending in the subscription's queue would cause a double free if some control messages happened to be in the queue. This is because the destroy of control messages was done before the destroying of messages still in the queue.

The order simply needed to be reversed.