### PR TITLE
core: destroy parser on disconnect in libuv-adapter mode

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -2469,6 +2469,9 @@ _processOpError(natsConnection *nc, natsStatus s, bool initialConnect)
             // but the actual socket close will be done from the event loop
             // adapter by calling natsConnection_ProcessCloseEvent().
             ls = _evStopPolling(nc);
+
+            // Libuv equivalent of _readLoop's per-cycle parser destroy.
+            nc->psReset = true;
         }
 
         // Fail pending flush requests.
@@ -4579,6 +4582,15 @@ natsConnection_ProcessReadEvent(natsConnection *nc)
     {
         natsConn_Unlock(nc);
         return;
+    }
+
+    // Same event-loop thread runs both this destroy and natsParser_Parse below,
+    // so the in-flight Parse on the previous socket has already returned.
+    if (nc->psReset)
+    {
+        natsParser_Destroy(nc->ps);
+        nc->ps = NULL;
+        nc->psReset = false;
     }
 
     if (nc->ps == NULL)

--- a/src/natsp.h
+++ b/src/natsp.h
@@ -866,6 +866,7 @@ struct __natsConnection
     char                errStr[256];
 
     natsParser          *ps;
+    bool                psReset; // libuv adapter: destroy nc->ps on next ProcessReadEvent
     natsTimer           *ptmr;
     int                 pout;
 


### PR DESCRIPTION
### Description

Fix an issue where protocol parser is not destroyed at disconnect when running with libuv adapter. Implements deferred destroy via a bool psReset flag on natsConnection.

### Related Issues

Fixes https://github.com/nats-io/nats.c/issues/1007