### PR TITLE
[ADDED] `natsMsgHeader_EncodedLength` and `natsMsg_SetData` functions

### DIFF
--- a/src/msg.c
+++ b/src/msg.c
@@ -22,7 +22,7 @@
 #include "msg.h"
 
 int
-natsMsgHeader_encodedLen(natsMsg *msg)
+natsMsgHeader_encodedLen(const natsMsg *msg)
 {
     natsStrHashIter iter;
     char            *key = NULL;
@@ -60,6 +60,15 @@ natsMsgHeader_encodedLen(natsMsg *msg)
     hl += _CRLF_LEN_;
 
     return hl;
+}
+
+int
+natsMsgHeader_EncodedLength(const natsMsg *msg)
+{
+    if (msg == NULL)
+        return 0;
+
+    return natsMsgHeader_encodedLen(msg);
 }
 
 natsStatus
@@ -733,10 +742,26 @@ natsMsg_GetReply(const natsMsg *msg)
     return (const char*) msg->reply;
 }
 
+natsStatus
+natsMsg_SetData(natsMsg *msg, const void *data, int len)
+{
+    if (msg == NULL)
+        return nats_setDefaultError(NATS_INVALID_ARG);
+    if ((len < 0) || (data == NULL && len != 0))
+        return nats_setDefaultError(NATS_INVALID_ARG);
+
+    msg->data = (const char*) data;
+    msg->dataLen = len;
+    return NATS_OK;
+}
+
 const char*
 natsMsg_GetData(const natsMsg *msg)
 {
     if (msg == NULL)
+        return NULL;
+
+    if (msg->dataLen == 0)
         return NULL;
 
     return (const char*) msg->data;

--- a/src/msg.h
+++ b/src/msg.h
@@ -93,7 +93,7 @@ typedef struct __natsHeaderValue
 } natsHeaderValue;
 
 int
-natsMsgHeader_encodedLen(natsMsg *msg);
+natsMsgHeader_encodedLen(const natsMsg *msg);
 
 natsStatus
 natsMsgHeader_encode(natsBuffer *buf, natsMsg *msg);

--- a/src/nats.h
+++ b/src/nats.h
@@ -5068,6 +5068,22 @@ natsMsg_GetSubject(const natsMsg *msg);
 NATS_EXTERN const char*
 natsMsg_GetReply(const natsMsg *msg);
 
+/** \brief Sets the message payload.
+ *
+ * Users can use this function to set the data of a message after it has
+ * been created with #natsMsg_Create.
+ *
+ * \warning The data is not copied and must remain valid and not mutated
+ * while the message has a reference to it. The user owns the data and it
+ * will not be freed when #natsMsg_Destroy is called.
+ *
+ * @param msg the pointer to the #natsMsg object.
+ * @param data the pointer to the data.
+ * @param len the length of the data that this message references.
+ */
+NATS_EXTERN natsStatus
+natsMsg_SetData(natsMsg *msg, const void *data, int len);
+
 /** \brief Returns the message payload.
  *
  * Returns the message payload, possibly `NULL`.
@@ -5235,6 +5251,17 @@ natsMsgHeader_Keys(natsMsg *msg, const char* **keys, int *count);
  */
 NATS_EXTERN natsStatus
 natsMsgHeader_Delete(natsMsg *msg, const char *key);
+
+/** \brief Returns the encoded length of the message headers.
+ *
+ * Returns the encoded length of the message headers.
+ *
+ * \note Returns 0 if the message is `NULL` or no headers are set.
+ *
+ * @param msg the pointer to the #natsMsg object.
+ */
+NATS_EXTERN int
+natsMsgHeader_EncodedLength(const natsMsg *msg);
 
 /** \brief Indicates if this message is a "no responders" message from the server.
  *

--- a/src/nats.h
+++ b/src/nats.h
@@ -5094,8 +5094,13 @@ natsMsg_SetData(natsMsg *msg, const void *data, int len);
  * allows you to call #natsMsg_GetData() without having to copy the returned
  * data to a buffer to add the `NULL` byte at the end.
  *
- * \warning The string belongs to the message and must not be freed.
- * Copy it if needed.
+ * \warning Unless the payload was set using #natsMsg_SetData, the string belongs
+ * to the message and must not be freed. Copy it if needed.
+ *
+ * \note Returns `NULL` if the message is `NULL` or has no payload (created with
+ * `dataLen == 0`).
+ *
+ * @see natsMsg_SetData
  *
  * @param msg the pointer to the #natsMsg object.
  */

