### PR TITLE
[ADDED] KeyValue: options `Heartbeat` and `ResumeFromRevision`

### DIFF
--- a/src/kv.c
+++ b/src/kv.c
@@ -1110,6 +1110,8 @@ kvStore_WatchMulti(kvWatcher **new_watcher, kvStore *kv, const char **keys, int 
     IFOK(s, natsMutex_Create(&(w->mu)));
     if (s == NATS_OK)
     {
+        bool updatesOnly = false;
+
         // Use ordered consumer to deliver results
 
         jsSubOptions_Init(&so);
@@ -1121,7 +1123,10 @@ kvStore_WatchMulti(kvWatcher **new_watcher, kvStore *kv, const char **keys, int 
             if (opts->MetaOnly)
                 so.Config.HeadersOnly = true;
             if (opts->UpdatesOnly)
+            {
                 so.Config.DeliverPolicy = js_DeliverNew;
+                updatesOnly = true;
+            }
             if (opts->IgnoreDeletes)
                 w->ignoreDel = true;
             if (opts->Heartbeat > 0)
@@ -1131,6 +1136,9 @@ kvStore_WatchMulti(kvWatcher **new_watcher, kvStore *kv, const char **keys, int 
             {
                 so.Config.DeliverPolicy = js_DeliverByStartSequence;
                 so.Config.OptStartSeq   = opts->ResumeFromRevision;
+                // We are not changing the user provided option `opts->UpdateOnly`,
+                // but indicate that we are not doing updateOnly.
+                updatesOnly = false;
             }
         }
         // Need to explicitly bind to the stream here because the subject
@@ -1143,7 +1151,7 @@ kvStore_WatchMulti(kvWatcher **new_watcher, kvStore *kv, const char **keys, int 
             natsSubscription *sub = w->sub;
 
             natsSub_Lock(sub);
-            if ((opts == NULL) || !opts->UpdatesOnly)
+            if ((opts == NULL) || !updatesOnly)
             {
                 if ((sub->jsi != NULL) && (sub->jsi->pending == 0))
                 {

--- a/src/kv.c
+++ b/src/kv.c
@@ -1124,6 +1124,13 @@ kvStore_WatchMulti(kvWatcher **new_watcher, kvStore *kv, const char **keys, int 
                 so.Config.DeliverPolicy = js_DeliverNew;
             if (opts->IgnoreDeletes)
                 w->ignoreDel = true;
+            if (opts->Heartbeat > 0)
+                so.Config.Heartbeat = opts->Heartbeat;
+            if (opts->ResumeFromRevision > 0)
+            {
+                so.Config.DeliverPolicy = js_DeliverByStartSequence;
+                so.Config.OptStartSeq   = opts->ResumeFromRevision;
+            }
         }
         // Need to explicitly bind to the stream here because the subject
         // we construct may not help find the stream when using mirrors.

--- a/src/kv.c
+++ b/src/kv.c
@@ -1136,7 +1136,7 @@ kvStore_WatchMulti(kvWatcher **new_watcher, kvStore *kv, const char **keys, int 
             {
                 so.Config.DeliverPolicy = js_DeliverByStartSequence;
                 so.Config.OptStartSeq   = opts->ResumeFromRevision;
-                // We are not changing the user provided option `opts->UpdateOnly`,
+                // We are not changing the user provided option `opts->UpdatesOnly`,
                 // but indicate that we are not doing updateOnly.
                 updatesOnly = false;
             }

--- a/src/kv.c
+++ b/src/kv.c
@@ -1126,6 +1126,7 @@ kvStore_WatchMulti(kvWatcher **new_watcher, kvStore *kv, const char **keys, int 
                 w->ignoreDel = true;
             if (opts->Heartbeat > 0)
                 so.Config.Heartbeat = opts->Heartbeat;
+            // If this is set, it will override IncludeHistory and/or UpdatesOnly.
             if (opts->ResumeFromRevision > 0)
             {
                 so.Config.DeliverPolicy = js_DeliverByStartSequence;

--- a/src/nats.h
+++ b/src/nats.h
@@ -1574,7 +1574,7 @@ typedef struct kvWatchOptions
          */
         bool            MetaOnly;
 
-        /** \brief  How long to wait for some operations to complete.
+        /** \brief How long to wait for some operations to complete.
          *
          * Expressed in milliseconds.
          */

--- a/src/nats.h
+++ b/src/nats.h
@@ -1562,7 +1562,9 @@ typedef struct kvWatchOptions
 
         /** \brief Receive all history per subject, not just the last one.
          *
-         * This is actually the default behavior.
+         * If not set, only the latest value per key is delivered as the initial snapshot.
+         *
+         * \warning This option is ignored if #ResumeFromRevision is set.
          */
         bool            IncludeHistory;
 
@@ -1572,20 +1574,22 @@ typedef struct kvWatchOptions
          */
         bool            MetaOnly;
 
+        /** \brief  How long to wait for some operations to complete.
+         *
+         * Expressed in milliseconds.
+         */
+        int64_t         Timeout;
+
         /** \brief Only receive updates, no initial snapshot.
          *
          * If set to `true`, the initial snapshot will not be received. Only new
          * updates after the watcher is created will be received.
          *
          * \note If this is set, #IncludeHistory option is ignored.
+         *
+         * \warning This option is ignored if #ResumeFromRevision is set.
          */
         bool            UpdatesOnly;
-
-        /** \brief  How long to wait for some operations to complete.
-         *
-         * Expressed in milliseconds.
-         */
-        int64_t         Timeout;
 
         /** \brief Heartbeat used by the internal ordered consumer.
          *

--- a/src/nats.h
+++ b/src/nats.h
@@ -1554,11 +1554,15 @@ typedef struct kvConfig
  */
 typedef struct kvWatchOptions
 {
-        bool            IgnoreDeletes;
-        bool            IncludeHistory;
-        bool            MetaOnly;
-        int64_t         Timeout;        ///< How long to wait (in milliseconds) for some operations to complete.
-        bool            UpdatesOnly;    ///< Only receive updates, no initial snapshot.
+        bool            IgnoreDeletes;          ///< Do not receive delete markers.
+        bool            IncludeHistory;         ///< Receive all history per subject, not just the last one.
+        bool            MetaOnly;               ///< Only receive the meta data of the entry.
+        bool            UpdatesOnly;            ///< Only receive updates, no initial snapshot.
+        int64_t         Timeout;                ///< How long to wait (in milliseconds) for some operations to complete.
+        int64_t         Heartbeat;              ///< Hearbeat used by the internal ordered consumer (expressed in
+                                                ///  nanoseconds, similar to #jsConsumerConfig.Hearbeat). If not specified,
+                                                ///  a default value of 5 seconds is used.
+        uint64_t        ResumeFromRevision;     ///< If set to a positive value, resume from this specific revision.
 
 } kvWatchOptions;
 

--- a/src/nats.h
+++ b/src/nats.h
@@ -1600,6 +1600,9 @@ typedef struct kvWatchOptions
          * If this is set to a positive value, the watcher will resume from this
          * specific revision.
          *
+         * \note This is intended for watchers that have restarted watching and
+         * have maintained some state of where they were in the watch.
+         *
          * \warning #IncludeHistory and #UpdatesOnly options will be ignored.
          */
         uint64_t        ResumeFromRevision;

--- a/src/nats.h
+++ b/src/nats.h
@@ -1554,15 +1554,55 @@ typedef struct kvConfig
  */
 typedef struct kvWatchOptions
 {
-        bool            IgnoreDeletes;          ///< Do not receive delete markers.
-        bool            IncludeHistory;         ///< Receive all history per subject, not just the last one.
-        bool            MetaOnly;               ///< Only receive the meta data of the entry.
-        bool            UpdatesOnly;            ///< Only receive updates, no initial snapshot.
-        int64_t         Timeout;                ///< How long to wait (in milliseconds) for some operations to complete.
-        int64_t         Heartbeat;              ///< Hearbeat used by the internal ordered consumer (expressed in
-                                                ///  nanoseconds, similar to #jsConsumerConfig.Hearbeat). If not specified,
-                                                ///  a default value of 5 seconds is used.
-        uint64_t        ResumeFromRevision;     ///< If set to a positive value, resume from this specific revision.
+        /** \brief Do not receive delete markers.
+         *
+         * If this is set to `true`, the watcher will not receive delete markers.
+         */
+        bool            IgnoreDeletes;
+
+        /** \brief Receive all history per subject, not just the last one.
+         *
+         * This is actually the default behavior.
+         */
+        bool            IncludeHistory;
+
+        /** \brief Only receive the meta data of the entry.
+         *
+         * The entry will not contain the actual content of entry.
+         */
+        bool            MetaOnly;
+
+        /** \brief Only receive updates, no initial snapshot.
+         *
+         * If set to `true`, the initial snapshot will not be received. Only new
+         * updates after the watcher is created will be received.
+         *
+         * \note If this is set, #IncludeHistory option is ignored.
+         */
+        bool            UpdatesOnly;
+
+        /** \brief  How long to wait for some operations to complete.
+         *
+         * Expressed in milliseconds.
+         */
+        int64_t         Timeout;
+
+        /** \brief Heartbeat used by the internal ordered consumer.
+         *
+         * Expressed in nanoseconds, similar to #jsConsumerConfig.Heartbeat.
+         *
+         * \note If not specified, a default value of 5 seconds is used.
+         */
+        int64_t         Heartbeat;
+
+        /** \brief Resume from this specific revision.
+         *
+         * If this is set to a positive value, the watcher will resume from this
+         * specific revision.
+         *
+         * \warning #IncludeHistory and #UpdatesOnly options will be ignored.
+         */
+        uint64_t        ResumeFromRevision;
 
 } kvWatchOptions;
 

--- a/test/test.c
+++ b/test/test.c
@@ -34959,7 +34959,7 @@ void test_KeyValueWatch(void)
     ws = w->sub->subject;
     natsMutex_Unlock(w->mu);
     s = natsConnection_SubscribeSync(&sub, nc2, ws);
-    IFOK(s, natsSubscription_NextMsg(&msg, sub, 200))
+    IFOK(s, natsSubscription_NextMsg(&msg, sub, 200));
     if (s == NATS_OK)
     {
         int jct = 0;
@@ -34995,10 +34995,14 @@ void test_KeyValueWatch(void)
 
     kvWatchOptions_Init(&o);
     o.ResumeFromRevision = 2;
+    // The following is incompatible with the above option. There won't be an
+    // error returned, just should be ignored.
+    o.UpdatesOnly = true;
     s = kvStore_WatchAll(&w, kv, &o);
     testCond((s == NATS_OK) && (w != NULL));
 
     testCond(_expectUpdate(w, "reconnected", "true", 2));
+    testCond(_expectInitDone(w));
 
     kvWatcher_Destroy(w);
     kvStore_Destroy(kv);

--- a/test/test.c
+++ b/test/test.c
@@ -34718,11 +34718,18 @@ void test_KeyValueWatch(void)
     kvWatcher           *w  = NULL;
     kvEntry             *e  = NULL;
     natsThread          *t  = NULL;
+    natsConnection      *nc2= NULL;
+    natsOptions         *o2 = NULL;
+    jsCtx               *js2= NULL;
+    natsSubscription    *sub= NULL;
+    natsMsg             *msg= NULL;
+    char                *ws = NULL;
     int                 plc = 0;
     int                 plb = 0;
     kvConfig            kvc;
     int64_t             start;
     int                 i;
+    struct threadArg    arg;
 
     JS_SETUP(2, 6, 2);
 
@@ -34909,7 +34916,96 @@ void test_KeyValueWatch(void)
     testCond((s == NATS_TIMEOUT) && (e == NULL));
     nats_clearLastError();
     kvWatcher_Destroy(w);
+    w = NULL;
     kvStore_Destroy(kv);
+    kv = NULL;
+
+    test("Delete kv: ");
+    s = js_DeleteKeyValue(js, "WATCH");
+    testCond(s == NATS_OK);
+
+    test("Connect with reconnect cb: ");
+    s = _createDefaultThreadArgsForCbTests(&arg);
+    IFOK(s, natsOptions_Create(&o2));
+    IFOK(s, natsOptions_SetReconnectWait(o2, 100));
+    IFOK(s, natsOptions_SetReconnectJitter(o2, 0, 0));
+    IFOK(s, natsOptions_SetReconnectedCB(o2, _reconnectedCb, (void*) &arg));
+    IFOK(s, natsOptions_SetErrorHandler(o2, _dummyErrHandler, NULL));
+    IFOK(s, natsConnection_Connect(&nc2, o2));
+    IFOK(s, natsConnection_JetStream(&js2, nc2, NULL));
+    testCond(s == NATS_OK);
+
+    test("Create kv: ");
+    kvConfig_Init(&kvc);
+    kvc.Bucket = "WATCH";
+    s = js_CreateKeyValue(&kv, js2, &kvc);
+    testCond(s == NATS_OK);
+
+    test("Create watcher: ");
+    kvWatchOptions_Init(&o);
+    o.Heartbeat = NATS_MILLIS_TO_NANOS(100);
+    s = kvStore_WatchAll(&w, kv, &o);
+    testCond((s == NATS_OK) && (w != NULL));
+
+    testCond(_expectInitDone(w));
+
+    test("Put: ");
+    s = kvStore_PutString(NULL, kv, "connected", "true");
+    testCond(s == NATS_OK);
+    testCond(_expectUpdate(w, "connected", "true", 1));
+
+    test("Check heartbeats: ");
+    natsMutex_Lock(w->mu);
+    ws = w->sub->subject;
+    natsMutex_Unlock(w->mu);
+    s = natsConnection_SubscribeSync(&sub, nc2, ws);
+    IFOK(s, natsSubscription_NextMsg(&msg, sub, 200))
+    if (s == NATS_OK)
+    {
+        int jct = 0;
+        s = (natsMsg_isJSCtrl(msg, &jct) && (jct == jsCtrlHeartbeat) ? NATS_OK : NATS_ERR);
+    }
+    testCond(s == NATS_OK);
+    natsMsg_Destroy(msg);
+    msg = NULL;
+    natsSubscription_Destroy(sub);
+    sub = NULL;
+
+    test("Disconnect, wait reconnect: ");
+    _stopServer(pid);
+    pid = NATS_INVALID_PID;
+    nats_Sleep(500);
+    pid = _startServer("nats://127.0.0.1:4222", cmdLine, true);
+    CHECK_SERVER_STARTED(pid);
+    natsMutex_Lock(arg.m);
+    while ((s != NATS_TIMEOUT) && !arg.reconnected)
+        s = natsCondition_TimedWait(arg.c, arg.m, 2000);
+    natsMutex_Unlock(arg.m);
+    testCond(s == NATS_OK);
+
+    test("Put: ");
+    s = kvStore_PutString(NULL, kv, "reconnected", "true");
+    testCond(s == NATS_OK);
+    testCond(_expectUpdate(w, "reconnected", "true", 2));
+
+    kvWatcher_Destroy(w);
+    w = NULL;
+
+    test("Check resume from revision: ");
+
+    kvWatchOptions_Init(&o);
+    o.ResumeFromRevision = 2;
+    s = kvStore_WatchAll(&w, kv, &o);
+    testCond((s == NATS_OK) && (w != NULL));
+
+    testCond(_expectUpdate(w, "reconnected", "true", 2));
+
+    kvWatcher_Destroy(w);
+    kvStore_Destroy(kv);
+    jsCtx_Destroy(js2);
+    natsConnection_Destroy(nc2);
+    natsOptions_Destroy(o2);
+    _destroyDefaultThreadArgs(&arg);
 
     JS_TEARDOWN;
 }


### PR DESCRIPTION
The first allows the hearbeat configuration of the underlying JetStream ordered consumer used to receive updates. The default has always been 5 seconds, but exposing this in the watcher options allow to configure it.

The second allows a watcher to start at a specific revision. Note that previous updates are completely skipped.

Relates to #988

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>