### PR TITLE
Fixed auto-generated doc PR [ci skip]

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -34,7 +34,7 @@ jobs:
           echo "SOURCE_SHA=$(git log -1 --pretty=%h)" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         if: steps.update.outputs.CHANGES == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It seems that updating peter-evans/create-pull-request to "@v6" caused a problem that is fixed in later releases. So bumping to "@v8"

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>