--- a/test/test.c
+++ b/test/test.c
@@ -4937,18 +4937,22 @@ void test_natsMsg(void)
 {
     natsMsg     *msg = NULL;
     natsStatus  s    = NATS_OK;
+    const char  *pay = "hello";
 
     test("Check invalid subj (NULL): ");
     s = natsMsg_Create(&msg, NULL, "reply", "data", 4);
     testCond((msg == NULL) && (s == NATS_INVALID_ARG));
+    nats_clearLastError();
 
     test("Check invalid subj (empty): ");
     s = natsMsg_Create(&msg, "", "reply", "data", 4);
     testCond((msg == NULL) && (s == NATS_INVALID_ARG));
+    nats_clearLastError();
 
     test("Check invalid reply (empty): ");
     s = natsMsg_Create(&msg, "foo", "", "data", 4);
     testCond((msg == NULL) && (s == NATS_INVALID_ARG));
+    nats_clearLastError();
 
     test("GetSubject with NULL msg: ");
     testCond(natsMsg_GetSubject(NULL) == NULL);
@@ -4965,6 +4969,33 @@ void test_natsMsg(void)
     test("Create ok: ");
     s = natsMsg_Create(&msg, "foo", "reply", "data", 4);
     testCond((s == NATS_OK) && (msg != NULL));
+
+    natsMsg_Destroy(msg);
+    msg = NULL;
+
+    test("Create with no data: ");
+    s = natsMsg_Create(&msg, "foo", NULL, NULL, 0);
+    // msg->data actually points to somewhere inside the message structure,
+    // however, natsMsg_GetData should return NULL.
+    testCond((s == NATS_OK) && (msg != NULL) && (msg->data != NULL) && (msg->dataLen == 0)
+                && (natsMsg_GetData(msg) == NULL) && (natsMsg_GetDataLength(msg) == 0));
+
+    test("Set data: ");
+    s = natsMsg_SetData(NULL, (const void*) "hello", 5);
+    testCond(s == NATS_INVALID_ARG);
+    nats_clearLastError();
+
+    test("Set NULL/0 is ok: ");
+    s = natsMsg_SetData(msg, NULL, 0);
+    testCond((s == NATS_OK) && (msg->data == NULL) && (msg->dataLen == 0));
+
+    test("Set data: ");
+    s = natsMsg_SetData(msg, (const void*) pay, 5);
+    testCond((s == NATS_OK) && (msg->data == pay) && (msg->dataLen == 5));
+
+    test("Set NULL/0 is ok: ");
+    s = natsMsg_SetData(msg, NULL, 0);
+    testCond((s == NATS_OK) && (msg->data == NULL) && (msg->dataLen == 0));
 
     natsMsg_Destroy(msg);
 }
@@ -5948,6 +5979,55 @@ void test_natsMsgHeaderAPIs(void)
     test("Should be gone: ");
     s = natsMsgHeader_Get(msg, "my-other-key", &val);
     testCond((s == NATS_NOT_FOUND) && (val == NULL));
