### PR TITLE
core: fire asyncErrCb on connection-fatal errors in _processOpError

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -2439,6 +2439,10 @@ _processOpError(natsConnection *nc, natsStatus s, bool initialConnect)
         }
     }
 
+    // Expose disconnect cause to asyncErrCb before reconnect clears it.
+    if ((s != NATS_OK) && (nc->opts->asyncErrCb != NULL))
+        natsAsyncCb_PostErrHandler(nc, NULL, s, NULL);
+
     // Do reconnect only if allowed and we were actually connected
     // or if we are retrying on initial failed connect.
     if (initialConnect || (nc->opts->allowReconnect && (nc->status == NATS_CONN_STATUS_CONNECTED)))


### PR DESCRIPTION
### Description

The library invokes the application-provided `asyncErrCb` for some error categories (slow consumer on a subscription, permission violation, auth failure, drain error) but silently bypasses it for connection-fatal errors handled by `processOpError`:
  - `NATS_STALE_CONNECTION` (PING/PONG keep-alive timeout)
  - `NATS_CONNECTION_CLOSED` (peer FIN/RST)
  - `NATS_IO_ERROR` (socket read/write failure)
  - `NATS_PROTOCOL_ERROR` (wire-level parse failure)
  - `NATS_NOT_YET_CONNECTED` (initial connect retry path)

The disconnect lifecycle callback (`onDisconnected`) fires, but with no status parameter and no usable error string: `doReconnect` clears `nc->err = NATS_OK` at `src/conn.c:1617` before posting `ASYNC_DISCONNECTED`, so `natsConnection_ReadLastError() ` called from inside `onDisconnected` returns `NATS_OK` with an empty buffer. The cause is effectively lost.

This forces every consumer of the libuv adapter to either accept blind disconnect events or carry an out-of-band guess based on cycle timing.

### Fix

Fire `asyncErrCb` (if registered) at the entry of `_processOpError`, while the cause is still in the `s` parameter and `nc->err` is still set. Mirrors the existing pattern used by `_processPermissionViolation`, `_processAuthError`, `_pushDrainErr` and the slow-consumer detection path in `natsConn_processMsg`, all of which call `natsAsyncCb_PostErrHandler` from inside a locked critical section.