### PR TITLE
comsock: apply socket setup after the proxy connect callback

### DIFF
--- a/src/comsock.c
+++ b/src/comsock.c
@@ -187,6 +187,24 @@ natsSock_ConnectTcp(natsSockCtx *ctx, const char *phost, int port)
         // Invoke the proxy connect callback.
         s = ctx->proxyConnectCb(&ctx->fd, host, port, ctx->proxyConnectClosure);
 
+        // The callback hands back a socket it created itself, so it has not been
+        // through the setup that the regular connect path below performs. Apply
+        // the same settings here. Leaving the socket in blocking mode is not an
+        // option: with TLS, natsSock_Read() holds ctx->sslMu across SSL_read(),
+        // so a blocking read would stall every concurrent write - and with it
+        // the flusher thread, which holds nc->mu while flushing.
+        if (s == NATS_OK)
+            s = natsSock_SetBlocking(ctx->fd, false);
+
+        if (s == NATS_OK)
+            s = natsSock_SetCommonTcpOptions(ctx->fd);
+
+        if (s != NATS_OK)
+        {
+            _closeFd(ctx->fd);
+            ctx->fd = NATS_SOCK_INVALID;
+        }
+
         // If there was a deadline, reset the deadline with whatever is left.
         if (totalTimeout > 0)
             _resetDeadline(ctx, start, totalTimeout);

--- a/test/test.c
+++ b/test/test.c
@@ -6421,6 +6421,60 @@ _proxyConnectCb(natsSock *fd, char *host, int port, void *closure)
     return s;
 }
 