+
+    natsMsg_Destroy(msg);
+    msg = NULL;
+
+    test("Encoded length with NULL msg: ");
+    testCond(natsMsgHeader_EncodedLength(msg) == 0);
+
+    test("Create empty msg: ");
+    s = natsMsg_Create(&msg, "headers", NULL, NULL, 0);
+    testCond(s == NATS_OK);
+
+    test("Encoded length with empty msg: ");
+    testCond(natsMsgHeader_EncodedLength(msg) == 0);
+
+    test("Set a header: ");
+    s = natsMsgHeader_Set(msg, "my-key", "my-value");
+    testCond(s == NATS_OK);
+
+    test("Encoded length: ");
+    // Should be: "NATS/1.0\r\nmy-key: my-value\r\n\r\n", which means
+    // 10+6+2+8+2+2=30
+    testCond(natsMsgHeader_EncodedLength(msg) == 30);
+
+    test("Add key: ");
+    s = natsMsgHeader_Set(msg, "my-key2", "my-value2");
+    testCond(s == NATS_OK);
+
+    test("Encoded length: ");
+    // Should be: "NATS/1.0\r\nmy-key: my-value\r\nmy-key2: my-value2\r\n\r\n", which means
+    // 10+6+2+8+2+7+2+9+2+2=50
+    testCond(natsMsgHeader_EncodedLength(msg) == 50);
+
+    test("Delete first: ");
+    s = natsMsgHeader_Delete(msg, "my-key");
+    testCond(s == NATS_OK);
+
+    test("Encoded length: ");
+    // Should be: "NATS/1.0\r\nmy-key2: my-value2\r\n\r\n", which means
+    // 10+7+2+9+2+2=32
+    testCond(natsMsgHeader_EncodedLength(msg) == 32);
+
+    test("Add to existing: ");
+    s = natsMsgHeader_Add(msg, "my-key2", "my-value22");
+    testCond(s == NATS_OK);
+
+    test("Encoded length: ");
+    // Should be: "NATS/1.0\r\nmy-key2: my-value2\r\nmy-key2: my-value22\r\n\r\n", which means
+    // 10+7+2+9+2+7+2+10+2+2=53
+    testCond(natsMsgHeader_EncodedLength(msg) == 53);
 
     natsMsg_Destroy(msg);
 }
@@ -11749,6 +11829,11 @@ void test_PublishMsg(void)
     natsConnection      *nc       = NULL;
     natsSubscription    *sub      = NULL;
     natsPid             serverPid = NATS_INVALID_PID;
+    natsMsg             *msg      = NULL;
+    natsMsg             *rmsg     = NULL;
+    int                 hdr       = 0;
+    char conf[256];
+    char cmdLine[1024];
     struct threadArg    arg;
 
     s = _createDefaultThreadArgsForCbTests(&arg);
@@ -11770,12 +11855,12 @@ void test_PublishMsg(void)
     if (s == NATS_OK)
     {
         const char  data[] = {104, 101, 108, 108, 111, 33};
-        natsMsg     *msg   = NULL;
 
         s = natsMsg_Create(&msg, "foo", NULL, data, sizeof(data));
         IFOK(s, natsConnection_PublishMsg(nc, msg));
 
         natsMsg_Destroy(msg);
+        msg = NULL;
     }
     IFOK(s, natsConnection_Flush(nc));
 
@@ -11789,11 +11874,105 @@ void test_PublishMsg(void)
     testCond(s == NATS_OK);
 
     natsSubscription_Destroy(sub);
+    sub = NULL;
+
+    test("Create sync sub: ");
+    s = natsConnection_SubscribeSync(&sub, nc, "setdata");
+    testCond(s == NATS_OK);
+
+    test("Create msg: ");
+    s = natsMsg_Create(&msg, "setdata", NULL, "willbereplaced", 14);
+    testCond((s == NATS_OK) && (msg != NULL));
+
+    test("Set data: ");
+    s = natsMsg_SetData(msg, (const void*) "hello", 5);
+    testCond(s == NATS_OK);
+
+    test("Publish: ");
+    s = natsConnection_PublishMsg(nc, msg);
+    testCond(s == NATS_OK);
+
+    test("Destroy published msg: ");
+    natsMsg_Destroy(msg);
+    msg = NULL;
+    testCond(true);
+
+    test("Receive: ");
+    s = natsSubscription_NextMsg(&msg, sub, 1000);
+    testCond((s == NATS_OK) && (msg != NULL));
+
+    test("Check content: ");
+    testCond((natsMsg_GetDataLength(msg) == 5) &&
+                (strncmp(natsMsg_GetData(msg), "hello", 5) == 0));
+
+    natsMsg_Destroy(msg);
+    natsSubscription_Destroy(sub);
+    sub = NULL;
     natsConnection_Destroy(nc);
+    nc = NULL;
 
     _stopServer(serverPid);
+    serverPid = NATS_INVALID_PID;
 
     _destroyDefaultThreadArgs(&arg);
