### PR TITLE
[FIXED] Data race between library's destructor and `nats_Close[AndWait]()`

### DIFF
--- a/src/glib/glib.c
+++ b/src/glib/glib.c
@@ -100,7 +100,7 @@ natsLib_Destructor(void)
 static void
 _freeLib(void)
 {
-    const unsigned int offset = (unsigned int)offsetof(natsLib, refs);
+    const unsigned int offset = (unsigned int) (offsetof(natsLib, refs) + sizeof(gLib.refs));
     bool callFinalCleanup = false;
 
     nats_freeTimers(&gLib);


### PR DESCRIPTION
This was reported by the test `nocrashonexit` when running with the sanitizer. The issue was that we were clearing the memory of the `natsLib` structure starting at `refs` instead of past that field.

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>