### PR TITLE
[FIXED] KeyValue: memory leak on watcher stop

### DIFF
--- a/src/kv.c
+++ b/src/kv.c
@@ -966,6 +966,7 @@ GET_NEXT:
         {
             natsMutex_Unlock(w->mu);
             _releaseWatcher(w);
+            natsMsg_Destroy(msg);
             return NATS_ILLEGAL_STATE;
         }
         w->refs--;


### PR DESCRIPTION
The message is not destroyed if `kvWatcher_Stop` was called. The ASAN report:

```
=================================================================
==1667809==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 266 byte(s) in 1 object(s) allocated from:
    #0 0x78bc63cfd9c7 in malloc asan/asan_malloc_linux.cpp:69
    #1 0x635e5ac47cf5 in natsMsg_createWithPadding nats-io/nats.c/src/msg.c:798
    #2 0x635e5abd71f0 in _createMsg nats-io/nats.c/src/conn.c:2726
    #3 0x635e5abd6130 in natsConn_processMsg nats-io/nats.c/src/conn.c:2752
    #4 0x635e5ac59176 in natsParser_Parse nats-io/nats.c/src/parser.c:427
    #5 0x635e5abeb19a in _readLoop nats-io/nats.c/src/conn.c:2338
    #6 0x635e5ac8bdd5 in _threadStart nats-io/nats.c/src/unix/thread.c:41
    #7 0x78bc63c5ea41 in asan_thread_start asan/asan_interceptors.cpp:234
    #8 0x78bc60e9caa3 in start_thread nptl/pthread_create.c:447

SUMMARY: AddressSanitizer: 266 byte(s) leaked in 1 allocation(s).
```