### PR TITLE
Fix FreeBSD build support

### DIFF
--- a/src/include/n-unix.h
+++ b/src/include/n-unix.h
@@ -18,9 +18,7 @@
 #define _GNU_SOURCE
 #endif
 
-#if defined(__arm__) || defined(__aarch64__)
 #include <sys/socket.h>
-#endif
 
 #include <stdint.h>
 #include <stdbool.h>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,10 @@ add_executable(testsuite test.c bench.c)
 # Link statically with the library
 target_link_libraries(testsuite nats_static ${NATS_EXTRA_LIB})
 
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  target_link_libraries(testsuite execinfo)
+endif()
+
 set(BENCH_LIST ${PROJECT_SOURCE_DIR}/test/list_bench.txt)
 set(STAN_LIST ${PROJECT_SOURCE_DIR}/test/list_stan.txt)
 


### PR DESCRIPTION
This fixes building nats.c on FreeBSD.

On FreeBSD 15.1-RELEASE amd64, `src/include/n-unix.h` did not include `<sys/socket.h>` because the include was limited to ARM/AArch64. This caused socket-related types, constants, and functions such as `struct linger`, `SHUT_RDWR`, `SOCK_STREAM`, and `setsockopt()` to be unavailable during compilation.

This change:

* Includes `<sys/socket.h>` for Unix builds unconditionally.
* Links the test suite against `libexecinfo` on FreeBSD, where `backtrace()` and `backtrace_symbols_fd()` are provided by that library.

Tested on FreeBSD 15.1-RELEASE amd64 with Clang.

Full test suite result:

```text
331/331 tests passed
100% tests passed, 0 tests failed
```