+// Returns a plain blocking socket, without going through any of the natsSock_*
+// helpers. This is what a callback that performs its own connect (say an HTTP
+// CONNECT tunnel to a proxy) hands back, and the library is responsible for
+// applying the socket setup to it.
+static natsStatus
+_plainSocketProxyConnectCb(natsSock *fd, char *host, int port, void *closure)
+{
+    struct threadArg    *arg      = (struct threadArg*) closure;
+    struct addrinfo     *servinfo = NULL;
+    struct addrinfo     hints;
+    natsStatus          s         = NATS_OK;
+    natsSock            sock      = NATS_SOCK_INVALID;
+    char                sport[6];
+    int                 res;
+
+    natsMutex_Lock(arg->m);
+    arg->sum++;
+    natsMutex_Unlock(arg->m);
+
+    snprintf(sport, sizeof(sport), "%d", port);
+
+    memset(&hints, 0, sizeof(hints));
+
+    hints.ai_family   = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+
+    if ((res = getaddrinfo(host, sport, &hints, &servinfo)) != 0)
+        s = NATS_SYS_ERROR;
+
+    if (s == NATS_OK)
+    {
+        sock = socket(servinfo->ai_family, servinfo->ai_socktype,
+                      servinfo->ai_protocol);
+        if (sock == NATS_SOCK_INVALID)
+            s = NATS_SYS_ERROR;
+    }
+    if ((s == NATS_OK)
+        && (connect(sock, servinfo->ai_addr, (natsSockLen) servinfo->ai_addrlen) != 0))
+    {
+        s = NATS_SYS_ERROR;
+    }
+
+    if (servinfo != NULL)
+        freeaddrinfo(servinfo);
+
+    if (s == NATS_OK)
+        *fd = sock;
+    else if (sock != NATS_SOCK_INVALID)
+        natsSock_Close(sock);
+
+    return s;
+}
+
 void test_ProxyConnectCb(void)
 {
     natsStatus          s;
@@ -6472,6 +6526,37 @@ void test_ProxyConnectCb(void)
     s = (args.sum == 1 ? NATS_OK : NATS_ERR);
     args.sum = 0;
     natsMutex_Unlock(args.m);
+    testCond(s == NATS_OK);
+
+    natsConnection_Destroy(nc);
+    nc = NULL;
+
+    test("Set connectCb that returns a plain socket: ");
+    s = natsOptions_SetProxyConnHandler(opts, _plainSocketProxyConnectCb, (void*) &args);
+    testCond(s == NATS_OK);
+
+    test("Connect with connectCb returning a plain socket: ");
+    s = natsConnection_Connect(&nc, opts);
+    testCond(s == NATS_OK);
+
+    // The socket the callback returned had no options set. Check that the
+    // library applied its own setup to it, as it does on the regular path.
+    test("Socket setup applied by the library: ");
+    {
+        int         nodelay = 0;
+        natsSockLen len     = (natsSockLen) sizeof(nodelay);
+
+        s = NATS_OK;
+        if (getsockopt(nc->sockCtx.fd, IPPROTO_TCP, TCP_NODELAY,
+                       (char*) &nodelay, &len) != 0)
+        {
+            s = NATS_SYS_ERROR;
+        }
+        else if (nodelay == 0)
+        {
+            s = NATS_ERR;
+        }
+    }
     testCond(s == NATS_OK);
 
     natsConnection_Destroy(nc);


### PR DESCRIPTION
Fixes #1010

`natsSock_ConnectTcp()` invokes `proxyConnectCb` and returns right away, skipping the
`natsSock_SetBlocking(fd, false)` and `natsSock_SetCommonTcpOptions(fd)` calls that the regular
connect path applies a hundred lines below. The callback hands back a socket in whatever state the
application's own connect code left it in — typically blocking and without `TCP_NODELAY`.

With TLS that stalls every publish, because `_processConnInit()` deliberately keeps the socket
non-blocking when TLS is in use and so never fixes it up:

| thread | holds | waits for |
|---|---|---|
| `_readLoop` | `ctx->sslMu` — `natsSock_Read()` takes it around `SSL_read()` | `SSL_read()` parked inside a blocking `recv()` |
| `_flusher` | `nc->mu` — held across `natsConn_bufferFlush()` | `ctx->sslMu` |
| application thread | — | `nc->mu` in `natsConn_publish()` |

Every `natsConnection_Publish*()` then blocks until the server sends something on its own — in
practice until the next connection PING. Measurements from a production setup over an HTTP CONNECT
proxy are in #1010: publish durations alternating between 0.0 s and 180–240 s, startup 8 minutes
instead of 25 seconds, shutdown 480 s instead of 63 ms. With this change all of it disappears.

### Changes

- `src/comsock.c` — apply the same socket setup the regular path applies, and close the socket if
  either call fails.
- `test/test.c` — extend `test_ProxyConnectCb` with `_plainSocketProxyConnectCb`, which returns a
  plain blocking socket without using any `natsSock_*` helper, and assert via `getsockopt()` that
  `TCP_NODELAY` ended up set on `nc->sockCtx.fd`.

The existing `_proxyConnectCb` cannot catch this: it delegates straight back to
`natsSock_ConnectTcp()` on a fresh `natsSockCtx` with no callback set, so the library performs the
setup itself and the gap stays invisible. The new assertion fails without the `comsock.c` change.

### Testing

The `comsock.c` change has been running in production over an HTTP CONNECT proxy with TLS, which is
where the numbers above come from.

`ProxyConnectCb` was run locally on Windows (MSVC 19.51, `-DNATS_BUILD_WITH_TLS=OFF`,
nats-server v2.12.2) — the new assertion is a genuine regression test:

```
# with this change
#07 Set connectCb that returns a plain socket: PASSED
#08 Connect with connectCb returning a plain socket: PASSED
#09 Socket setup applied by the library: PASSED
ALL PASSED

# same test, src/comsock.c reverted to main
#09 Socket setup applied by the library: FAILED
*** TEST FAILED ***
```

Note that the test does not need TLS: it asserts on the socket setup itself, which is what goes
missing. TLS is only what turns the missing setup into the stall described above.

### Notes

After this change the proxy path behaves like the non-proxy path, including that the connect
deadline `_createConn()` installs from `opts->timeout` now also covers the TLS handshake, where it
previously did not apply at all on this path. Applications behind a slow proxy may need a larger
`natsOptions_SetTimeout()`.