+
+    test("Start server with max_payload: ");
+    _createConfFile(conf, sizeof(conf), "max_payload: 40\n");
+    snprintf(cmdLine, sizeof(cmdLine), "-c %s", conf);
+    serverPid = _startServer("nats://127.0.0.1:4222", cmdLine, true);
+    CHECK_SERVER_STARTED(serverPid);
+    testCond(true);
+
+    test("Connect and subscribe: ");
+    s = natsConnection_ConnectTo(&nc, NATS_DEFAULT_URL);
+    IFOK(s, natsConnection_SubscribeSync(&sub, nc, "setdata"));
+    testCond((s == NATS_OK) && (nc != NULL) && (sub != NULL));
+
+    test("Create msg: ");
+    s = natsMsg_Create(&msg, "setdata", NULL, NULL, 0);
+    testCond((s == NATS_OK) && (msg != NULL));
+
+    test("Set header: ");
+    s = natsMsgHeader_Set(msg, "my-key", "my-value");
+    testCond(s == NATS_OK);
+
+    test("Headers Encoded length: ");
+    // Should be: "NATS/1.0\r\nmy-key: my-value\r\n\r\n", which means
+    // 10+6+2+8+2+2=30
+    hdr = natsMsgHeader_EncodedLength(msg);
+    testCond(hdr == 30);
+
+    test("Set data at 40-30=10: ");
+    s = natsMsg_SetData(msg, (const void*) "hellohello", 10);
+    testCond(s == NATS_OK);
+
+    test("Publish ok: ");
+    s = natsConnection_PublishMsg(nc, msg);
+    testCond(s == NATS_OK);
+
+    test("Check received: ");
+    s = natsSubscription_NextMsg(&rmsg, sub, 1000);
+    testCond((s == NATS_OK) && (rmsg != NULL));
+
+    test("Check content: ");
+    testCond((natsMsg_GetDataLength(rmsg) == 10) &&
+                (strncmp(natsMsg_GetData(rmsg), "hellohello", 10) == 0));
+    natsMsg_Destroy(rmsg);
+    rmsg = NULL;
+
+    test("Set data too long: ");
+    s = natsMsg_SetData(msg, (const void*) "hellohello!", 11);
+    testCond(s == NATS_OK);
+
+    test("Publish fails: ");
+    s = natsConnection_PublishMsg(nc, msg);
+    testCond(s == NATS_MAX_PAYLOAD);
+    nats_clearLastError();
+
+    natsMsg_Destroy(msg);
+    natsSubscription_Destroy(sub);
+    natsConnection_Destroy(nc);
+    _stopServer(serverPid);
 }
 
 void test_InvalidSubsArgs(void)

--- a/test/test.c
+++ b/test/test.c
@@ -4980,6 +4980,16 @@ void test_natsMsg(void)
     testCond((s == NATS_OK) && (msg != NULL) && (msg->data != NULL) && (msg->dataLen == 0)
                 && (natsMsg_GetData(msg) == NULL) && (natsMsg_GetDataLength(msg) == 0));
 
+    test("Set NULL data with non-zero len: ");
+    s = natsMsg_SetData(msg, NULL, 5);
+    testCond(s == NATS_INVALID_ARG);
+    nats_clearLastError();
+
+    test("Set negative len: ");
+    s = natsMsg_SetData(msg, (const void*) "hi", -1);
+    testCond(s == NATS_INVALID_ARG);
+    nats_clearLastError();
+
     test("Set data: ");
     s = natsMsg_SetData(NULL, (const void*) "hello", 5);
     testCond(s == NATS_INVALID_ARG);


### PR DESCRIPTION
[FIXED] `natsMsg_GetData` would return a non `NULL` pointer when msg was empty.

The first allows to know the encoded length of the headers of a message object. The second allows to reference data that the user owns.

Normally, when you create a message, you pass the data and length and the library creates a block that embeds the data portion. This is mainly used when consuming messages and helps with reducing memory fragmentation.

However, there are cases where it is useful to create the message without any associated data at first and then set data before a publish. A use case is to ensure that the payload is maximized but without reaching the max payload. If the message has headers, the total of the encoding of the headers and the payload size is checked against the connection's max payload on publish. With the new `natsMsgHeader_EncodedLength`, the user can determine that part of the equation, then with a simple substraction between the connection's max payload and the header size, the user can set data for the max length without going over the limit.

Adding a fix for `natsMsg_GetData` that would return a pointer to the
internal structure even when the message was created with `NULL, 0` for
data and length.

Resolves #1015

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>